### PR TITLE
generated from make generate in api

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -75,7 +75,8 @@ spec:
                     properties:
                       disabled:
                         description: If set to true then the corresponding user should
-                          not be able to login "false" is assumed by default
+                          not be able to login "false" is assumed by default. This
+                          field is duplicated and will be removed in the future.
                         type: boolean
                       nsLimit:
                         description: The namespace limit name
@@ -116,12 +117,12 @@ spec:
                       userID:
                         description: UserID is the user ID from RHD Identity Provider
                           token (“sub” claim) Is to be used to create Identity and
-                          UserIdentityMapping resources
+                          UserIdentityMapping resources. This field is duplicated
+                          and will be removed in the future.
                         type: string
                     required:
                     - nsLimit
                     - nsTemplateSet
-                    - userID
                     type: object
                   syncIndex:
                     description: SyncIndex is to be updated by UserAccount Controller

--- a/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -78,41 +78,49 @@ spec:
                           not be able to login "false" is assumed by default. This
                           field is duplicated and will be removed in the future.
                         type: boolean
-                      nsLimit:
-                        description: The namespace limit name
-                        type: string
-                      nsTemplateSet:
-                        description: Namespace template set
+                      userAccountSpecBase:
+                        description: UserAccountBase contains all base fields
                         properties:
-                          namespaces:
-                            description: The namespace templates
-                            items:
-                              description: NSTemplateSetNamespace the namespace definition
-                                in an NSTemplateSet resource
-                              properties:
-                                revision:
-                                  description: The revision of the corresponding template
-                                  type: string
-                                template:
-                                  description: Optional field. Used to specify a custom
-                                    template
-                                  type: string
-                                type:
-                                  description: 'The type of the namespace. For example:
-                                    ide|cicd|stage|default'
-                                  type: string
-                              required:
-                              - revision
-                              - type
-                              type: object
-                            type: array
-                          tierName:
-                            description: The name of the tier represented by this
-                              template set
+                          nsLimit:
+                            description: The namespace limit name
                             type: string
+                          nsTemplateSet:
+                            description: Namespace template set
+                            properties:
+                              namespaces:
+                                description: The namespace templates
+                                items:
+                                  description: NSTemplateSetNamespace the namespace
+                                    definition in an NSTemplateSet resource
+                                  properties:
+                                    revision:
+                                      description: The revision of the corresponding
+                                        template
+                                      type: string
+                                    template:
+                                      description: Optional field. Used to specify
+                                        a custom template
+                                      type: string
+                                    type:
+                                      description: 'The type of the namespace. For
+                                        example: ide|cicd|stage|default'
+                                      type: string
+                                  required:
+                                  - revision
+                                  - type
+                                  type: object
+                                type: array
+                              tierName:
+                                description: The name of the tier represented by this
+                                  template set
+                                type: string
+                            required:
+                            - namespaces
+                            - tierName
+                            type: object
                         required:
-                        - namespaces
-                        - tierName
+                        - nsLimit
+                        - nsTemplateSet
                         type: object
                       userID:
                         description: UserID is the user ID from RHD Identity Provider
@@ -121,8 +129,7 @@ spec:
                           and will be removed in the future.
                         type: string
                     required:
-                    - nsLimit
-                    - nsTemplateSet
+                    - userAccountSpecBase
                     type: object
                   syncIndex:
                     description: SyncIndex is to be updated by UserAccount Controller

--- a/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -78,49 +78,41 @@ spec:
                           not be able to login "false" is assumed by default. This
                           field is duplicated and will be removed in the future.
                         type: boolean
-                      userAccountSpecBase:
-                        description: UserAccountBase contains all base fields
+                      nsLimit:
+                        description: The namespace limit name
+                        type: string
+                      nsTemplateSet:
+                        description: Namespace template set
                         properties:
