### PR TITLE
 feat(CRT-176): add garbage collection for MasterUserRecord that deletes UserAccounts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/operator-framework/operator-sdk v0.10.0
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/common v0.6.0 // indirect
+	github.com/redhat-cop/operator-utils v0.0.0-20190530184149-66ee667a40b2
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -457,6 +457,8 @@ github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNG
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/redhat-cop/operator-utils v0.0.0-20190530184149-66ee667a40b2 h1:RGAwRHq6sD6ik/1SoYp2+js2sRywHUBNDw97+5jcaGE=
+github.com/redhat-cop/operator-utils v0.0.0-20190530184149-66ee667a40b2/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=
 github.com/robfig/cron v0.0.0-20170526150127-736158dc09e1/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -45,7 +45,8 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 		Exists().
 		HasSpec(mur.Spec.UserAccounts[0].Spec)
 	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-		HasConditions(toBeNotReady(provisioningReason, ""))
+		HasConditions(toBeNotReady(provisioningReason, "")).
+		HasFinalizer()
 }
 
 func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
@@ -72,10 +73,11 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 		Exists().
 		HasSpec(mur.Spec.UserAccounts[1].Spec)
 	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-		HasConditions(toBeNotReady(provisioningReason, ""))
+		HasConditions(toBeNotReady(provisioningReason, "")).
+		HasFinalizer()
 }
 
-func TestCreateOrSynchronizeUserAccountFailed(t *testing.T) {
+func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
@@ -98,7 +100,8 @@ func TestCreateOrSynchronizeUserAccountFailed(t *testing.T) {
 
 		uatest.AssertThatUserAccount(t, "john", memberClient).DoesNotExist()
 		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-			HasConditions(toBeNotReady(targetClusterNotReadyReason, msg))
+			HasConditions(toBeNotReady(targetClusterNotReadyReason, msg)).
+			HasFinalizer()
 	})
 
 	t.Run("when member cluster does not exist and UA was already created", func(t *testing.T) {
@@ -114,9 +117,9 @@ func TestCreateOrSynchronizeUserAccountFailed(t *testing.T) {
 		require.Error(t, err)
 		msg := "the member cluster member-cluster not found in the registry"
 		assert.Contains(t, err.Error(), msg)
-
 		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-			HasConditions(toBeNotReady(targetClusterNotReadyReason, msg))
+			HasConditions(toBeNotReady(targetClusterNotReadyReason, msg)).
+			HasFinalizer()
 	})
 
 	t.Run("when member cluster is not ready and UA hasn't been created yet", func(t *testing.T) {
@@ -135,7 +138,8 @@ func TestCreateOrSynchronizeUserAccountFailed(t *testing.T) {
 
 		uatest.AssertThatUserAccount(t, "john", memberClient).DoesNotExist()
 		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-			HasConditions(toBeNotReady(targetClusterNotReadyReason, msg))
+			HasConditions(toBeNotReady(targetClusterNotReadyReason, msg)).
+			HasFinalizer()
 	})
 
 	t.Run("when member cluster is not ready and UA was already created", func(t *testing.T) {
@@ -153,7 +157,8 @@ func TestCreateOrSynchronizeUserAccountFailed(t *testing.T) {
 		assert.Contains(t, err.Error(), msg)
 
 		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-			HasConditions(toBeNotReady(targetClusterNotReadyReason, msg))
+			HasConditions(toBeNotReady(targetClusterNotReadyReason, msg)).
+			HasFinalizer()
 	})
 
 	t.Run("status update of the MasterUserRecord failed", func(t *testing.T) {
@@ -254,6 +259,80 @@ func TestCreateOrSynchronizeUserAccountFailed(t *testing.T) {
 		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
 			HasConditions(updatingCond).
 			HasStatusUserAccounts()
+	})
+
+	t.Run("creation of the UserAccount fails because it cannot add finalizer", func(t *testing.T) {
+		// given
+		hostClient := commontest.NewFakeClient(t, mur)
+		memberClient := commontest.NewFakeClient(t)
+		hostClient.MockUpdate = func(obj runtime.Object) error {
+			return fmt.Errorf("unable to add finalizer to MUR %s", mur.Name)
+		}
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+			clusterClient(test.MemberClusterName, memberClient))
+
+		// when
+		_, err := cntrl.Reconcile(newMurRequest(mur))
+
+		// then
+		require.Error(t, err)
+		msg := "failed while updating with added finalizer: unable to add finalizer to MUR john"
+		assert.Contains(t, err.Error(), msg)
+
+		uatest.AssertThatUserAccount(t, "john", memberClient).DoesNotExist()
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions(toBeNotReady(unableToAddFinalizerReason, "unable to add finalizer to MUR john"))
+	})
+
+	t.Run("deletion of MasterUserRecord fails because it cannot remove finalizer", func(t *testing.T) {
+		// given
+		mur := murtest.NewMasterUserRecord("john", murtest.ToBeDeleted())
+
+		hostClient := commontest.NewFakeClient(t, mur)
+		memberClient := commontest.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
+		hostClient.MockUpdate = func(obj runtime.Object) error {
+			return fmt.Errorf("unable to remove finalizer from MUR %s", mur.Name)
+		}
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+			clusterClient(test.MemberClusterName, memberClient))
+
+		// when
+		_, err := cntrl.Reconcile(newMurRequest(mur))
+
+		// then
+		require.Error(t, err)
+		msg := "failed to update MasterUserRecord while deleting finalizer"
+		assert.Contains(t, err.Error(), msg)
+
+		uatest.AssertThatUserAccount(t, "john", memberClient).DoesNotExist()
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions(toBeNotReady(unableToRemoveFinalizerReason, "unable to remove finalizer from MUR john"))
+	})
+
+	t.Run("deletion of the UserAccount failed", func(t *testing.T) {
+		// given
+		mur := murtest.NewMasterUserRecord("john", murtest.ToBeDeleted())
+		hostClient := commontest.NewFakeClient(t, mur)
+
+		memberClient := commontest.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
+		memberClient.MockDelete = func(obj runtime.Object, opts ...client.DeleteOptionFunc) error {
+			return fmt.Errorf("unable to delete user account %s", mur.Name)
+		}
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+			clusterClient(test.MemberClusterName, memberClient))
+
+		// when
+		_, err := cntrl.Reconcile(newMurRequest(mur))
+
+		// then
+		require.Error(t, err)
+		msg := "failed to delete UserAccount in the member cluster 'member-cluster'"
+		assert.Contains(t, err.Error(), msg)
+
+		uatest.AssertThatUserAccount(t, "john", memberClient).Exists()
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions(toBeNotReady(unableToDeleteUserAccountsReason, "unable to delete user account john")).
+			HasFinalizer()
 	})
 }
 
