### PR TITLE
Remove deprecated TargetCluster from MUR status

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -220,11 +220,8 @@ spec:
                       some MasterUserRecord <-> UserAccount synchronization for this
                       specific UserAccount in the specific member cluster
                     type: string
-                  targetCluster:
-                    description: Deprecated! Use Cluster instead The cluster in which
-                      the user exists
-                    type: string
                 required:
+                - cluster
                 - syncIndex
                 type: object
               type: array

--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -220,11 +220,8 @@ spec:
                       some MasterUserRecord <-> UserAccount synchronization for this
                       specific UserAccount in the specific member cluster
                     type: string
-                  targetCluster:
-                    description: Deprecated! Use Cluster instead The cluster in which
-                      the user exists
-                    type: string
                 required:
+                - cluster
                 - syncIndex
                 type: object
               type: array

--- a/go.mod
+++ b/go.mod
@@ -46,4 +46,9 @@ replace (
 	github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.29.0
 )
 
+replace (
+	github.com/codeready-toolchain/api => github.com/alexeykazakov/api v0.0.0-20191203022256-57871e5e6c39
+	github.com/codeready-toolchain/toolchain-common => github.com/alexeykazakov/toolchain-common v0.0.0-20191203023806-0035b5057ff0
+)
+
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,37 @@ module github.com/codeready-toolchain/host-operator
 require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20191129104300-b4af5bf7d40a
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20191121080604-19eb69496fd9
+	github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20191203230412-406b2c86bd6c
+	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.3 // indirect
+	github.com/gogo/protobuf v1.3.0 // indirect
+	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
+	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.3.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/onsi/ginkgo v1.10.1 // indirect
+	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible
 	github.com/operator-framework/operator-sdk v0.11.0
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v1.1.0 // indirect
+	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
+	github.com/prometheus/common v0.7.0 // indirect
+	github.com/prometheus/procfs v0.0.5 // indirect
 	github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/crypto v0.0.0-20190926114937-fa1a29108794 // indirect
+	golang.org/x/net v0.0.0-20190926025831-c00fd9afed17 // indirect
+	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe // indirect
+	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
+	google.golang.org/appengine v1.6.3 // indirect
 	gopkg.in/h2non/gock.v1 v1.0.14
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0
@@ -44,11 +63,6 @@ replace (
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.0.0+incompatible
 	github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.29.0
-)
-
-replace (
-	github.com/codeready-toolchain/api => github.com/alexeykazakov/api v0.0.0-20191203022256-57871e5e6c39
-	github.com/codeready-toolchain/toolchain-common => github.com/alexeykazakov/toolchain-common v0.0.0-20191203023806-0035b5057ff0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alexeykazakov/api v0.0.0-20191203022256-57871e5e6c39 h1:FputXJLjfX+V69j3QfPxgB2Hq5QcWLx40E0KzaP7gCg=
-github.com/alexeykazakov/api v0.0.0-20191203022256-57871e5e6c39/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
-github.com/alexeykazakov/toolchain-common v0.0.0-20191203023806-0035b5057ff0 h1:HdMlI8i8iFlbepvws714CR/8mKOqUJ9w4+3CtEt/waY=
-github.com/alexeykazakov/toolchain-common v0.0.0-20191203023806-0035b5057ff0/go.mod h1:r+aKEQqapHuSdwcIMi2J+Z7n2UR146y5jl89FhyKIQo=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -73,6 +69,10 @@ github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBT
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts/dN2/vJb+9Fjc5I3QpOx/OBWzObGKj6zdPPU=
+github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20191203230412-406b2c86bd6c h1:0ifmV7vF71GSlT3AribGdMKX91Zo5iTFGDrJt3iXTt8=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20191203230412-406b2c86bd6c/go.mod h1:c5EL9bEskD3ViC/ma1OhyIWNdGQMu+0K2nhGs+vfb9M=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.9+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -353,6 +353,7 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible h1:sMBjLRdoavwnc2khLpIOmBkMPDGRB4sIbhOb8Cx2Uh0=
 github.com/openshift/api v3.9.1-0.20190730142803-0922aa5a655b+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
+github.com/openshift/library-go v0.0.0-20191121124438-7c776f7cc17a/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,10 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alexeykazakov/api v0.0.0-20191203022256-57871e5e6c39 h1:FputXJLjfX+V69j3QfPxgB2Hq5QcWLx40E0KzaP7gCg=
+github.com/alexeykazakov/api v0.0.0-20191203022256-57871e5e6c39/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
+github.com/alexeykazakov/toolchain-common v0.0.0-20191203023806-0035b5057ff0 h1:HdMlI8i8iFlbepvws714CR/8mKOqUJ9w4+3CtEt/waY=
+github.com/alexeykazakov/toolchain-common v0.0.0-20191203023806-0035b5057ff0/go.mod h1:r+aKEQqapHuSdwcIMi2J+Z7n2UR146y5jl89FhyKIQo=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -69,12 +73,6 @@ github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBT
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/codeready-toolchain/api v0.0.0-20191115062940-693a0063cf16 h1:ZNcDBuHef21y96zaiPKOlq0SW6GT+cxl9I0U/zcKmgc=
-github.com/codeready-toolchain/api v0.0.0-20191115062940-693a0063cf16/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
-github.com/codeready-toolchain/api v0.0.0-20191129104300-b4af5bf7d40a h1:+uU6k4bh3uoreNrQFf35G/5y9B6+5G3M7pSDnhUlGaA=
-github.com/codeready-toolchain/api v0.0.0-20191129104300-b4af5bf7d40a/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20191121080604-19eb69496fd9 h1:NOwojCb0JGVaWFzkhd/R1h9c3N5Hacq5B4hn52w5QPQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20191121080604-19eb69496fd9/go.mod h1:Hu7D45LXLGOkZF0Z6A34eDGtti6O1Rc2Ejxn8c0rHOA=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.9+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -240,11 +240,8 @@ data:
                             some MasterUserRecord <-> UserAccount synchronization for this
                             specific UserAccount in the specific member cluster
                           type: string
-                        targetCluster:
-                          description: Deprecated! Use Cluster instead The cluster in which
-                            the user exists
-                          type: string
                       required:
+                      - cluster
                       - syncIndex
                       type: object
                     type: array


### PR DESCRIPTION
See
https://github.com/codeready-toolchain/api/pull/66
and
https://github.com/codeready-toolchain/toolchain-common/pull/65