-                          nsLimit:
-                            description: The namespace limit name
+                          namespaces:
+                            description: The namespace templates
+                            items:
+                              description: NSTemplateSetNamespace the namespace definition
+                                in an NSTemplateSet resource
+                              properties:
+                                revision:
+                                  description: The revision of the corresponding template
+                                  type: string
+                                template:
+                                  description: Optional field. Used to specify a custom
+                                    template
+                                  type: string
+                                type:
+                                  description: 'The type of the namespace. For example:
+                                    ide|cicd|stage|default'
+                                  type: string
+                              required:
+                              - revision
+                              - type
+                              type: object
+                            type: array
+                          tierName:
+                            description: The name of the tier represented by this
+                              template set
                             type: string
-                          nsTemplateSet:
-                            description: Namespace template set
-                            properties:
-                              namespaces:
-                                description: The namespace templates
-                                items:
-                                  description: NSTemplateSetNamespace the namespace
-                                    definition in an NSTemplateSet resource
-                                  properties:
-                                    revision:
-                                      description: The revision of the corresponding
-                                        template
-                                      type: string
-                                    template:
-                                      description: Optional field. Used to specify
-                                        a custom template
-                                      type: string
-                                    type:
-                                      description: 'The type of the namespace. For
-                                        example: ide|cicd|stage|default'
-                                      type: string
-                                  required:
-                                  - revision
-                                  - type
-                                  type: object
-                                type: array
-                              tierName:
-                                description: The name of the tier represented by this
-                                  template set
-                                type: string
-                            required:
-                            - namespaces
-                            - tierName
-                            type: object
                         required:
-                        - nsLimit
-                        - nsTemplateSet
+                        - namespaces
+                        - tierName
                         type: object
                       userID:
                         description: UserID is the user ID from RHD Identity Provider
@@ -129,7 +121,8 @@ spec:
                           and will be removed in the future.
                         type: string
                     required:
-                    - userAccountSpecBase
+                    - nsLimit
+                    - nsTemplateSet
                     type: object
                   syncIndex:
                     description: SyncIndex is to be updated by UserAccount Controller

--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
@@ -6,6 +6,38 @@ metadata:
       [
         {
           "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+          "kind": "RegistrationService",
+          "metadata": {
+            "labels": {
+              "provider": "codeready-toolchain"
+            },
+            "name": "reg-service",
+            "namespace": "toolchain-host-operator"
+          },
+          "spec": {
+            "envVars": {
+              "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
+              "ENVIRONMENT": "dev",
+              "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
+              "REPLICAS": "4"
+            }
+          }
+        },
+        {
+          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+          "kind": "UserSignup",
+          "metadata": {
+            "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
+          },
+          "spec": {
+            "approved": true,
+            "compliantUsername": "johnsmith-at-redhat-com",
+            "targetCluster": "east-2a",
+            "username": "johnsmith@redhat.com"
+          }
+        },
+        {
+          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
           "kind": "BannedUser",
           "metadata": {
             "labels": {
@@ -86,38 +118,6 @@ metadata:
                 "type": "default"
               }
             ]
-          }
-        },
-        {
-          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-          "kind": "RegistrationService",
-          "metadata": {
-            "labels": {
-              "provider": "codeready-toolchain"
-            },
-            "name": "reg-service",
-            "namespace": "toolchain-host-operator"
-          },
-          "spec": {
-            "envVars": {
-              "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
-              "ENVIRONMENT": "dev",
-              "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
-              "REPLICAS": "4"
-            }
-          }
-        },
-        {
-          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-          "kind": "UserSignup",
-          "metadata": {
-            "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
-          },
-          "spec": {
-            "approved": true,
-            "compliantUsername": "johnsmith-at-redhat-com",
-            "targetCluster": "east-2a",
-            "username": "johnsmith@redhat.com"
           }
         }
       ]

