### PR TITLE
Updated host operator to remove UserSignup.Spec.UserID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
 	github.com/appscode/jsonpatch v0.0.0-20190625103638-320dcdd0e1f7 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20191013054335-17f0782f9285
+	github.com/codeready-toolchain/api v0.0.0-20191023231919-300ac3dd8c36
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20191010043304-822e291d04cb
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/codeready-toolchain/api v0.0.0-20191009081803-8f4e395353de h1:bExhq0r
 github.com/codeready-toolchain/api v0.0.0-20191009081803-8f4e395353de/go.mod h1:/Is7p+crldTqYG0f8LQL7OqmdQRnMJ7u//N82tQdf28=
 github.com/codeready-toolchain/api v0.0.0-20191013054335-17f0782f9285 h1:cEyMmDOG7f0+DDt+Kepj9UV0IRr+XLMfEGdL+0Sbhfg=
 github.com/codeready-toolchain/api v0.0.0-20191013054335-17f0782f9285/go.mod h1:9uSs8YlapNzaxIubqp2P9TA4L4iO4gCuqW1rrhCwsV4=
+github.com/codeready-toolchain/api v0.0.0-20191023231919-300ac3dd8c36 h1:OZuIMbGR1jo2E0VIV1elaBaByZBqIElSBut9M88yOis=
+github.com/codeready-toolchain/api v0.0.0-20191023231919-300ac3dd8c36/go.mod h1:9uSs8YlapNzaxIubqp2P9TA4L4iO4gCuqW1rrhCwsV4=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191010043304-822e291d04cb h1:2Al5qMR1lSVpIbD10GIDyDg7OaX1KM4kggivVlg7fbc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191010043304-822e291d04cb/go.mod h1:dyqWm9EXBYMXzdfaHqipJSujNiK5BvZ3YjukErym4BE=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,6 @@ github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codeready-toolchain/api v0.0.0-20191009081803-8f4e395353de h1:bExhq0ri3+O/3rHHBtJIfJkEev9a9yDQgjD7XhMDln0=
 github.com/codeready-toolchain/api v0.0.0-20191009081803-8f4e395353de/go.mod h1:/Is7p+crldTqYG0f8LQL7OqmdQRnMJ7u//N82tQdf28=
-github.com/codeready-toolchain/api v0.0.0-20191013054335-17f0782f9285 h1:cEyMmDOG7f0+DDt+Kepj9UV0IRr+XLMfEGdL+0Sbhfg=
-github.com/codeready-toolchain/api v0.0.0-20191013054335-17f0782f9285/go.mod h1:9uSs8YlapNzaxIubqp2P9TA4L4iO4gCuqW1rrhCwsV4=
 github.com/codeready-toolchain/api v0.0.0-20191023231919-300ac3dd8c36 h1:OZuIMbGR1jo2E0VIV1elaBaByZBqIElSBut9M88yOis=
 github.com/codeready-toolchain/api v0.0.0-20191023231919-300ac3dd8c36/go.mod h1:9uSs8YlapNzaxIubqp2P9TA4L4iO4gCuqW1rrhCwsV4=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191010043304-822e291d04cb h1:2Al5qMR1lSVpIbD10GIDyDg7OaX1KM4kggivVlg7fbc=

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -240,7 +240,7 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 			"Error creating MasterUserRecord")
 	}
 
-	logger.Info("Created MasterUserRecord", "Name", userSignup.Spec.CompliantUsername, "TargetCluster", targetCluster)
+	logger.Info("### Created MasterUserRecord", "Name", mur.Name, "TargetCluster", targetCluster)
 	return nil
 }
 

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -240,7 +240,7 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 			"Error creating MasterUserRecord")
 	}
 
-	logger.Info("Created MasterUserRecord", "Name", userSignup.Name, "TargetCluster", targetCluster)
+	logger.Info("Created MasterUserRecord", "Name", userSignup.Spec.CompliantUsername, "TargetCluster", targetCluster)
 	return nil
 }
 

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -199,7 +199,7 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 		{
 			TargetCluster: targetCluster,
 			Spec: toolchainv1alpha1.UserAccountSpec{
-				UserID:  userSignup.Spec.UserID,
+				UserID:  userSignup.Name,
 				NSLimit: "default",
 				NSTemplateSet: toolchainv1alpha1.NSTemplateSetSpec{
 					Namespaces: []toolchainv1alpha1.NSTemplateSetNamespace{},
@@ -213,11 +213,11 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 
 	mur := &toolchainv1alpha1.MasterUserRecord{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      userSignup.Name,
+			Name:      userSignup.Spec.CompliantUsername,
 			Namespace: userSignup.Namespace,
 		},
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
-			UserID:       userSignup.Spec.UserID,
+			UserID:       userSignup.Name,
 			UserAccounts: userAccounts,
 		},
 	}

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -240,7 +240,7 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 			"Error creating MasterUserRecord")
 	}
 
