### PR TITLE
fix - no kind is registered error while starting host operator locally

### DIFF
--- a/examples/toolchain_v1alpha1_masteruserrecord_cr.yaml
+++ b/examples/toolchain_v1alpha1_masteruserrecord_cr.yaml
@@ -19,7 +19,7 @@ spec:
             - type: stage
               revision: a34r57
             - type: default
-              revison: ra24qw
+              revision: ra24qw
 status:
   userAccounts:
     - targetCluster: east-2a

--- a/examples/toolchain_v1alpha1_nstemplatetier_cr.yaml
+++ b/examples/toolchain_v1alpha1_nstemplatetier_cr.yaml
@@ -17,6 +17,6 @@ spec:
       template: >
         {"apiVersion":"v1","kind":"Template","metadata":{"name":"stage-template"},"objects":{"apiVersion":"v1","kind":"ProjectRequest","metadata":{"name":"$USERNAME-stage"}}}
     - type: default
-      revison: ra24qw
+      revision: ra24qw
       template: >
         {"apiVersion":"v1","kind":"Template","metadata":{"name":"default-template"},"objects":{"apiVersion":"v1","kind":"ProjectRequest","metadata":{"name":"$USERNAME"}}}

--- a/pkg/apis/addtoscheme_toolchain_v1alpha1.go
+++ b/pkg/apis/addtoscheme_toolchain_v1alpha1.go
@@ -1,0 +1,10 @@
+package apis
+
+import (
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+)
+
+func init() {
+	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
+	AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme)
+}


### PR DESCRIPTION
To run `host-operator` locally.  I have deployed relevant CRD, SA, Role and RoleBinding from host-operator project.

After that I tried to run host-operator locally with following command but got error.

Command: `operator-sdk up local --namespace myproject`
Error:
```
INFO[0000] Running the operator locally.                
INFO[0000] Using namespace myproject.                   
{"level":"info","ts":1560844031.4633334,"logger":"cmd","msg":"Go Version: go1.12.6"}
{"level":"info","ts":1560844031.4633586,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1560844031.4633708,"logger":"cmd","msg":"Version of operator-sdk: v0.8.1"}
{"level":"info","ts":1560844031.4706278,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1560844031.4706776,"logger":"leader","msg":"Skipping leader election; not running in a cluster."}
{"level":"info","ts":1560844031.5542064,"logger":"cmd","msg":"Registering Components."}
{"level":"info","ts":1560844031.554286,"logger":"kubebuilder.controller","msg":"Starting EventSource","controller":"masteruserrecord-controller","source":"kind source: /, Kind="}
{"level":"error","ts":1560844031.5543146,"logger":"cmd","msg":"","error":"no kind is registered for the type v1alpha1.MasterUserRecord in scheme \"k8s.io/client-go/kubernetes/scheme/register.go:61\"","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/nvirani/go/src/github.com/codeready-toolchain/host-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nmain.main\n\t/home/nvirani/go/src/github.com/codeready-toolchain/host-operator/cmd/manager/main.go:108\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:200"}
Error: failed to run operator locally: (failed to exec []string{"build/_output/bin/host-operator-local"}: exit status 1)
```
This PR add `github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1` to scheme.  The file is copied from `api` project - [link](https://github.com/codeready-toolchain/api/blob/master/pkg/apis/addtoscheme_toolchain_v1alpha1.go)