--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
@@ -6,38 +6,6 @@ metadata:
       [
         {
           "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-          "kind": "RegistrationService",
-          "metadata": {
-            "labels": {
-              "provider": "codeready-toolchain"
-            },
-            "name": "reg-service",
-            "namespace": "toolchain-host-operator"
-          },
-          "spec": {
-            "envVars": {
-              "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
-              "ENVIRONMENT": "dev",
-              "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
-              "REPLICAS": "4"
-            }
-          }
-        },
-        {
-          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-          "kind": "UserSignup",
-          "metadata": {
-            "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
-          },
-          "spec": {
-            "approved": true,
-            "compliantUsername": "johnsmith-at-redhat-com",
-            "targetCluster": "east-2a",
-            "username": "johnsmith@redhat.com"
-          }
-        },
-        {
-          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
           "kind": "BannedUser",
           "metadata": {
             "labels": {
@@ -118,6 +86,38 @@ metadata:
                 "type": "default"
               }
             ]
+          }
+        },
+        {
+          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+          "kind": "RegistrationService",
+          "metadata": {
+            "labels": {
+              "provider": "codeready-toolchain"
+            },
+            "name": "reg-service",
+            "namespace": "toolchain-host-operator"
+          },
+          "spec": {
+            "envVars": {
+              "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
+              "ENVIRONMENT": "dev",
+              "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
+              "REPLICAS": "4"
+            }
+          }
+        },
+        {
+          "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+          "kind": "UserSignup",
+          "metadata": {
+            "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
+          },
+          "spec": {
+            "approved": true,
+            "compliantUsername": "johnsmith-at-redhat-com",
+            "targetCluster": "east-2a",
+            "username": "johnsmith@redhat.com"
           }
         }
       ]

--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -75,7 +75,8 @@ spec:
                     properties:
                       disabled:
                         description: If set to true then the corresponding user should
-                          not be able to login "false" is assumed by default
+                          not be able to login "false" is assumed by default. This
+                          field is duplicated and will be removed in the future.
                         type: boolean
                       nsLimit:
                         description: The namespace limit name
@@ -116,12 +117,12 @@ spec:
                       userID:
                         description: UserID is the user ID from RHD Identity Provider
                           token (“sub” claim) Is to be used to create Identity and
-                          UserIdentityMapping resources
+                          UserIdentityMapping resources. This field is duplicated
+                          and will be removed in the future.
                         type: string
                     required:
                     - nsLimit
                     - nsTemplateSet
-                    - userID
                     type: object
                   syncIndex:
                     description: SyncIndex is to be updated by UserAccount Controller

--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -78,41 +78,49 @@ spec:
                           not be able to login "false" is assumed by default. This
                           field is duplicated and will be removed in the future.
                         type: boolean
-                      nsLimit:
-                        description: The namespace limit name
-                        type: string
-                      nsTemplateSet:
-                        description: Namespace template set
+                      userAccountSpecBase:
+                        description: UserAccountBase contains all base fields
                         properties:
-                          namespaces:
-                            description: The namespace templates
-                            items:
-                              description: NSTemplateSetNamespace the namespace definition
-                                in an NSTemplateSet resource
-                              properties:
-                                revision:
-                                  description: The revision of the corresponding template
-                                  type: string
-                                template:
-                                  description: Optional field. Used to specify a custom
-                                    template
-                                  type: string
-                                type:
-                                  description: 'The type of the namespace. For example:
-                                    ide|cicd|stage|default'
-                                  type: string
-                              required:
-                              - revision
-                              - type
-                              type: object
-                            type: array
-                          tierName:
-                            description: The name of the tier represented by this
-                              template set
+                          nsLimit:
+                            description: The namespace limit name
                             type: string