-	logger.Info("### Created MasterUserRecord", "Name", mur.Name, "TargetCluster", targetCluster)
+	logger.Info("#### Created MasterUserRecord", "Name", mur.Name, "TargetCluster", targetCluster)
 	return nil
 }
 

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -125,9 +125,9 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 
 	// Check if the MasterUserRecord already exists
 	mur := &toolchainv1alpha1.MasterUserRecord{}
-	// We can use the same NamespacedName from the request as the MasterUserRecord will have the same name as the
-	// UserSignup (i.e. the user's username)
-	err = r.client.Get(context.TODO(), request.NamespacedName, mur)
+	// Lookup the MasterUserRecord with the CompliantUsername value from the UserSignup resource, in the same namespace
+	namespacedMurName := types.NamespacedName{Namespace: request.Namespace, Name: instance.Spec.CompliantUsername}
+	err = r.client.Get(context.TODO(), namespacedMurName, mur)
 	if err != nil {
 		// We generally EXPECT the MasterUserRecord to not be found here, so we only deal with other error types
 		if !errors.IsNotFound(err) {

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -49,7 +49,7 @@ func TestUserSignupWithAutoApproval(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          false,
 		},
@@ -70,7 +70,7 @@ func TestUserSignupWithAutoApproval(t *testing.T) {
 
 	require.Equal(t, operatorNamespace, mur.Namespace)
 	require.Equal(t, userSignup.Name, mur.Name)
-	require.Equal(t, userSignup.Spec.UserID, mur.Spec.UserID)
+	require.Equal(t, userSignup.Name, mur.Spec.UserID)
 	require.Len(t, mur.Spec.UserAccounts, 1)
 
 	// Lookup the userSignup again
@@ -113,7 +113,7 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          true,
 		},
@@ -133,8 +133,8 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, operatorNamespace, mur.Namespace)
-	require.Equal(t, userSignup.Name, mur.Name)
-	require.Equal(t, userSignup.Spec.UserID, mur.Spec.UserID)
+	require.Equal(t, userSignup.Spec.CompliantUsername, mur.Name)
+	require.Equal(t, userSignup.Name, mur.Spec.UserID)
 	require.Len(t, mur.Spec.UserAccounts, 1)
 
 	// Lookup the userSignup again
@@ -178,7 +178,7 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          true,
 		},
@@ -198,8 +198,8 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, operatorNamespace, mur.Namespace)
-	require.Equal(t, userSignup.Name, mur.Name)
-	require.Equal(t, userSignup.Spec.UserID, mur.Spec.UserID)
+	require.Equal(t, userSignup.Spec.CompliantUsername, mur.Name)
+	require.Equal(t, userSignup.Name, mur.Spec.UserID)
 	require.Len(t, mur.Spec.UserAccounts, 1)
 
 	// Lookup the userSignup again
@@ -242,7 +242,7 @@ func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          false,
 		},
@@ -288,7 +288,7 @@ func TestUserSignupWithAutoApprovalClusterSet(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          false,
 			TargetCluster:     "east",
@@ -309,8 +309,8 @@ func TestUserSignupWithAutoApprovalClusterSet(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, operatorNamespace, mur.Namespace)
-	require.Equal(t, userSignup.Name, mur.Name)
-	require.Equal(t, userSignup.Spec.UserID, mur.Spec.UserID)
+	require.Equal(t, userSignup.Spec.CompliantUsername, mur.Name)
+	require.Equal(t, userSignup.Name, mur.Spec.UserID)
 	require.Len(t, mur.Spec.UserAccounts, 1)
 
 	// Lookup the userSignup again
@@ -353,7 +353,7 @@ func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "bar",
+			Username:          "bar",
 			CompliantUsername: "bar",
 			Approved:          false,
 			TargetCluster:     "east",
@@ -391,7 +391,7 @@ func TestUserSignupMURCreateFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          true,
 		},
@@ -425,7 +425,7 @@ func TestUserSignupMURCreateAlreadyExists(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          true,
 		},
@@ -474,7 +474,7 @@ func TestUserSignupMURReadFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          true,
 		},
@@ -508,7 +508,7 @@ func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          true,
 		},
@@ -542,7 +542,7 @@ func TestUserSignupSetStatusApprovedAutomaticallyFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 		},
 	}
@@ -575,7 +575,7 @@ func TestUserSignupSetStatusNoClustersAvailableFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 		},
 	}
@@ -609,7 +609,7 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          false,
 		},
