### PR TITLE
chore: install github.com/kislyuk/yq binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
 - cp operator-sdk /home/travis/bin/operator-sdk
 - rm operator-sdk
 - pip3 install operator-courier
+- pip3 install yq
 
 script:
 - make build && make docker-login && make docker-push && curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/push-to-quay-nightly.sh | bash -s -- -pr ../host-operator/

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -28,7 +28,11 @@ RUN yum install epel-release -y \
     python36-virtualenv \
     jq \
     gcc \
+    pip3 \
     && yum clean all
+
+# Install yq that will be used for parsing/reading yaml files.
+RUN pip3 install yq
 
 WORKDIR /tmp
 


### PR DESCRIPTION
`yq` binary is needed in the script introduced here https://github.com/codeready-toolchain/api/pull/88. The script will be then used for e2e tests as well as for CD