+                          nsTemplateSet:
+                            description: Namespace template set
+                            properties:
+                              namespaces:
+                                description: The namespace templates
+                                items:
+                                  description: NSTemplateSetNamespace the namespace
+                                    definition in an NSTemplateSet resource
+                                  properties:
+                                    revision:
+                                      description: The revision of the corresponding
+                                        template
+                                      type: string
+                                    template:
+                                      description: Optional field. Used to specify
+                                        a custom template
+                                      type: string
+                                    type:
+                                      description: 'The type of the namespace. For
+                                        example: ide|cicd|stage|default'
+                                      type: string
+                                  required:
+                                  - revision
+                                  - type
+                                  type: object
+                                type: array
+                              tierName:
+                                description: The name of the tier represented by this
+                                  template set
+                                type: string
+                            required:
+                            - namespaces
+                            - tierName
+                            type: object
                         required:
-                        - namespaces
-                        - tierName
+                        - nsLimit
+                        - nsTemplateSet
                         type: object
                       userID:
                         description: UserID is the user ID from RHD Identity Provider
@@ -121,8 +129,7 @@ spec:
                           and will be removed in the future.
                         type: string
                     required:
-                    - nsLimit
-                    - nsTemplateSet
+                    - userAccountSpecBase
                     type: object
                   syncIndex:
                     description: SyncIndex is to be updated by UserAccount Controller

--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -78,49 +78,41 @@ spec:
                           not be able to login "false" is assumed by default. This
                           field is duplicated and will be removed in the future.
                         type: boolean
-                      userAccountSpecBase:
-                        description: UserAccountBase contains all base fields
+                      nsLimit:
+                        description: The namespace limit name
+                        type: string
+                      nsTemplateSet:
+                        description: Namespace template set
                         properties:
-                          nsLimit:
-                            description: The namespace limit name
+                          namespaces:
+                            description: The namespace templates
+                            items:
+                              description: NSTemplateSetNamespace the namespace definition
+                                in an NSTemplateSet resource
+                              properties:
+                                revision:
+                                  description: The revision of the corresponding template
+                                  type: string
+                                template:
+                                  description: Optional field. Used to specify a custom
+                                    template
+                                  type: string
+                                type:
+                                  description: 'The type of the namespace. For example:
+                                    ide|cicd|stage|default'
+                                  type: string
+                              required:
+                              - revision
+                              - type
+                              type: object
+                            type: array
+                          tierName:
+                            description: The name of the tier represented by this
+                              template set
                             type: string
-                          nsTemplateSet:
-                            description: Namespace template set
-                            properties:
-                              namespaces:
-                                description: The namespace templates
-                                items:
-                                  description: NSTemplateSetNamespace the namespace
-                                    definition in an NSTemplateSet resource
-                                  properties:
-                                    revision:
-                                      description: The revision of the corresponding
-                                        template
-                                      type: string
-                                    template:
-                                      description: Optional field. Used to specify
-                                        a custom template
-                                      type: string
-                                    type:
-                                      description: 'The type of the namespace. For
-                                        example: ide|cicd|stage|default'
-                                      type: string
-                                  required:
-                                  - revision
-                                  - type
-                                  type: object
-                                type: array
-                              tierName:
-                                description: The name of the tier represented by this
-                                  template set
-                                type: string
-                            required:
-                            - namespaces
-                            - tierName
-                            type: object
                         required:
-                        - nsLimit
-                        - nsTemplateSet
+                        - namespaces
+                        - tierName
                         type: object
                       userID:
                         description: UserID is the user ID from RHD Identity Provider
@@ -129,7 +121,8 @@ spec:
                           and will be removed in the future.
                         type: string
                     required:
-                    - userAccountSpecBase
+                    - nsLimit
+                    - nsTemplateSet
                     type: object
                   syncIndex:
                     description: SyncIndex is to be updated by UserAccount Controller

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -152,41 +152,49 @@ data:
                                 not be able to login "false" is assumed by default. This
                                 field is duplicated and will be removed in the future.
                               type: boolean
-                            nsLimit:
-                              description: The namespace limit name
-                              type: string
-                            nsTemplateSet:
-                              description: Namespace template set
+                            userAccountSpecBase:
+                              description: UserAccountBase contains all base fields
                               properties:
