### PR TITLE
fix: add toolchain.dev.openshift.com group to host-operator role

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -39,3 +39,10 @@ rules:
   - host-operator
   verbs:
   - "update"
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - masteruserrecords
+  - nstemplatetiers
+  verbs:
+  - '*'


### PR DESCRIPTION
add toolchain.dev.openshift.com group to host-operator role so the ServiceAccount can watch these CRs