### PR TITLE
fix: change role to have full permissions for toolchain.dev.openshift.com group

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -60,14 +60,6 @@ rules:
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:
-  - masteruserrecords
-  - nstemplatetiers
-  - usersignups
+  - '*'
   verbs:
   - '*'
-- apiGroups:
-  - toolchain.dev.openshift.com
-  resources:
-  - usersignups/status
-  verbs:
-  - update


### PR DESCRIPTION
With the original configuration, it was failing for e2e tests with `no RBAC policy matched` error