### PR TITLE
Grant users admin role

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced-code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced-code.yaml
@@ -20,12 +20,12 @@ objects:
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-edit
+    name: user-admin
     namespace: ${USERNAME}-code
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: edit
+    name: admin
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/advanced-dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced-dev.yaml
@@ -20,12 +20,12 @@ objects:
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-edit
+    name: user-admin
     namespace: ${USERNAME}-dev
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: edit
+    name: admin
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/advanced-stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced-stage.yaml
@@ -20,12 +20,12 @@ objects:
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-edit
+    name: user-admin
     namespace: ${USERNAME}-stage
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: edit
+    name: admin
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/basic-code.yaml
+++ b/deploy/templates/nstemplatetiers/basic-code.yaml
@@ -20,12 +20,12 @@ objects:
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-edit
+    name: user-admin
     namespace: ${USERNAME}-code
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: edit
+    name: admin
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/basic-dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic-dev.yaml
@@ -20,12 +20,12 @@ objects:
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-edit
+    name: user-admin
     namespace: ${USERNAME}-dev
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: edit
+    name: admin
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/basic-stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic-stage.yaml
@@ -20,12 +20,12 @@ objects:
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-edit
+    name: user-admin
     namespace: ${USERNAME}-stage
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: edit
+    name: admin
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -167,12 +167,12 @@ func TestNewNSTemplateTier(t *testing.T) {
 							require.Len(t, ns.Template.Objects, 2)
 							rbFound := false
 							for _, object := range ns.Template.Objects {
-								if strings.Contains(string(object.Raw), `"kind":"RoleBinding","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"user-edit"`) {
+								if strings.Contains(string(object.Raw), `"kind":"RoleBinding","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"user-admin"`) {
 									rbFound = true
 									break
 								}
 							}
-							assert.True(t, rbFound, "the user-edit RoleBinding wasn't found in the namespace of the type", "ns-type", nsType)
+							assert.True(t, rbFound, "the user-admin RoleBinding wasn't found in the namespace of the type", "ns-type", nsType)
 
 							break
 						}


### PR DESCRIPTION
Edit role is not enough for Che. It requires access to some resources like roles which is not allowed by edit.
We can probably create a specific role and define the minimum permissions but I think it's OK if we just add admin role for the user for now. Deleting a namespace by user should not be a problem because our NSTemplateSet Controller will recreate namespaces.
Later we will improve it.

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/62