-                                namespaces:
-                                  description: The namespace templates
-                                  items:
-                                    description: NSTemplateSetNamespace the namespace definition
-                                      in an NSTemplateSet resource
-                                    properties:
-                                      revision:
-                                        description: The revision of the corresponding template
-                                        type: string
-                                      template:
-                                        description: Optional field. Used to specify a custom
-                                          template
-                                        type: string
-                                      type:
-                                        description: 'The type of the namespace. For example:
-                                          ide|cicd|stage|default'
-                                        type: string
-                                    required:
-                                    - revision
-                                    - type
-                                    type: object
-                                  type: array
-                                tierName:
-                                  description: The name of the tier represented by this
-                                    template set
+                                nsLimit:
+                                  description: The namespace limit name
                                   type: string
+                                nsTemplateSet:
+                                  description: Namespace template set
+                                  properties:
+                                    namespaces:
+                                      description: The namespace templates
+                                      items:
+                                        description: NSTemplateSetNamespace the namespace
+                                          definition in an NSTemplateSet resource
+                                        properties:
+                                          revision:
+                                            description: The revision of the corresponding
+                                              template
+                                            type: string
+                                          template:
+                                            description: Optional field. Used to specify
+                                              a custom template
+                                            type: string
+                                          type:
+                                            description: 'The type of the namespace. For
+                                              example: ide|cicd|stage|default'
+                                            type: string
+                                        required:
+                                        - revision
+                                        - type
+                                        type: object
+                                      type: array
+                                    tierName:
+                                      description: The name of the tier represented by this
+                                        template set
+                                      type: string
+                                  required:
+                                  - namespaces
+                                  - tierName
+                                  type: object
                               required:
-                              - namespaces
-                              - tierName
+                              - nsLimit
+                              - nsTemplateSet
                               type: object
                             userID:
                               description: UserID is the user ID from RHD Identity Provider
@@ -195,8 +203,7 @@ data:
                                 and will be removed in the future.
                               type: string
                           required:
-                          - nsLimit
-                          - nsTemplateSet
+                          - userAccountSpecBase
                           type: object
                         syncIndex:
                           description: SyncIndex is to be updated by UserAccount Controller
@@ -743,6 +750,38 @@ data:
             [
               {
                 "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+                "kind": "RegistrationService",
+                "metadata": {
+                  "labels": {
+                    "provider": "codeready-toolchain"
+                  },
+                  "name": "reg-service",
+                  "namespace": "toolchain-host-operator"
+                },
+                "spec": {
+                  "envVars": {
+                    "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
+                    "ENVIRONMENT": "dev",
+                    "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
+                    "REPLICAS": "4"
+                  }
+                }
+              },
+              {
+                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+                "kind": "UserSignup",
+                "metadata": {
+                  "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
+                },
+                "spec": {
+                  "approved": true,
+                  "compliantUsername": "johnsmith-at-redhat-com",
+                  "targetCluster": "east-2a",
+                  "username": "johnsmith@redhat.com"
+                }
+              },
+              {
+                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
                 "kind": "BannedUser",
                 "metadata": {
                   "labels": {
@@ -823,38 +862,6 @@ data:
                       "type": "default"
                     }
                   ]
-                }
-              },
-              {
-                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-                "kind": "RegistrationService",
-                "metadata": {
-                  "labels": {
-                    "provider": "codeready-toolchain"
-                  },
-                  "name": "reg-service",
-                  "namespace": "toolchain-host-operator"
-                },
-                "spec": {
-                  "envVars": {
-                    "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
-                    "ENVIRONMENT": "dev",
-                    "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
-                    "REPLICAS": "4"
-                  }
-                }
-              },
-              {
-                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-                "kind": "UserSignup",
-                "metadata": {
-                  "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
-                },
-                "spec": {
-                  "approved": true,
-                  "compliantUsername": "johnsmith-at-redhat-com",
-                  "targetCluster": "east-2a",
-                  "username": "johnsmith@redhat.com"
                 }
               }
             ]

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -152,49 +152,41 @@ data:
                                 not be able to login "false" is assumed by default. This
                                 field is duplicated and will be removed in the future.
                               type: boolean
