### PR TITLE
Exclude cmd/manager (main) from coverage report

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -28,6 +28,7 @@ coverage:
     - "build/*"
     - "example/*"
     - "openshift-ci/*"
+    - "cmd/*"
 
 # See http://docs.codecov.io/docs/pull-request-comments-1
 comment:

--- a/make/test.mk
+++ b/make/test.mk
@@ -26,7 +26,7 @@ test-with-coverage: generate
 	@echo "running the tests with coverage..."
 	@-mkdir -p $(COV_DIR)
 	@-rm $(COV_DIR)/coverage.txt
-	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /test/e2e) -coverprofile=$(COV_DIR)/coverage.txt -covermode=atomic ./...
+	$(Q)go test -vet off ${V_FLAG} $(shell go list ./... | grep -v /cmd/manager) -coverprofile=$(COV_DIR)/coverage.txt -covermode=atomic ./...
 
 .PHONY: upload-codecov-report
 # Uploads the test coverage reports to codecov.io. 


### PR DESCRIPTION
We can't really test cmd/manager properly in unit tests (it's coverd in e2e tests) so excluding it from the codecov report. See https://github.com/codeready-toolchain/host-operator/pull/80