### PR TITLE
configure golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,14 @@ service:
   prepare: # see https://github.com/golangci/golangci/wiki/Configuration#config-directives
     - make generate
 
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 10m
+
+
 linters:
   enable:
-    - gofmt
+    - gofmt 
     - unparam
 
 # all available settings of specific linters

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -12,4 +12,4 @@ lint-yaml: ${YAML_FILES}
 ## Checks the code with golangci-lint
 lint-go-code: generate
 	$(Q)go get github.com/golangci/golangci-lint/cmd/golangci-lint
-	$(Q)${GOPATH}/bin/golangci-lint ${V_FLAG} run --deadline=10m
+	$(Q)${GOPATH}/bin/golangci-lint ${V_FLAG} run


### PR DESCRIPTION
configure in .golangci.yml instead of in the CLI,
using the new `timeout` name in replacement of
`deadline` which is now deprecated.

fixes CRT-295

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>