### PR TITLE
(DO NOT MERGE) chore: deploy csv for every commit in master via travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+dist: "trusty"
+
+language: go
+
+env:
+- GO111MODULE=on
+
+python:
+- "3.6.3"
+
+git:
+  depth: false
+
+branches:
+  only:
+  - master
+
+go:
+- 1.13.x
+
+before_install:
+- pyenv shell 3.6.3
+- OPERATOR_SDK_VERSION=v0.11.0
+
+install:
+- curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -o operator-sdk
+- curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu.asc -o operator-sdk.asc
+- gpg --keyserver keyserver.ubuntu.com --recv-key 78086003
+- gpg --verify operator-sdk.asc
+- chmod +x operator-sdk
+- cp operator-sdk /home/travis/bin/operator-sdk
+- rm operator-sdk
+- pip3 install operator-courier
+
+script:
+- make build && make docker-login && make docker-push && curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/push-to-quay-nightly.sh | bash -s -- -pr ../host-operator/

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -34,3 +34,7 @@ docker-push-to-os: set-os-registry docker-image docker-push
 ## Sets TARGET_REGISTRY:=$(shell oc get images.config.openshift.io/cluster  -o jsonpath={.status.externalRegistryHostnames[0]})
 set-os-registry:
 	$(eval TARGET_REGISTRY:=$(shell oc get images.config.openshift.io/cluster  -o jsonpath={.status.externalRegistryHostnames[0]}))
+
+.PHONY: docker-login
+docker-login:
+	@echo "${DOCKER_PASSWORD}" | docker login quay.io -u "${QUAY_NAMESPACE}" --password-stdin

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -1,6 +1,7 @@
 QUAY_NAMESPACE ?= ${GO_PACKAGE_ORG_NAME}
 TARGET_REGISTRY := quay.io
 IMAGE ?= ${TARGET_REGISTRY}/${QUAY_NAMESPACE}/${GO_PACKAGE_REPO_NAME}:${GIT_COMMIT_ID_SHORT}
+QUAY_USERNAME ?= ${QUAY_NAMESPACE}
 
 .PHONY: docker-image
 ## Build the docker image locally that can be deployed (only contains bare operator)
@@ -37,4 +38,4 @@ set-os-registry:
 
 .PHONY: docker-login
 docker-login:
-	@echo "${DOCKER_PASSWORD}" | docker login quay.io -u "${QUAY_NAMESPACE}" --password-stdin
+	@echo "${DOCKER_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin


### PR DESCRIPTION
brings travis config file that will for every commit to master branch:
* build the project
* build the image of the project and push it to quay
* using the olm scripts from `api` repo generate a new version of the host-operator and (using operator courier) pushes it to quay

Already working build can be seen here: https://travis-ci.org/MatousJobanek/host-operator
and the pushed bundles here: https://quay.io/application/matousjobanek/toolchain-host-operator?tab=releases

This PR depends on logic introduced in this PR https://github.com/codeready-toolchain/api/pull/58

IMPORTANT: This PR is ready to review, but please, don't merge it yet as I need to do some additional setup (in quay and in travis) just before merging it ;-) 