### PR TITLE
chore: replace git.apache.org/thrift.git by github.com/apache/thrift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,9 @@ require (
 	sigs.k8s.io/kubefed v0.1.0-rc2
 )
 
+// fix for unavailable git.apache.org https://status.apache.org/incidents/63030p4241xj
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+
 replace (
 	github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.29.0
 	sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.1.10


### PR DESCRIPTION
the git.apache.org seems to be still down https://status.apache.org/incidents/63030p4241xj
so I'm adding permanent workaround/solution