### PR TITLE
Reduce user permissions

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced-code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced-code.yaml
@@ -60,7 +60,7 @@ objects:
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: toolchain-workspaces
+    name: toolchain-che-edit
   subjects:
     - kind: User
       name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/advanced-code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced-code.yaml
@@ -15,20 +15,55 @@ objects:
     labels:
       provider: codeready-toolchain
     name: ${USERNAME}-code
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    labels:
+      provider: codeready-toolchain
+    name: toolchain-che-edit
+    namespace: ${USERNAME}-code
+  rules:
+    - apiGroups:
+        - authorization.openshift.io
+        - rbac.authorization.k8s.io
+      resources:
+        - roles
+        - rolebindings
+      verbs:
+        - get
+        - list
+        - create
+        - update
+        - patch
+        - delete
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-admin
+    name: user-edit
     namespace: ${USERNAME}-code
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: admin
+    name: edit
   subjects:
   - kind: User
     name: ${USERNAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      provider: codeready-toolchain
+    name: user-toolchain-che-edit
+    namespace: ${USERNAME}-code
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: toolchain-workspaces
+  subjects:
+    - kind: User
+      name: ${USERNAME}
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/advanced-code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced-code.yaml
@@ -30,12 +30,7 @@ objects:
         - roles
         - rolebindings
       verbs:
-        - get
-        - list
-        - create
-        - update
-        - patch
-        - delete
+        - '*'
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:

--- a/deploy/templates/nstemplatetiers/advanced-dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced-dev.yaml
@@ -15,17 +15,17 @@ objects:
     labels:
       provider: codeready-toolchain
     name: ${USERNAME}-dev
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-admin
+    name: user-edit
     namespace: ${USERNAME}-dev
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: admin
+    name: edit
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/advanced-stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced-stage.yaml
@@ -15,17 +15,17 @@ objects:
     labels:
       provider: codeready-toolchain
     name: ${USERNAME}-stage
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-admin
+    name: user-edit
     namespace: ${USERNAME}-stage
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: admin
+    name: edit
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/basic-code.yaml
+++ b/deploy/templates/nstemplatetiers/basic-code.yaml
@@ -60,7 +60,7 @@ objects:
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: toolchain-workspaces
+    name: toolchain-che-edit
   subjects:
     - kind: User
       name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/basic-code.yaml
+++ b/deploy/templates/nstemplatetiers/basic-code.yaml
@@ -15,20 +15,55 @@ objects:
     labels:
       provider: codeready-toolchain
     name: ${USERNAME}-code
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    labels:
+      provider: codeready-toolchain
+    name: toolchain-che-edit
+    namespace: ${USERNAME}-code
+  rules:
+    - apiGroups:
+        - authorization.openshift.io
+        - rbac.authorization.k8s.io
+      resources:
+        - roles
+        - rolebindings
+      verbs:
+        - get
+        - list
+        - create
+        - update
+        - patch
+        - delete
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-admin
+    name: user-edit
     namespace: ${USERNAME}-code
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: admin
+    name: edit
   subjects:
   - kind: User
     name: ${USERNAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      provider: codeready-toolchain
+    name: user-toolchain-che-edit
+    namespace: ${USERNAME}-code
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: toolchain-workspaces
+  subjects:
+    - kind: User
+      name: ${USERNAME}
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basic-code.yaml
+++ b/deploy/templates/nstemplatetiers/basic-code.yaml
@@ -30,12 +30,7 @@ objects:
         - roles
         - rolebindings
       verbs:
-        - get
-        - list
-        - create
-        - update
-        - patch
-        - delete
+        - '*'
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:

--- a/deploy/templates/nstemplatetiers/basic-dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic-dev.yaml
@@ -15,17 +15,17 @@ objects:
     labels:
       provider: codeready-toolchain
     name: ${USERNAME}-dev
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-admin
+    name: user-edit
     namespace: ${USERNAME}-dev
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: admin
+    name: edit
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/basic-stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic-stage.yaml
@@ -15,17 +15,17 @@ objects:
     labels:
       provider: codeready-toolchain
     name: ${USERNAME}-stage
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
     labels:
       provider: codeready-toolchain
-    name: user-admin
+    name: user-edit
     namespace: ${USERNAME}-stage
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: admin
+    name: edit
   subjects:
   - kind: User
     name: ${USERNAME}

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -164,15 +164,20 @@ func TestNewNSTemplateTier(t *testing.T) {
 
 							// Assert expected objects in the template
 							// Each template should have one Namespace and one RoleBinding object
-							require.Len(t, ns.Template.Objects, 2)
+							// except "code" which should also have additional RoleBinding and Role
+							if nsType == "code" {
+								require.Len(t, ns.Template.Objects, 4)
+							} else {
+								require.Len(t, ns.Template.Objects, 2)
+							}
 							rbFound := false
 							for _, object := range ns.Template.Objects {
-								if strings.Contains(string(object.Raw), `"kind":"RoleBinding","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"user-admin"`) {
+								if strings.Contains(string(object.Raw), `"kind":"RoleBinding","metadata":{"labels":{"provider":"codeready-toolchain"},"name":"user-edit"`) {
 									rbFound = true
 									break
 								}
 							}
-							assert.True(t, rbFound, "the user-admin RoleBinding wasn't found in the namespace of the type", "ns-type", nsType)
+							assert.True(t, rbFound, "the user-edit RoleBinding wasn't found in the namespace of the type", "ns-type", nsType)
 
 							break
 						}


### PR DESCRIPTION
Requires https://github.com/codeready-toolchain/member-operator/pull/109 to be merged first to pass e2e tests.

After some investigation it looks like che requires edit permissions for roles and rolebindings in the namespace to create workspaces. This is on top of the edit role (to create other resources like deployments, routes, services, etc).

This PR reduces permissions to edit role for all namespaces and adds the missing edit permissions for roles and rolebindings for -code namespace.

E2E tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/63