### PR TITLE
 Fix 'cannot list resource bindings' error

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -11,6 +11,7 @@ rules:
   - componentstatuses
   - pods
   - services
+  - bindings
   verbs:
   - get
   - list

--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
@@ -149,6 +149,7 @@ spec:
           - componentstatuses
           - pods
           - services
+          - bindings
           verbs:
           - get
           - list

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -856,6 +856,7 @@ data:
                 - componentstatuses
                 - pods
                 - services
+                - bindings
                 verbs:
                 - get
                 - list


### PR DESCRIPTION
Fixes:
```
Failed to list *unstructured.Unstructured: bindings is forbidden: User "system:serviceaccount:toolchain-host-operator:host-operator" cannot list resource "bindings" in API group "" in the namespace "toolchain-host-operator"
```