### PR TITLE
chore: remove unneeded permissons

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -7,14 +7,8 @@ rules:
   - ""
   resources:
   - nodes
-  - namespaces
-  - componentstatuses
-  - pods
-  - services
   verbs:
-  - get
-  - list
-  - watch
+  - "list"
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -22,13 +16,3 @@ rules:
   verbs:
   - "get"
   - "create"
-  - "list"
-  - "watch"
-- apiGroups:
-  - template.openshift.io
-  resources:
-  - brokertemplateinstances
-  - processedtemplates
-  verbs:
-  - "get"
-  - "list"

--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
@@ -145,14 +145,8 @@ spec:
           - ""
           resources:
           - nodes
-          - namespaces
-          - componentstatuses
-          - pods
-          - services
           verbs:
-          - get
           - list
-          - watch
         - apiGroups:
           - apiextensions.k8s.io
           resources:
@@ -160,16 +154,6 @@ spec:
           verbs:
           - get
           - create
-          - list
-          - watch
-        - apiGroups:
-          - template.openshift.io
-          resources:
-          - brokertemplateinstances
-          - processedtemplates
-          verbs:
-          - get
-          - list
         serviceAccountName: host-operator
       deployments:
       - name: host-operator
@@ -219,18 +203,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - ""
-          resources:
-          - podtemplates
-          - resourcequotas
-          - serviceaccounts
-          - replicationcontrollers
-          - limitranges
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - route.openshift.io
           resources:
           - routes
@@ -240,9 +212,6 @@ spec:
           - apps
           resources:
           - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
           verbs:
           - '*'
         - apiGroups:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -54,13 +54,13 @@ rules:
   resources:
   - kubefedclusters/status
   verbs:
-  - update
+  - "update"
 - apiGroups:
   - toolchain.dev.openshift.com
   resources:
-  - '*'
+  - "*"
   verbs:
-  - '*'
+  - "*"
 - apiGroups:
   - rbac.authorization.k8s.io
   - authorization.openshift.io
@@ -68,4 +68,4 @@ rules:
   - roles
   - rolebindings
   verbs:
-  - '*'
+  - "*"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -17,18 +17,6 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - ""
-  resources:
-  - podtemplates
-  - resourcequotas
-  - serviceaccounts
-  - replicationcontrollers
-  - limitranges
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - route.openshift.io
   resources:
   - routes
@@ -38,9 +26,6 @@ rules:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - "*"
 - apiGroups:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -852,14 +852,8 @@ data:
                 - ""
                 resources:
                 - nodes
-                - namespaces
-                - componentstatuses
-                - pods
-                - services
                 verbs:
-                - get
                 - list
-                - watch
               - apiGroups:
                 - apiextensions.k8s.io
                 resources:
@@ -867,16 +861,6 @@ data:
                 verbs:
                 - get
                 - create
-                - list
-                - watch
-              - apiGroups:
-                - template.openshift.io
-                resources:
-                - brokertemplateinstances
-                - processedtemplates
-                verbs:
-                - get
-                - list
               serviceAccountName: host-operator
             deployments:
             - name: host-operator
@@ -926,18 +910,6 @@ data:
                 verbs:
                 - '*'
               - apiGroups:
-                - ""
-                resources:
-                - podtemplates
-                - resourcequotas
-                - serviceaccounts
-                - replicationcontrollers
-                - limitranges
-                verbs:
-                - get
-                - list
-                - watch
-              - apiGroups:
                 - route.openshift.io
                 resources:
                 - routes
@@ -947,9 +919,6 @@ data:
                 - apps
                 resources:
                 - deployments
-                - daemonsets
-                - replicasets
-                - statefulsets
                 verbs:
                 - '*'
               - apiGroups:


### PR DESCRIPTION
Since the RBAC issue with `reflector.go:95: Failed to list` errors should be fixed I decided to remove unneeded permissions from our roles. I didn't spend much time investigating which particular permissions are used and which are not, I just removed those that were apparently added just as a workaround for making our logs clean and happy.