### PR TITLE
chore: add push-to-quay-nightly makefile target & add courier to dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,4 @@ install:
 - pip3 install yq
 
 script:
-- make build && make docker-login && make docker-push && curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/scripts/push-to-quay-nightly.sh | bash -s -- -pr ../host-operator/ -er https://github.com/codeready-toolchain/registration-service/
-
+- make build && make docker-login && make docker-push && make push-to-quay-nightly

--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -1,0 +1,14 @@
+
+PATH_TO_PUSH_NIGHTLY_FILE=scripts/push-to-quay-nightly.sh
+
+.PHONY: push-to-quay-nightly
+## Creates a new version of CSV and pushes it to quay
+push-to-quay-nightly:
+	$(eval PUSH_PARAMS = -pr ../host-operator/ -er https://github.com/codeready-toolchain/registration-service/ -qn ${QUAY_NAMESPACE})
+ifneq ("$(wildcard ../api/$(PATH_TO_PUSH_NIGHTLY_FILE))","")
+	@echo "creating release manifest in ./manifest/ directory using script from local api repo..."
+	../api/${PATH_TO_PUSH_NIGHTLY_FILE} ${PUSH_PARAMS}
+else
+	@echo "creating release manifest in ./manifest/ directory using script from GH api repo (using latest version in master)..."
+	curl -sSL https://raw.githubusercontent.com/codeready-toolchain/api/master/${PATH_TO_PUSH_NIGHTLY_FILE} | bash -s -- ${PUSH_PARAMS}
+endif

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -34,6 +34,9 @@ RUN yum install epel-release -y \
 # Install yq that will be used for parsing/reading yaml files.
 RUN pip3 install yq
 
+# Install operator-courier that will be used in CD for nightly builds
+RUN pip3 install operator-courier
+
 WORKDIR /tmp
 
 # download, verify and install golang


### PR DESCRIPTION
this is another preparation for running builds via Tekton pipelines
* adds `push-to-quay-nightly` makefile target so we can trigger the push process by calling the target that already uses all necessary params
* add installation of operator-courier to the `Dockerfile.tools` so we can use the image for pushing the CSV to quay