### PR TITLE
Add operator deploymentconfig and imagestream for continuous deployment

### DIFF
--- a/deploy/operator_dev_cluster.yaml
+++ b/deploy/operator_dev_cluster.yaml
@@ -1,0 +1,86 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: host-operator-v0.1
+  namespace: toolchain-host-operator
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/codeready-toolchain/host-operator-v0.1:host-operator
+    importPolicy:
+      scheduled: true
+    name: host-operator
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: host-operator
+  name: host-operator
+  namespace: toolchain-host-operator
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    app: host-operator
+    deploymentconfig: host-operator
+  strategy:
+    activeDeadlineSeconds: 21600
+    resources: {}
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+    type: Rolling
+  template:
+    metadata:
+      labels:
+        app: host-operator
+        deploymentconfig: host-operator
+    spec:
+      serviceAccountName: host-operator
+      containers:
+      - name: host-operator
+        image: ''
+        command:
+        - host-operator
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "host-operator"
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  test: false
+  triggers:
+  - type: ConfigChange
+  - imageChangeParams:
+      automatic: true
+      containerNames:
+      - host-operator
+      from:
+        kind: ImageStreamTag
+        name: host-operator-v0.1:host-operator
+        namespace: toolchain-host-operator
+    type: ImageChange

--- a/deploy/operator_dev_cluster.yaml
+++ b/deploy/operator_dev_cluster.yaml
@@ -22,7 +22,7 @@ metadata:
   name: host-operator
   namespace: toolchain-host-operator
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     app: host-operator
@@ -65,6 +65,13 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: "host-operator"
+        resources:
+          requests:
+            cpu: 0.1m
+            memory: 10Mi
+          limits:
+            cpu: 400m
+            memory: 1.5Gi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst

--- a/examples/toolchain_v1alpha1_userprovisionrequest_cr.yaml
+++ b/examples/toolchain_v1alpha1_userprovisionrequest_cr.yaml
@@ -1,5 +1,5 @@
 apiVersion: toolchain.dev.openshift.com/v1alpha1
-kind: UserProvisionRequest
+kind: UserSignup
 metadata:
   name: johnsmith #username
 spec:

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -1,0 +1,5 @@
+
+.PHONY: deploy-host
+## Run Operator locally
+deploy-host: create-namespace deploy-rbac deploy-crd
+	oc apply -f deploy/operator_dev_cluster.yaml

--- a/make/deploy.mk
+++ b/make/deploy.mk
@@ -1,5 +1,5 @@
 
 .PHONY: deploy-host
-## Run Operator locally
+## Deploy Operator on dev cluster
 deploy-host: create-namespace deploy-rbac deploy-crd
 	oc apply -f deploy/operator_dev_cluster.yaml

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -26,8 +26,6 @@ login-as-admin:
 create-namespace:
 	$(Q)-echo "Creating Namespace"
 	$(Q)-oc new-project $(LOCAL_TEST_NAMESPACE)
-	$(Q)-echo "Switching to the namespace $(LOCAL_TEST_NAMESPACE)"
-	$(Q)-oc project $(LOCAL_TEST_NAMESPACE)
 
 .PHONY: use-namespace
 ## Log in as system:admin and enter the test namespace
@@ -50,7 +48,7 @@ reset-namespace: login-as-admin clean-namespace create-namespace deploy-rbac
 deploy-rbac:
 	$(Q)-oc apply -f deploy/service_account.yaml
 	$(Q)-oc apply -f deploy/role.yaml
-	$(Q)-oc apply -f deploy/role_binding.yaml
+	$(Q)-sed -e 's|REPLACE_NAMESPACE|${LOCAL_TEST_NAMESPACE}|g' ./deploy/role_binding.yaml  | oc apply -f -
 
 .PHONY: deploy-crd
 ## Deploy CRD


### PR DESCRIPTION
*Changes Proposed in this PR*
- Adds ImageStream which points to image from openshift CI cluster.
- Add DeploymentConfig which uses above ImageStream
- Fix minor make targets

To Do
- [ ] Add Documentation
- [ ] Testing on actual clusters