### PR TITLE
Fix MUR status synchronization in case of target availability error

### DIFF
--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -410,7 +410,7 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 			Cluster: toolchainv1alpha1.Cluster{
 				Name: "member3-cluster",
 			},
-			UserAccountStatus: userAccount.Status,
+			UserAccountStatus: userAccount3.Status,
 		})
 
 		memberClient := test.NewFakeClient(t, userAccount, consoleRoute())

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -393,27 +393,27 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 		userAccount := uatest.NewUserAccountFromMur(mur,
 			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
-		mur.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{}
-
 		userAccount2 := uatest.NewUserAccountFromMur(mur,
 			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
-		mur.Status.UserAccounts = append(mur.Status.UserAccounts, toolchainv1alpha1.UserAccountStatusEmbedded{
-			SyncIndex: "111aaa",
-			Cluster: toolchainv1alpha1.Cluster{
-				Name: "member2-cluster",
-			},
-			UserAccountStatus: userAccount2.Status,
-		})
-
 		userAccount3 := uatest.NewUserAccountFromMur(mur,
 			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
-		mur.Status.UserAccounts = append(mur.Status.UserAccounts, toolchainv1alpha1.UserAccountStatusEmbedded{
-			SyncIndex: "123abc",
-			Cluster: toolchainv1alpha1.Cluster{
-				Name: "member3-cluster",
+
+		mur.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{
+			{
+				SyncIndex: "111aaa",
+				Cluster: toolchainv1alpha1.Cluster{
+					Name: "member2-cluster",
+				},
+				UserAccountStatus: userAccount2.Status,
 			},
-			UserAccountStatus: userAccount3.Status,
-		})
+			{
+				SyncIndex: "123abc",
+				Cluster: toolchainv1alpha1.Cluster{
+					Name: "member3-cluster",
+				},
+				UserAccountStatus: userAccount3.Status,
+			},
+		}
 
 		memberClient := test.NewFakeClient(t, userAccount, consoleRoute())
 		memberClient2 := test.NewFakeClient(t, userAccount2, consoleRoute())

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -380,71 +380,116 @@ func TestModifyUserAccounts(t *testing.T) {
 }
 
 func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
-	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
 
-	mur := murtest.NewMasterUserRecord("john",
-		murtest.StatusCondition(toBeNotReady(provisioningReason, "")),
-		murtest.AdditionalAccounts("member2-cluster", "member3-cluster"))
+	t.Run("mur status synced with updated user account statuses", func(t *testing.T) {
+		// given
+		mur := murtest.NewMasterUserRecord("john",
+			murtest.StatusCondition(toBeNotReady(provisioningReason, "")),
+			murtest.AdditionalAccounts("member2-cluster", "member3-cluster"))
 
-	userAccount := uatest.NewUserAccountFromMur(mur,
-		uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
-	mur.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{}
+		userAccount := uatest.NewUserAccountFromMur(mur,
+			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
+		mur.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{}
 
-	userAccount2 := uatest.NewUserAccountFromMur(mur,
-		uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
-	mur.Status.UserAccounts = append(mur.Status.UserAccounts, toolchainv1alpha1.UserAccountStatusEmbedded{
-		SyncIndex: "111aaa",
-		Cluster: toolchainv1alpha1.Cluster{
-			Name: "member2-cluster",
-		},
-		UserAccountStatus: userAccount.Status,
+		userAccount2 := uatest.NewUserAccountFromMur(mur,
+			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
+		mur.Status.UserAccounts = append(mur.Status.UserAccounts, toolchainv1alpha1.UserAccountStatusEmbedded{
+			SyncIndex: "111aaa",
+			Cluster: toolchainv1alpha1.Cluster{
+				Name: "member2-cluster",
+			},
+			UserAccountStatus: userAccount.Status,
+		})
+
+		userAccount3 := uatest.NewUserAccountFromMur(mur,
+			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
+		mur.Status.UserAccounts = append(mur.Status.UserAccounts, toolchainv1alpha1.UserAccountStatusEmbedded{
+			SyncIndex: "123abc",
+			Cluster: toolchainv1alpha1.Cluster{
+				Name: "member3-cluster",
+			},
+			UserAccountStatus: userAccount.Status,
+		})
+
+		memberClient := test.NewFakeClient(t, userAccount, consoleRoute())
+		memberClient2 := test.NewFakeClient(t, userAccount2, consoleRoute())
+		memberClient3 := test.NewFakeClient(t, userAccount3, consoleRoute())
+
+		hostClient := test.NewFakeClient(t, mur)
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+			clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
+			clusterClient("member3-cluster", memberClient3))
+
+		// when
+		_, err := cntrl.Reconcile(newMurRequest(mur))
+
+		// then
+		require.NoError(t, err)
+
+		uatest.AssertThatUserAccount(t, "john", memberClient).
+			Exists().
+			HasSpec(mur.Spec.UserAccounts[0].Spec).
+			HasConditions(userAccount.Status.Conditions...)
+		uatest.AssertThatUserAccount(t, "john", memberClient2).
+			Exists().
+			HasSpec(mur.Spec.UserAccounts[1].Spec).
+			HasConditions(userAccount2.Status.Conditions...)
+		uatest.AssertThatUserAccount(t, "john", memberClient3).
+			Exists().
+			HasSpec(mur.Spec.UserAccounts[2].Spec).
+			HasConditions(userAccount3.Status.Conditions...)
+
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions(toBeNotReady(provisioningReason, "")).
+			HasStatusUserAccounts(test.MemberClusterName, "member2-cluster", "member3-cluster").
+			AllUserAccountsHaveStatusSyncIndex("123abc").
+			AllUserAccountsHaveCondition(userAccount.Status.Conditions[0])
 	})
 
-	userAccount3 := uatest.NewUserAccountFromMur(mur,
-		uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
-	mur.Status.UserAccounts = append(mur.Status.UserAccounts, toolchainv1alpha1.UserAccountStatusEmbedded{
-		SyncIndex: "123abc",
-		Cluster: toolchainv1alpha1.Cluster{
-			Name: "member3-cluster",
-		},
-		UserAccountStatus: userAccount.Status,
+	t.Run("outdated mur status error cleaned", func(t *testing.T) {
+		// given
+		// MUR with ready condition set to false with an error
+		// all MUR.Status.UserAccount[] conditions are already in sync with the corresponding UserAccounts and set to Ready
+		mur := murtest.NewMasterUserRecord("john",
+			murtest.StatusCondition(toBeNotReady(targetClusterNotReadyReason, "something went wrong")),
+			murtest.AdditionalAccounts("member2-cluster"))
+		userAccount := uatest.NewUserAccountFromMur(mur, uatest.StatusCondition(toBeProvisioned()), uatest.ResourceVersion("123abc"))
+		userAccount2 := uatest.NewUserAccountFromMur(mur, uatest.StatusCondition(toBeProvisioned()), uatest.ResourceVersion("123abc"))
+		mur.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{
+			{
+				Cluster:           toolchainv1alpha1.Cluster{Name: test.MemberClusterName},
+				SyncIndex:         userAccount.ResourceVersion,
+				UserAccountStatus: userAccount.Status,
+			},
+			{
+				Cluster:           toolchainv1alpha1.Cluster{Name: "member2-cluster"},
+				SyncIndex:         userAccount2.ResourceVersion,
+				UserAccountStatus: userAccount2.Status,
+			},
+		}
+
+		hostClient := test.NewFakeClient(t, mur)
+
+		memberClient := test.NewFakeClient(t, userAccount, consoleRoute())
+		memberClient2 := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur), consoleRoute())
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+			clusterClient(test.MemberClusterName, memberClient),
+			clusterClient("member2-cluster", memberClient2))
+
+		// when
+		_, err := cntrl.Reconcile(newMurRequest(mur))
+
+		// then
+		// the original error status should be cleaned
+		require.NoError(t, err)
+
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions(toBeProvisioned()).
+			HasStatusUserAccounts(test.MemberClusterName, "member2-cluster").
+			HasFinalizer()
 	})
-
-	memberClient := test.NewFakeClient(t, userAccount, consoleRoute())
-	memberClient2 := test.NewFakeClient(t, userAccount2, consoleRoute())
-	memberClient3 := test.NewFakeClient(t, userAccount3, consoleRoute())
-
-	hostClient := test.NewFakeClient(t, mur)
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
-		clusterClient("member3-cluster", memberClient3))
-
-	// when
-	_, err := cntrl.Reconcile(newMurRequest(mur))
-
-	// then
-	require.NoError(t, err)
-
-	uatest.AssertThatUserAccount(t, "john", memberClient).
-		Exists().
-		HasSpec(mur.Spec.UserAccounts[0].Spec).
-		HasConditions(userAccount.Status.Conditions...)
-	uatest.AssertThatUserAccount(t, "john", memberClient2).
-		Exists().
-		HasSpec(mur.Spec.UserAccounts[1].Spec).
-		HasConditions(userAccount2.Status.Conditions...)
-	uatest.AssertThatUserAccount(t, "john", memberClient3).
-		Exists().
-		HasSpec(mur.Spec.UserAccounts[2].Spec).
-		HasConditions(userAccount3.Status.Conditions...)
-
-	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-		HasConditions(toBeNotReady(provisioningReason, "")).
-		HasStatusUserAccounts(test.MemberClusterName, "member2-cluster", "member3-cluster").
-		AllUserAccountsHaveStatusSyncIndex("123abc").
-		AllUserAccountsHaveCondition(userAccount.Status.Conditions[0])
 }
 
 func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -400,7 +400,7 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 			Cluster: toolchainv1alpha1.Cluster{
 				Name: "member2-cluster",
 			},
-			UserAccountStatus: userAccount.Status,
+			UserAccountStatus: userAccount2.Status,
 		})
 
 		userAccount3 := uatest.NewUserAccountFromMur(mur,

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -385,6 +385,8 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 	t.Run("mur status synced with updated user account statuses", func(t *testing.T) {
 		// given
+		// setup MUR that wil contain UserAccountStatusEmbedded fields for UserAccounts from "member2-cluster" and "member3-cluster" but will miss from test.MemberClusterName
+		// then the reconcile should add the misssing UserAccountStatusEmbedded for the missing test.MemberClusterName cluster without updating anything else
 		mur := murtest.NewMasterUserRecord("john",
 			murtest.StatusCondition(toBeNotReady(provisioningReason, "")),
 			murtest.AdditionalAccounts("member2-cluster", "member3-cluster"))

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -81,15 +81,21 @@ func (s *Synchronizer) synchronizeStatus() error {
 
 		err = s.hostClient.Status().Update(context.TODO(), s.record)
 		if err != nil {
+			// if there is an error during status update then we "roll back" all the status changes we did above
+			// (don't add new user account status if it was added or don't change it if it's updated)
 			if index < 0 {
 				s.record.Status.UserAccounts = s.record.Status.UserAccounts[:len(s.record.Status.UserAccounts)-1]
 			} else {
 				s.record.Status.UserAccounts[index] = originalStatusUserAcc
 			}
-			return err
 		}
+		return err
 	}
-	return nil
+
+	// Align readiness even if the user account statuses were not changed.
+	// We need to do it to cleanup outdated errors (for example if the target cluster was unavailable) if any
+	s.alignReadiness()
+	return s.hostClient.Status().Update(context.TODO(), s.record)
 }
 
 // withClusterDetails returns the given user account status with additional information about


### PR DESCRIPTION
Currently ff MUR reconcile failed with some error (target member cluster is temporally not available for example) then the error is stuck in MUR.Status.Ready condition if there is no changes in the MUR.Status.UserAccount[] conditions.

Steps to reproduce:
- Create a MUR and get it provisioned. UserAccount is provisioned and MUR is Ready.
- Break the member kubefedcluster, so member is not available from host.
- Trigger MUR reconcile
- MUR.Status.Ready condition is false now with the error about unavailable member
- Fix member cluster
- MUR reconcile is called but there is nothing to update in MUR.Status.UserAccount[] since the corresponding UserAccount statuses didn't change in member. So, MUR do not update Ready condition either and we stuck with the error.

This PR fixes the problem and force Ready condition update even if there is no UserAccount status changes.

TODO:
- [x] Add Unit tests

Writing e2e tests for that fix is pretty tricky... We can't make an existing kubefed cluster unhealthy by updating the spec of the existing kubefedcluster resource. The update is ignored if it breaks the cluster.