-                            userAccountSpecBase:
-                              description: UserAccountBase contains all base fields
+                            nsLimit:
+                              description: The namespace limit name
+                              type: string
+                            nsTemplateSet:
+                              description: Namespace template set
                               properties:
-                                nsLimit:
-                                  description: The namespace limit name
+                                namespaces:
+                                  description: The namespace templates
+                                  items:
+                                    description: NSTemplateSetNamespace the namespace definition
+                                      in an NSTemplateSet resource
+                                    properties:
+                                      revision:
+                                        description: The revision of the corresponding template
+                                        type: string
+                                      template:
+                                        description: Optional field. Used to specify a custom
+                                          template
+                                        type: string
+                                      type:
+                                        description: 'The type of the namespace. For example:
+                                          ide|cicd|stage|default'
+                                        type: string
+                                    required:
+                                    - revision
+                                    - type
+                                    type: object
+                                  type: array
+                                tierName:
+                                  description: The name of the tier represented by this
+                                    template set
                                   type: string
-                                nsTemplateSet:
-                                  description: Namespace template set
-                                  properties:
-                                    namespaces:
-                                      description: The namespace templates
-                                      items:
-                                        description: NSTemplateSetNamespace the namespace
-                                          definition in an NSTemplateSet resource
-                                        properties:
-                                          revision:
-                                            description: The revision of the corresponding
-                                              template
-                                            type: string
-                                          template:
-                                            description: Optional field. Used to specify
-                                              a custom template
-                                            type: string
-                                          type:
-                                            description: 'The type of the namespace. For
-                                              example: ide|cicd|stage|default'
-                                            type: string
-                                        required:
-                                        - revision
-                                        - type
-                                        type: object
-                                      type: array
-                                    tierName:
-                                      description: The name of the tier represented by this
-                                        template set
-                                      type: string
-                                  required:
-                                  - namespaces
-                                  - tierName
-                                  type: object
                               required:
-                              - nsLimit
-                              - nsTemplateSet
+                              - namespaces
+                              - tierName
                               type: object
                             userID:
                               description: UserID is the user ID from RHD Identity Provider
@@ -203,7 +195,8 @@ data:
                                 and will be removed in the future.
                               type: string
                           required:
-                          - userAccountSpecBase
+                          - nsLimit
+                          - nsTemplateSet
                           type: object
                         syncIndex:
                           description: SyncIndex is to be updated by UserAccount Controller
@@ -750,38 +743,6 @@ data:
             [
               {
                 "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-                "kind": "RegistrationService",
-                "metadata": {
-                  "labels": {
-                    "provider": "codeready-toolchain"
-                  },
-                  "name": "reg-service",
-                  "namespace": "toolchain-host-operator"
-                },
-                "spec": {
-                  "envVars": {
-                    "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
-                    "ENVIRONMENT": "dev",
-                    "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
-                    "REPLICAS": "4"
-                  }
-                }
-              },
-              {
-                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-                "kind": "UserSignup",
-                "metadata": {
-                  "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
-                },
-                "spec": {
-                  "approved": true,
-                  "compliantUsername": "johnsmith-at-redhat-com",
-                  "targetCluster": "east-2a",
-                  "username": "johnsmith@redhat.com"
-                }
-              },
-              {
-                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
                 "kind": "BannedUser",
                 "metadata": {
                   "labels": {
@@ -862,6 +823,38 @@ data:
                       "type": "default"
                     }
                   ]
+                }
+              },
+              {
+                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+                "kind": "RegistrationService",
+                "metadata": {
+                  "labels": {
+                    "provider": "codeready-toolchain"
+                  },
+                  "name": "reg-service",
+                  "namespace": "toolchain-host-operator"
+                },
+                "spec": {
+                  "envVars": {
+                    "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
+                    "ENVIRONMENT": "dev",
+                    "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
+                    "REPLICAS": "4"
+                  }
+                }
+              },
+              {
+                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+                "kind": "UserSignup",
+                "metadata": {
+                  "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
+                },
+                "spec": {
+                  "approved": true,
+                  "compliantUsername": "johnsmith-at-redhat-com",
+                  "targetCluster": "east-2a",
+                  "username": "johnsmith@redhat.com"
                 }
               }
             ]

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -149,7 +149,8 @@ data:
                           properties:
                             disabled:
                               description: If set to true then the corresponding user should
