### PR TITLE
chore(CRT-361): copy registration-service deployment and embed it as an asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tmp/
 pkg/templates/nstemplatetiers/nstemplatetier_assets.go
 test/templates/nstemplatetiers/nstemplatetier_assets.go
 deploy/templates/nstemplatetiers/metadata.yaml
+pkg/controller/registrationservice/deployment_assets.go
 
 # Created by https://www.gitignore.io/api/go,vim,git,macos,linux,emacs,windows,eclipse,intellij+all,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=go,vim,git,macos,linux,emacs,windows,eclipse,intellij+all,visualstudiocode

--- a/deploy/registration-service/deployment.yaml
+++ b/deploy/registration-service/deployment.yaml
@@ -1,0 +1,149 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: registration-service
+objects:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        provider: codeready-toolchain
+      name: registration-service
+      namespace: ${NAMESPACE}
+  - kind: Deployment
+    apiVersion: apps/v1
+    metadata:
+      labels:
+        provider: codeready-toolchain
+      name: registration-service
+      namespace: ${NAMESPACE}
+    spec:
+      replicas: ${{REPLICAS}}
+      selector:
+        matchLabels:
+          name: registration-service
+      template:
+        metadata:
+          labels:
+            name: registration-service
+            run: registration-service
+        spec:
+          serviceAccountName: registration-service
+          containers:
+            - name: registration-service
+              image: ${IMAGE}
+              ports:
+                - containerPort: 8080
+              command:
+                - registration-service
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /api/v1/health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 1
+                periodSeconds: 10
+                successThreshold: 1
+                timeoutSeconds: 1
+              readinessProbe:
+                failureThreshold: 30
+                httpGet:
+                  path: /api/v1/health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 1
+                periodSeconds: 1
+                successThreshold: 1
+                timeoutSeconds: 1
+              env:
+                - name: REGISTRATION_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: REGISTRATION_ENVIRONMENT
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: environment
+                - name: REGISTRATION_AUTH_CLIENT_LIBRARY_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.library_url
+                - name: REGISTRATION_AUTH_CLIENT_CONFIG_RAW
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.config_raw
+                - name: REGISTRATION_AUTH_CLIENT_PUBLIC_KEYS_URL
+                  valueFrom:
+                    configMapKeyRef:
+                      name: registration-service
+                      key: auth_client.public_keys_url
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: registration-service
+      namespace: ${NAMESPACE}
+      labels:
+        provider: codeready-toolchain
+        run: registration-service
+    spec:
+      ports:
+        - name: "8080"
+          protocol: TCP
+          port: 80
+          targetPort: 8080
+      selector:
+        run: registration-service
+      type: ClusterIP
+      sessionAffinity: null
+  - kind: Route
+    apiVersion: v1
+    metadata:
+      labels:
+        provider: codeready-toolchain
+        run: registration-service
+      name: registration-service
+      namespace: ${NAMESPACE}
+    spec:
+      host: ''
+      port:
+        targetPort: "8080"
+      to:
+        kind: Service
+        name: registration-service
+        weight: 100
+      tls:
+        termination: edge
+      wildcardPolicy: None
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      labels:
+        provider: codeready-toolchain
+      name: registration-service
+      namespace: ${NAMESPACE}
+    type: Opaque
+    data:
+      environment: ${ENVIRONMENT}
+      auth_client.library_url: ${AUTH_CLIENT_LIBRARY_URL}
+      auth_client.config_raw: ${AUTH_CLIENT_CONFIG_RAW}
+      auth_client.public_keys_url: ${AUTH_CLIENT_PUBLIC_KEYS_URL}
+parameters:
+  - name: NAMESPACE
+    value: 'toolchain-host-operator'
+  - name: IMAGE
+    value: quay.io/openshiftio/codeready-toolchain/registration-service:latest
+  - name: REPLICAS
+    value: '3'
+  - name: ENVIRONMENT
+    value: 'prod' # prod, stage, e2e-tests, dev, etc
+  - name: AUTH_CLIENT_LIBRARY_URL
+    value: '' #use default value from reg-service configuration
+  - name: AUTH_CLIENT_CONFIG_RAW
+    value: '' #use default value from reg-service configuration
+  - name: AUTH_CLIENT_PUBLIC_KEYS_URL
+    value: '' #use default value from reg-service configuration

--- a/make/go.mk
+++ b/make/go.mk
@@ -24,6 +24,7 @@ vendor:
 
 NSTEMPLATES_DIR=deploy/templates/nstemplatetiers
 NSTEMPLATES_TEST_DIR=test/templates/nstemplatetiers
+REGISTRATION_SERVICE_DIR=deploy/registration-service
 
 .PHONY: generate
 generate: generate-metadata generate-assets 
@@ -35,6 +36,8 @@ generate-assets:
 	@$(GOPATH)/bin/go-bindata -pkg nstemplatetiers -o ./pkg/templates/nstemplatetiers/nstemplatetier_assets.go -nocompress -prefix $(NSTEMPLATES_DIR) $(NSTEMPLATES_DIR)
 	@echo "generating test templates bindata..."
 	@$(GOPATH)/bin/go-bindata -pkg nstemplatetiers_test -o ./test/templates/nstemplatetiers/nstemplatetier_assets.go -nocompress -prefix $(NSTEMPLATES_TEST_DIR) $(NSTEMPLATES_TEST_DIR)
+	@echo "generating registration service deployment data..."
+	@$(GOPATH)/bin/go-bindata -pkg registrationservice -o ./pkg/controller/registrationservice/deployment_assets.go -nocompress -prefix $(REGISTRATION_SERVICE_DIR) $(REGISTRATION_SERVICE_DIR)
 
 .PHONY: generate-metadata
 generate-metadata: clean-metadata


### PR DESCRIPTION
As the registration service needs to be created programmatically we need the deployment template inside of host-operator repo - this PR:
* copies the deployment template
* embed it as an asset (will be used later)

See these PRs for better context:
https://github.com/codeready-toolchain/registration-service/pull/75
https://github.com/codeready-toolchain/api/pull/65