### PR TITLE
chore: remove vendor support when running operator locally

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ To run this operator locally you need to have at least one Minishift profile sta
 $ minishift start --profile host
 ```
 
-Then you can run the operator locally with the help of `operator-sdk`:
+Then you can run the operator locally with the help of `operator-sdk` (you need version v0.10.0 or higher):
 
 ```bash
 $ make up-local

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -11,7 +11,7 @@ ADD_CLUSTER_SCRIPT_PATH?=../toolchain-common/scripts/add-cluster.sh
 
 .PHONY: up-local
 ## Run Operator locally
-up-local: login-as-admin create-namespace deploy-rbac build vendor deploy-crd
+up-local: login-as-admin create-namespace deploy-rbac build deploy-crd
 	$(Q)-oc new-project $(LOCAL_TEST_NAMESPACE) || true
 	$(Q)OPERATOR_NAMESPACE=$(LOCAL_TEST_NAMESPACE) operator-sdk up local --namespace=$(APP_NAMESPACE) --verbose
 


### PR DESCRIPTION
Since operator-sdk 0.10.x has go module support, we don't need it when running the operator locally 