### PR TITLE
Add short name for MasterUserRecord

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_masteruserrecord.yaml
+++ b/deploy/crds/toolchain_v1alpha1_masteruserrecord.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: MasterUserRecord
     plural: masteruserrecords
+    shortNames:
+      - mur
   scope: Namespaced
   subresources:
     status: {}

--- a/examples/toolchain_v1alpha1_masteruserrecord_cr.yaml
+++ b/examples/toolchain_v1alpha1_masteruserrecord_cr.yaml
@@ -9,6 +9,7 @@ spec:
       syncIndex: '135540409'
       spec:
         nsLimit: admin
+        userID: 1a03ecac-7c0b-44fc-b66d-12dd7fb21c40
         nsTemplateSet:
           tierName: basic
           namespaces:


### PR DESCRIPTION
1. Add `mur` as a short name for `MasterUserRecord`
2. Fix MUR example CR. We will need to refactor our MUR API (see https://github.com/codeready-toolchain/host-operator/pull/27#pullrequestreview-276884345) but for now let's fix the example since it's not valid atm.