-                                not be able to login "false" is assumed by default
+                                not be able to login "false" is assumed by default. This
+                                field is duplicated and will be removed in the future.
                               type: boolean
                             nsLimit:
                               description: The namespace limit name
@@ -190,12 +191,12 @@ data:
                             userID:
                               description: UserID is the user ID from RHD Identity Provider
                                 token (“sub” claim) Is to be used to create Identity and
-                                UserIdentityMapping resources
+                                UserIdentityMapping resources. This field is duplicated
+                                and will be removed in the future.
                               type: string
                           required:
                           - nsLimit
                           - nsTemplateSet
-                          - userID
                           type: object
                         syncIndex:
                           description: SyncIndex is to be updated by UserAccount Controller

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -743,6 +743,38 @@ data:
             [
               {
                 "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+                "kind": "RegistrationService",
+                "metadata": {
+                  "labels": {
+                    "provider": "codeready-toolchain"
+                  },
+                  "name": "reg-service",
+                  "namespace": "toolchain-host-operator"
+                },
+                "spec": {
+                  "envVars": {
+                    "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
+                    "ENVIRONMENT": "dev",
+                    "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
+                    "REPLICAS": "4"
+                  }
+                }
+              },
+              {
+                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
+                "kind": "UserSignup",
+                "metadata": {
+                  "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
+                },
+                "spec": {
+                  "approved": true,
+                  "compliantUsername": "johnsmith-at-redhat-com",
+                  "targetCluster": "east-2a",
+                  "username": "johnsmith@redhat.com"
+                }
+              },
+              {
+                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
                 "kind": "BannedUser",
                 "metadata": {
                   "labels": {
@@ -823,38 +855,6 @@ data:
                       "type": "default"
                     }
                   ]
-                }
-              },
-              {
-                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-                "kind": "RegistrationService",
-                "metadata": {
-                  "labels": {
-                    "provider": "codeready-toolchain"
-                  },
-                  "name": "reg-service",
-                  "namespace": "toolchain-host-operator"
-                },
-                "spec": {
-                  "envVars": {
-                    "AUTH_CLIENT_LIBRARY_URL": "https://sso.prod-preview.openshift.io/auth/js/keycloak.js",
-                    "ENVIRONMENT": "dev",
-                    "IMAGE": "quay.io/codeready-toolchain/registration-service:60d3b74",
-                    "REPLICAS": "4"
-                  }
-                }
-              },
-              {
-                "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
-                "kind": "UserSignup",
-                "metadata": {
-                  "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
-                },
-                "spec": {
-                  "approved": true,
-                  "compliantUsername": "johnsmith-at-redhat-com",
-                  "targetCluster": "east-2a",
-                  "username": "johnsmith@redhat.com"
                 }
               }
             ]


### PR DESCRIPTION
Relates to PR: https://github.com/codeready-toolchain/api/pull/100 
Relates to Jira task: https://issues.redhat.com/browse/CRT-455
Relates to Jira story: https://issues.redhat.com/browse/CRT-444

Copying UserAccountSpec to masteruserrecord_types and rename to UserAccountEmbedded in order to decouple UserAccountSpec type from UserAccount.

This will be done in three stages:

1. Deprecate Embedded UA ID/Disabled
2. Change the implementation and start using the new API. Roll out to prod.
3. Delete deprecated API.

This PR is a part of stage 1.