### PR TITLE
Rename CRD files to align with api generator

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_masteruserrecord.yaml
+++ b/deploy/crds/toolchain_v1alpha1_masteruserrecord.yaml
@@ -1,14 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: masteruserrecords.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com
   names:
     kind: MasterUserRecord
-    listKind: MasterUserRecordList
     plural: masteruserrecords
-    singular: masteruserrecord
   scope: Namespaced
   subresources:
     status: {}
@@ -120,7 +121,9 @@ spec:
               type: array
           type: object
   version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/crds/toolchain_v1alpha1_nstemplatetier.yaml
+++ b/deploy/crds/toolchain_v1alpha1_nstemplatetier.yaml
@@ -1,14 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
   name: nstemplatetiers.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com
   names:
     kind: NSTemplateTier
-    listKind: NSTemplateTierList
     plural: nstemplatetiers
-    singular: nstemplatetier
   scope: Namespaced
   subresources:
     status: {}
@@ -53,7 +54,9 @@ spec:
         status:
           type: object
   version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
The CRDs are regenerated with the new `make generate` target from `api` repo. There are a few differences:
- `_crd` prefix is removed.
- the generator uses a different version of **k8s controller-tools** (the last stable one, which is 0.1.10) comparing to operator-sdk. Some changes look suspicious but let's fix them later if they cause any problems. We should fix them by using the proper version of the generator tools rather than manually changing the CRDs.