@@ -361,6 +440,58 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 		HasStatusUserAccounts(test.MemberClusterName, "member2-cluster", "member3-cluster").
 		AllUserAccountsHaveStatusSyncIndex("123abc").
 		AllUserAccountsHaveCondition(userAccount.Status.Conditions[0])
+}
+
+func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
+	// given
+	logf.SetLogger(logf.ZapLogger(true))
+	s := apiScheme(t)
+	mur := murtest.NewMasterUserRecord("john", murtest.ToBeDeleted())
+	userAcc := uatest.NewUserAccountFromMur(mur)
+
+	memberClient := commontest.NewFakeClient(t, userAcc)
+	hostClient := commontest.NewFakeClient(t, mur)
+	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		clusterClient(test.MemberClusterName, memberClient))
+
+	// when
+	_, err := cntrl.Reconcile(newMurRequest(mur))
+
+	// then
+	require.NoError(t, err)
+
+	uatest.AssertThatUserAccount(t, "john", memberClient).
+		DoesNotExist()
+	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+		DoesNotHaveFinalizer()
+}
+
+func TestDeleteMultipleUserAccountsViaMasterUserRecordBeingDeleted(t *testing.T) {
+	// given
+	logf.SetLogger(logf.ZapLogger(true))
+	s := apiScheme(t)
+	mur := murtest.NewMasterUserRecord("john",
+		murtest.ToBeDeleted(), murtest.AdditionalAccounts("member2-cluster"))
+	userAcc := uatest.NewUserAccountFromMur(mur)
+
+	memberClient := commontest.NewFakeClient(t, userAcc)
+	memberClient2 := commontest.NewFakeClient(t, userAcc)
+	hostClient := commontest.NewFakeClient(t, mur)
+	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
+
+	// when
+	_, err := cntrl.Reconcile(newMurRequest(mur))
+
+	// then
+	require.NoError(t, err)
+
+	uatest.AssertThatUserAccount(t, "john", memberClient).
+		DoesNotExist()
+	uatest.AssertThatUserAccount(t, "john", memberClient2).
+		DoesNotExist()
+	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+		DoesNotHaveFinalizer()
 }
 
 func newMurRequest(mur *toolchainv1alpha1.MasterUserRecord) reconcile.Request {

--- a/test/e2e/wait_util.go
+++ b/test/e2e/wait_util.go
@@ -44,6 +44,21 @@ func (a *HostAwaitility) WaitForMasterUserRecord(name string) error {
 	})
 }
 
