### PR TITLE
fix: use toolchain apis for listing CRs to be monitored

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 
+	api "github.com/codeready-toolchain/api/pkg/apis"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	"github.com/codeready-toolchain/host-operator/pkg/controller"
 	"github.com/codeready-toolchain/host-operator/pkg/templates/nstemplatetiers"
@@ -215,7 +216,7 @@ func ensureKubeFedClusterCRD(config *rest.Config) error {
 func serveCRMetrics(cfg *rest.Config) error {
 	// Below function returns filtered operator/CustomResource specific GVKs.
 	// For more control override the below GVK list with your own custom logic.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(api.AddToScheme)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When creating metrics of our CRs we should use our toolchain apis
This will get rid of the annoying errors `reflector.go:95: Failed to list` in the logs