### PR TITLE
Isolate pods in user namespaces

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -75,6 +75,50 @@ objects:
       defaultRequest:
         cpu: 100m
         memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-same-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-code
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-code
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
@@ -45,6 +45,50 @@ objects:
       defaultRequest:
         cpu: 100m
         memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-same-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
@@ -45,6 +45,50 @@ objects:
       defaultRequest:
         cpu: 100m
         memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-same-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_code.yaml
@@ -75,6 +75,50 @@ objects:
       defaultRequest:
         cpu: 100m
         memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-same-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-code
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-code
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
@@ -45,6 +45,50 @@ objects:
       defaultRequest:
         cpu: 100m
         memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-same-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
@@ -45,6 +45,50 @@ objects:
       defaultRequest:
         cpu: 100m
         memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-same-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_dev.yaml
@@ -75,6 +75,50 @@ objects:
       defaultRequest:
         cpu: 100m
         memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-same-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_stage.yaml
@@ -75,6 +75,50 @@ objects:
       defaultRequest:
         cpu: 100m
         memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-same-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
 parameters:
 - name: USERNAME
   required: true


### PR DESCRIPTION
This PR adds NetworkPolicies to all namespace templates to block traffic from pods from other namespaces.

Requires https://github.com/codeready-toolchain/member-operator/pull/133 to be merged first.

See https://issues.redhat.com/browse/CRT-492

e2e tests - https://github.com/codeready-toolchain/toolchain-e2e/pull/83