+func (a *HostAwaitility) WaitForDeletedMasterUserRecord(name string) error {
+	return wait.Poll(e2e.RetryInterval, e2e.Timeout, func() (done bool, err error) {
+		mur := &toolchainv1alpha1.MasterUserRecord{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, mur); err != nil {
+			if errors.IsNotFound(err) {
+				a.T.Logf("MasterUserAccount is checked as deleted '%s'", name)
+				return true, nil
+			}
+			return false, err
+		}
+		a.T.Logf("waiting until MasterUserAccount is deleted '%s'", name)
+		return false, nil
+	})
+}
+
 func (a *HostAwaitility) GetMasterUserRecord(name string) *toolchainv1alpha1.MasterUserRecord {
 	mur := &toolchainv1alpha1.MasterUserRecord{}
 	err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, mur)
@@ -136,6 +151,21 @@ func (a *MemberAwaitility) WaitForUserAccount(name string, expSpec toolchainv1al
 			return true, nil
 		}
 		a.T.Logf("waiting for UserAccount '%s' with expected spec and status condition", name)
+		return false, nil
+	})
+}
+
+func (a *MemberAwaitility) WaitForDeletedUserAccount(name string) error {
+	return wait.Poll(e2e.RetryInterval, e2e.Timeout, func() (done bool, err error) {
+		ua := &toolchainv1alpha1.UserAccount{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, ua); err != nil {
+			if errors.IsNotFound(err) {
+				a.T.Logf("UserAccount is checked as deleted '%s'", name)
+				return true, nil
+			}
+			return false, err
+		}
+		a.T.Logf("waiting until UserAccount is deleted '%s'", name)
 		return false, nil
 	})
 }

--- a/test/masteruserrecord/assertion.go
+++ b/test/masteruserrecord/assertion.go
@@ -45,6 +45,21 @@ func (a *MurAssertion) HasConditions(expected ...toolchainv1alpha1.Condition) *M
 	return a
 }
 
+func (a *MurAssertion) HasFinalizer() *MurAssertion {
+	err := a.loadUaAssertion()
+	require.NoError(a.t, err)
+	assert.Len(a.t, a.masterUserRecord.Finalizers, 1)
+	assert.Contains(a.t, a.masterUserRecord.Finalizers, "finalizer.toolchain.dev.openshift.com")
+	return a
+}
+
+func (a *MurAssertion) DoesNotHaveFinalizer() *MurAssertion {
+	err := a.loadUaAssertion()
+	require.NoError(a.t, err)
+	assert.Len(a.t, a.masterUserRecord.Finalizers, 0)
+	return a
+}
+
 func (a *MurAssertion) HasStatusUserAccounts(targetClusters ...string) *MurAssertion {
 	err := a.loadUaAssertion()
 	require.NoError(a.t, err)

--- a/test/masteruserrecord/doubles.go
+++ b/test/masteruserrecord/doubles.go
@@ -4,8 +4,10 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 	uuid "github.com/satori/go.uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 type MurModifier func(mur *toolchainv1alpha1.MasterUserRecord)
@@ -131,5 +133,12 @@ func Namespace(nsType, revision string) UaInMurModifier {
 				return
 			}
 		}
+	}
+}
+
+func ToBeDeleted() MurModifier {
+	return func(mur *toolchainv1alpha1.MasterUserRecord) {
+		util.AddFinalizer(mur, "finalizer.toolchain.dev.openshift.com")
+		mur.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 	}
 }


### PR DESCRIPTION
This PR:
* adds a finalizer to `MasterUserRecord` for the first reconcile (after the creation of `MUR` and before creating `UserAccouts`)
* deletes `UserAccounts` when the `MasterUserRecord` is going to be deleted
* removes the finalizer from `MasterUserRecord` after successful deletion of all `UserAccounts`
* adds unit tests as well as e2e test