@@ -662,7 +662,7 @@ func TestUserSignupNoMembersAvailableFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:            "foo",
+			Username:          "foo",
 			CompliantUsername: "foo",
 			Approved:          true,
 		},

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -604,7 +604,7 @@ func TestUserSignupSetStatusNoClustersAvailableFails(t *testing.T) {
 func TestUserSignupWithExistingMUROK(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
+			Name:      uuid.NewV4().String(),
 			Namespace: operatorNamespace,
 			UID:       types.UID(uuid.NewV4().String()),
 		},
@@ -618,12 +618,12 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 	// Create a MUR with the same name
 	mur := &v1alpha1.MasterUserRecord{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
+			Name:      userSignup.Spec.CompliantUsername,
 			Namespace: operatorNamespace,
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.MasterUserRecordSpec{
-			UserID: "foo",
+			UserID: userSignup.Name,
 		},
 	}
 
@@ -637,7 +637,7 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 
 	key := types.NamespacedName{
 		Namespace: operatorNamespace,
-		Name:      "foo",
+		Name:      userSignup.Name,
 	}
 	instance := &v1alpha1.UserSignup{}
 	err = r.client.Get(context.TODO(), key, instance)

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -49,8 +49,8 @@ func TestUserSignupWithAutoApproval(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          false,
 		},
 	}
@@ -65,11 +65,11 @@ func TestUserSignupWithAutoApproval(t *testing.T) {
 	require.Equal(t, reconcile.Result{}, res)
 
 	mur := &v1alpha1.MasterUserRecord{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, mur)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Spec.CompliantUsername, Namespace: req.Namespace}, mur)
 	require.NoError(t, err)
 
 	require.Equal(t, operatorNamespace, mur.Namespace)
-	require.Equal(t, userSignup.Name, mur.Name)
+	require.Equal(t, userSignup.Spec.CompliantUsername, mur.Name)
 	require.Equal(t, userSignup.Name, mur.Spec.UserID)
 	require.Len(t, mur.Spec.UserAccounts, 1)
 
@@ -113,8 +113,8 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          true,
 		},
 	}
@@ -129,7 +129,7 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 	require.Equal(t, reconcile.Result{}, res)
 
 	mur := &v1alpha1.MasterUserRecord{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, mur)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Spec.CompliantUsername, Namespace: req.Namespace}, mur)
 	require.NoError(t, err)
 
 	require.Equal(t, operatorNamespace, mur.Namespace)
@@ -178,8 +178,8 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          true,
 		},
 	}
@@ -194,7 +194,7 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 	require.Equal(t, reconcile.Result{}, res)
 
 	mur := &v1alpha1.MasterUserRecord{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, mur)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Spec.CompliantUsername, Namespace: req.Namespace}, mur)
 	require.NoError(t, err)
 
 	require.Equal(t, operatorNamespace, mur.Namespace)
@@ -242,8 +242,8 @@ func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          false,
 		},
 	}
@@ -288,8 +288,8 @@ func TestUserSignupWithAutoApprovalClusterSet(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          false,
 			TargetCluster:     "east",
 		},
@@ -305,7 +305,7 @@ func TestUserSignupWithAutoApprovalClusterSet(t *testing.T) {
 	require.Equal(t, reconcile.Result{}, res)
 
 	mur := &v1alpha1.MasterUserRecord{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, mur)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Spec.CompliantUsername, Namespace: req.Namespace}, mur)
 	require.NoError(t, err)
 
 	require.Equal(t, operatorNamespace, mur.Namespace)
@@ -353,8 +353,8 @@ func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "bar",
-			CompliantUsername: "bar",
+			Username:          "bar@redhat.com",
+			CompliantUsername: "bar-at-redhat-com",
 			Approved:          false,
 			TargetCluster:     "east",
 		},
@@ -391,8 +391,8 @@ func TestUserSignupMURCreateFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          true,
 		},
 	}
@@ -425,8 +425,8 @@ func TestUserSignupMURCreateAlreadyExists(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          true,
 		},
 	}
@@ -474,8 +474,8 @@ func TestUserSignupMURReadFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          true,
 		},
 	}
@@ -508,8 +508,8 @@ func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          true,
 		},
 	}
@@ -542,8 +542,8 @@ func TestUserSignupSetStatusApprovedAutomaticallyFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 		},
 	}
 
@@ -575,8 +575,8 @@ func TestUserSignupSetStatusNoClustersAvailableFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 		},
 	}
 
@@ -609,8 +609,8 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          false,
 		},
 	}
@@ -662,8 +662,8 @@ func TestUserSignupNoMembersAvailableFails(t *testing.T) {
 			UID:       types.UID(uuid.NewV4().String()),
 		},
 		Spec: v1alpha1.UserSignupSpec{
-			Username:          "foo",
-			CompliantUsername: "foo",
+			Username:          "foo@redhat.com",
+			CompliantUsername: "foo-at-redhat-com",
 			Approved:          true,
 		},
 	}


### PR DESCRIPTION
This PR updates the host operator to remove usage of the `UserSignup.Spec.UserID` field.  Instead of using the `UserID` field to populate the MasterUserRecord name, the UserSignup.Name value is now used instead.


Fixes https://jira.coreos.com/browse/CRT-315