### PR TITLE
chore: print logs when e2e tests fail & change variable names

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ The `make test-e2e` will take care of creating a namespace/project with a random
 the operator-sdk.
 
 
- NOTE: you can specify the namepace you want to use for running the end-to-end tests by writing its name in the `./build/_output/test-namespace` file. Otherwise, the file will be generated on the fly with a namespace in the form of `test-<UUID>`.
+ NOTE: you can override the default namepace names where the end-to-end tests are going to be executed - eg.: `make test-e2e HOST_NS=my-host MEMBER_NS=my-member` file.
 
 === Verifying the OpenShift CI configuration
 

--- a/make/test.mk
+++ b/make/test.mk
@@ -84,7 +84,7 @@ e2e-run:
 	oc get kubefedcluster -n $(HOST_NS)
 	oc get kubefedcluster -n $(MEMBER_NS)
 	MEMBER_NS=${MEMBER_NS} operator-sdk test local ./test/e2e --no-setup --namespace $(HOST_NS) --verbose --go-test-flags "-timeout=15m" || \
-	$(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} && exit 1
+	($(MAKE) print-logs HOST_NS=${HOST_NS} MEMBER_NS=${MEMBER_NS} && exit 1)
 
 .PHONY: print-logs
 print-logs:


### PR DESCRIPTION
This PR introduces changes to the test Makefile:
* prints logs when the e2e tests fail (useful in CI, otherwise there is no way to figure out what happened)
* renames variable `TEST_NAMESPACE` to `HOST_NS` to make it consistent with `MEMBER_NS`
* load names of the namespaces from variable

I also changed the README to reflect the changes

When and if we agree on these changes, then I'll push the same to member-operator repo