### PR TITLE
fix(CRT-223): separate Role and ClusterRole permissions + test fixes/adjustments

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,0 +1,24 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: host-operator
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - core.kubefed.k8s.io
+  resources:
+  - kubefedclusters
+  verbs:
+  - "*"

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,11 +1,13 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: host-operator
 subjects:
 - kind: ServiceAccount
   name: host-operator
+  # Replace this with the namespace in which the operator will be deployed
+  namespace: REPLACE_NAMESPACE
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: host-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,10 +25,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/operator_dev_cluster.yaml
+++ b/deploy/operator_dev_cluster.yaml
@@ -55,10 +55,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: OPERATOR_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,4 +1,4 @@
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: host-operator
@@ -25,13 +25,6 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - "get"
-  - "create"
-- apiGroups:
   - apps
   resources:
   - deployments/finalizers
@@ -42,21 +35,9 @@ rules:
 - apiGroups:
   - core.kubefed.k8s.io
   resources:
-  - kubefedclusters
-  verbs:
-  - "*"
-- apiGroups:
-  - core.kubefed.k8s.io
-  resources:
   - kubefedclusters/status
   verbs:
   - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - list
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Azure/go-autorest v13.0.0+incompatible // indirect
 	github.com/appscode/jsonpatch v0.0.0-20190625103638-320dcdd0e1f7 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20190813211537-c2a9a838ce38
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20190822023853-ee967b4125e7
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20190827045201-35e4f49da4c9
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.2 // indirect
 	github.com/gobuffalo/envy v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/codeready-toolchain/api v0.0.0-20190813211537-c2a9a838ce38 h1:wHuHNqZ
 github.com/codeready-toolchain/api v0.0.0-20190813211537-c2a9a838ce38/go.mod h1:jHr8IvmLGTxmgD+jc1bBbucP4bSbT2JHnM+HdAw6N2g=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190822023853-ee967b4125e7 h1:BMxUbc0leFMb5wLGfXjA/atAB5lzwwmCXh85iVGZECw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20190822023853-ee967b4125e7/go.mod h1:T/a1aW1kqIKrRxbpUxDp3l3wz97jtQBI68AFl+j+I9Q=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190827045201-35e4f49da4c9 h1:o2fX6Qv4goQbPw2IV2PcFE8CY4NalYMiSseSNeMrGQs=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20190827045201-35e4f49da4c9/go.mod h1:T/a1aW1kqIKrRxbpUxDp3l3wz97jtQBI68AFl+j+I9Q=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.9+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -5,7 +5,7 @@ TIMESTAMP:=$(shell date +%s)
 TAG?=$(GIT_COMMIT_ID_SHORT)-$(TIMESTAMP)
 
 # to watch all namespaces, keep namespace empty
-APP_NAMESPACE ?= ""
+APP_NAMESPACE ?= $(LOCAL_TEST_NAMESPACE)
 LOCAL_TEST_NAMESPACE ?= "toolchain-host-operator"
 ADD_CLUSTER_SCRIPT_PATH?=../toolchain-common/scripts/add-cluster.sh
 
@@ -13,7 +13,7 @@ ADD_CLUSTER_SCRIPT_PATH?=../toolchain-common/scripts/add-cluster.sh
 ## Run Operator locally
 up-local: login-as-admin create-namespace deploy-rbac build deploy-crd
 	$(Q)-oc new-project $(LOCAL_TEST_NAMESPACE) || true
-	$(Q)OPERATOR_NAMESPACE=$(LOCAL_TEST_NAMESPACE) operator-sdk up local --namespace=$(APP_NAMESPACE) --verbose
+	$(Q)operator-sdk up local --namespace=$(APP_NAMESPACE) --verbose
 
 .PHONY: login-as-admin
 ## Log in as system:admin

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -48,7 +48,9 @@ reset-namespace: login-as-admin clean-namespace create-namespace deploy-rbac
 deploy-rbac:
 	$(Q)-oc apply -f deploy/service_account.yaml
 	$(Q)-oc apply -f deploy/role.yaml
-	$(Q)-sed -e 's|REPLACE_NAMESPACE|${LOCAL_TEST_NAMESPACE}|g' ./deploy/role_binding.yaml  | oc apply -f -
+	$(Q)-oc apply -f deploy/role_binding.yaml
+	$(Q)-oc apply -f deploy/cluster_role.yaml
+	$(Q)-sed -e 's|REPLACE_NAMESPACE|${LOCAL_TEST_NAMESPACE}|g' ./deploy/cluster_role_binding.yaml  | oc apply -f -
 
 .PHONY: deploy-crd
 ## Deploy CRD

