### PR TITLE
Add Che Dashboard URL to MUR status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/host-operator
 require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396
+	github.com/codeready-toolchain/api v0.0.0-20191212002517-882a587d15ce
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20191206100349-1d3b3ba54c59
 	github.com/emicklei/go-restful v2.10.0+incompatible // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1/go.mod h1:/iP1
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0 h1:APb57ts/dN2/vJb+9Fjc5I3QpOx/OBWzObGKj6zdPPU=
 github.com/codeready-toolchain/api v0.0.0-20191203182149-f994640853b0/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
-github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396 h1:OTMOZninxzV2p2gTfyF825h4rUNb8rBQ5JwvPOVN1nk=
-github.com/codeready-toolchain/api v0.0.0-20191206004733-862cefb68396/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
+github.com/codeready-toolchain/api v0.0.0-20191212002517-882a587d15ce h1:Ipie8qsA9Vkonj/y2p+Ddlo2Z4wtg2OQzWruUO8te0I=
+github.com/codeready-toolchain/api v0.0.0-20191212002517-882a587d15ce/go.mod h1:K2iSNSOwpQf+Wo3LdmrGaPlha2BLwuywwWrnbuiy8Pg=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191206100349-1d3b3ba54c59 h1:jolppHHBI9Vouzd2X5fvvj/73kvyBgxMFMUAMCXeih4=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20191206100349-1d3b3ba54c59/go.mod h1:c5EL9bEskD3ViC/ma1OhyIWNdGQMu+0K2nhGs+vfb9M=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -142,7 +142,7 @@ func (s *Synchronizer) withConsoleURL(status toolchainv1alpha1.UserAccountStatus
 func (s *Synchronizer) withCheDashboardURL(status toolchainv1alpha1.UserAccountStatusEmbedded) (toolchainv1alpha1.UserAccountStatusEmbedded, error) {
 	if status.Cluster.CheDashboardURL == "" {
 		route := &routev1.Route{}
-		namespacedName := types.NamespacedName{Namespace: cheNamespace, Name: "console"}
+		namespacedName := types.NamespacedName{Namespace: cheNamespace, Name: "che"}
 		err := s.memberCluster.Client.Get(context.TODO(), namespacedName, route)
 		if err != nil {
 			s.log.Error(err, "unable to get che dashboard route")

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -138,7 +138,7 @@ func (s *Synchronizer) withConsoleURL(status toolchainv1alpha1.UserAccountStatus
 	return status, nil
 }
 
-// withClusterAPIEndpoint returns the given user account status with Che Dashboard URL set if it's not already set yet
+// withCheDashboardURL returns the given user account status with Che Dashboard URL set if it's not already set yet
 func (s *Synchronizer) withCheDashboardURL(status toolchainv1alpha1.UserAccountStatusEmbedded) (toolchainv1alpha1.UserAccountStatusEmbedded, error) {
 	if status.Cluster.CheDashboardURL == "" {
 		route := &routev1.Route{}


### PR DESCRIPTION
Add Che Dashboard URL to MUR status if Che is available in the cluster.

There is no e2e tests for this change because we do not install Che Operator on our tests clusters.
This is something to address later.