--- a/make/test.mk
+++ b/make/test.mk
@@ -103,7 +103,9 @@ e2e-setup: is-minishift
 	oc new-project $(HOST_NS) --display-name e2e-tests
 	oc apply -f ./deploy/service_account.yaml
 	oc apply -f ./deploy/role.yaml
-	cat ./deploy/role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(HOST_NS)/ | oc apply -f -
+	oc apply -f ./deploy/role_binding.yaml
+	oc apply -f ./deploy/cluster_role.yaml
+	sed -e 's|REPLACE_NAMESPACE|${HOST_NS}|g' ./deploy/cluster_role_binding.yaml  | oc apply -f -
 	oc apply -f deploy/crds
 	sed -e 's|REPLACE_IMAGE|${IMAGE_NAME}|g' ./deploy/operator.yaml  | oc apply -f -
 
@@ -145,6 +147,8 @@ deploy-member:
 	oc new-project $(MEMBER_NS)
 	oc apply -f /tmp/member-operator/deploy/service_account.yaml
 	oc apply -f /tmp/member-operator/deploy/role.yaml
-	cat /tmp/member-operator/deploy/role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(MEMBER_NS)/ | oc apply -f -
+	oc apply -f /tmp/member-operator/deploy/role_binding.yaml
+	oc apply -f /tmp/member-operator/deploy/cluster_role.yaml
+	cat /tmp/member-operator/deploy/cluster_role_binding.yaml | sed s/\REPLACE_NAMESPACE/$(MEMBER_NS)/ | oc apply -f -
 	oc apply -f /tmp/member-operator/deploy/crds
 	sed -e 's|REPLACE_IMAGE|registry.svc.ci.openshift.org/codeready-toolchain/member-operator-v0.1:member-operator|g' /tmp/member-operator/deploy/operator.yaml  | oc apply -f -

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -1,8 +1,6 @@
 package config
 
 const (
-	OperatorNamespace = "OPERATOR_NAMESPACE"
-
 	ToolchainConfigMapName = "toolchain-saas-config"
 
 	ToolchainConfigMapUserApprovalPolicy = "user-approval-policy"

--- a/pkg/controller/kubefedcluster.go
+++ b/pkg/controller/kubefedcluster.go
@@ -1,17 +1,13 @@
 package controller
 
 import (
-	"fmt"
 	"github.com/codeready-toolchain/toolchain-common/pkg/controller"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/klog"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/kubefed/pkg/controller/kubefedcluster"
 	"sigs.k8s.io/kubefed/pkg/controller/util"
 )
-
-const varOperatorNamespace = "OPERATOR_NAMESPACE"
 
 func StartKubeFedClusterControllers(mgr manager.Manager, stopChan <-chan struct{}) error {
 	if err := startHealthCheckController(mgr, stopChan); err != nil {
@@ -28,16 +24,16 @@ func StartKubeFedClusterControllers(mgr manager.Manager, stopChan <-chan struct{
 }
 
 func startHealthCheckController(mgr manager.Manager, stopChan <-chan struct{}) error {
-	ns, found := os.LookupEnv(varOperatorNamespace)
-	if !found {
-		return fmt.Errorf("%s must be set", varOperatorNamespace)
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return err
 	}
 	controllerConfig := &util.ControllerConfig{
 		KubeConfig:              mgr.GetConfig(),
 		ClusterAvailableDelay:   util.DefaultClusterAvailableDelay,
 		ClusterUnavailableDelay: util.DefaultClusterUnavailableDelay,
 		KubeFedNamespaces: util.KubeFedNamespaces{
-			KubeFedNamespace: ns,
+			KubeFedNamespace: namespace,
 		},
 	}
 	clusterHealthCheckConfig := &util.ClusterHealthCheckConfig{

--- a/pkg/controller/kubefedcluster.go
+++ b/pkg/controller/kubefedcluster.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"fmt"
 	"github.com/codeready-toolchain/toolchain-common/pkg/controller"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/klog"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -16,7 +17,11 @@ func StartKubeFedClusterControllers(mgr manager.Manager, stopChan <-chan struct{
 	if err := startHealthCheckController(mgr, stopChan); err != nil {
 		return err
 	}
-	if err := controller.StartCachingController(mgr, stopChan); err != nil {
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return err
+	}
+	if err := controller.StartCachingController(mgr, namespace, stopChan); err != nil {
 		return err
 	}
 	return nil

--- a/test/e2e/usersignup_test.go
+++ b/test/e2e/usersignup_test.go
@@ -46,6 +46,10 @@ func (s *userSignupIntegrationTest) SetupSuite() {
 	s.namespace = ns
 }
 
+func (s *userSignupIntegrationTest) TearDownTest() {
+	s.testCtx.Cleanup()
+}
+
 func (s *userSignupIntegrationTest) TestUserSignupCreated() {
 	// Clear the user approval policy
 	err := s.clearApprovalPolicyConfig()
@@ -55,8 +59,7 @@ func (s *userSignupIntegrationTest) TestUserSignupCreated() {
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("foo")
 
-	err = s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -81,8 +84,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithNoApprovalConfig() {
 	// Create user signup - no approval set
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("francis")
-	err = s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -112,8 +114,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithNoApprovalConfig() {
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup = s.newUserSignup("gretel")
 	userSignup.Spec.Approved = false
-	err = s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -161,8 +162,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithNoApprovalConfig() {
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup = s.newUserSignup("harold")
 	userSignup.Spec.Approved = true
-	err = s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -198,8 +198,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithManualApproval() {
 	// Create user signup - no approval set
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("mariecurie")
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -233,8 +232,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithManualApproval() {
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup = s.newUserSignup("janedoe")
 	userSignup.Spec.Approved = false
-	err = s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -290,8 +288,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithManualApproval() {
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup = s.newUserSignup("robertjones")
 	userSignup.Spec.Approved = true
-	err = s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -329,8 +326,7 @@ func (s *userSignupIntegrationTest) TestTargetClusterSelectedAutomatically() {
 	userSignup := s.newUserSignup("reginald")
 	// Remove the specified target cluster
 	userSignup.Spec.TargetCluster = ""
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -376,8 +372,7 @@ func (s *userSignupIntegrationTest) TestDeletedUserSignupIsGarbageCollected() {
 	// Create user signup - no approval set
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("oliver")
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -409,8 +404,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithAutoApprovalNoApprovalSet(
 	// Create user signup - no approval set
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("charles")
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -446,8 +440,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithAutoApprovalMURValuesOK() 
 	// Create user signup - no approval set
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("theodore")
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -495,8 +488,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithAutoApprovalAndApprovalSet
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("dorothy")
 	userSignup.Spec.Approved = false
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -534,8 +526,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithAutoApprovalAndApprovalSet
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("edith")
 	userSignup.Spec.Approved = true
-	err := s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("user signup '%s' created", userSignup.Name)
 
@@ -573,8 +564,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithAutoApprovalWhenMURAlready
 	s.T().Logf("Creating MasterUserRecord with namespace %s", s.namespace)
 	userID := uuid.NewV4().String()
 	mur := s.newMasterUserRecord("paul", userID)
-	err := s.awaitility.Client.Create(context.TODO(), mur, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err := s.awaitility.Client.Create(context.TODO(), mur, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("MasterUserRecord '%s' created", mur.Name)
 
@@ -586,8 +576,7 @@ func (s *userSignupIntegrationTest) TestUserSignupWithAutoApprovalWhenMURAlready
 	s.T().Logf("Creating UserSignup with namespace %s", s.namespace)
 	userSignup := s.newUserSignup("paul")
 	userSignup.Spec.UserID = userID
-	err = s.awaitility.Client.Create(context.TODO(), userSignup, &framework.CleanupOptions{TestContext: s.testCtx,
-		Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	err = s.awaitility.Client.Create(context.TODO(), userSignup, e2e.CleanupOptions(s.testCtx))
 	require.NoError(s.T(), err)
 	s.T().Logf("UserSignup '%s' created", userSignup.Name)
 


### PR DESCRIPTION
* separates Role and ClusterRole permissions
* modifies KubeFedCluster e2e test to meet changes in https://github.com/codeready-toolchain/toolchain-common/pull/33
* cleanup fixes in UserSignup e2e test 
* removed unnecessary `OPERATOR_NAMESPACE` var

NOTE: depends on changes made in https://github.com/codeready-toolchain/toolchain-common/pull/33 as well as https://github.com/codeready-toolchain/member-operator/pull/56