### PR TITLE
Code cleanup 

### DIFF
--- a/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/0.0.1/toolchain-host-operator.v0.0.1.clusterserviceversion.yaml
@@ -111,6 +111,12 @@ metadata:
           "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
           "kind": "UserSignup",
           "metadata": {
+            "annotations": {
+              "toolchain.dev.openshift.com/user-email": "johnsmith@redhat.com"
+            },
+            "labels": {
+              "toolchain.dev.openshift.com/email-hash": "57e46a4968bab87c552924607e46be82"
+            },
             "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
           },
           "spec": {

--- a/examples/toolchain_v1alpha1_usersignup_cr.yaml
+++ b/examples/toolchain_v1alpha1_usersignup_cr.yaml
@@ -2,8 +2,12 @@ apiVersion: toolchain.dev.openshift.com/v1alpha1
 kind: UserSignup
 metadata:
   name: 1a03ecac-7c0b-44fc-b66d-12dd7fb21c40
+  labels:
+    toolchain.dev.openshift.com/email-hash: 57e46a4968bab87c552924607e46be82
+  annotations:
+    toolchain.dev.openshift.com/user-email: johnsmith@redhat.com
 spec:
   username: johnsmith@redhat.com
   compliantUsername: johnsmith-at-redhat-com
-  targetCluster: east-2a
+  targetCluster: member-xcoulon-20200325-jm8zd
   approved: true

--- a/examples/toolchain_v1alpha1_usersignup_cr.yaml
+++ b/examples/toolchain_v1alpha1_usersignup_cr.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   username: johnsmith@redhat.com
   compliantUsername: johnsmith-at-redhat-com
-  targetCluster: member-xcoulon-20200325-jm8zd
+  targetCluster: member-xcoulon-20200326-l9nnt
   approved: true

--- a/examples/toolchain_v1alpha1_usersignup_cr.yaml
+++ b/examples/toolchain_v1alpha1_usersignup_cr.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   username: johnsmith@redhat.com
   compliantUsername: johnsmith-at-redhat-com
-  targetCluster: member-xcoulon-20200326-l9nnt
+  targetCluster: member-xcoulon-20200327-44kmj
   approved: true

--- a/go.mod
+++ b/go.mod
@@ -5,15 +5,10 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200326105658-321c7798c5b2
-	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
-	github.com/go-openapi/spec v0.19.7 // indirect
-	github.com/go-openapi/swag v0.19.8 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible
-	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/gophercloud/gophercloud v0.3.0 // indirect
-	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-sdk v0.15.2
 	github.com/pkg/errors v0.9.1
@@ -23,7 +18,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/h2non/gock.v1 v1.0.14
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.17.4
@@ -31,10 +25,8 @@ require (
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
-	k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // indirect
 	sigs.k8s.io/controller-runtime v0.5.0
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 // Pinned to kubernetes-1.16.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200318175254-83627f297ee0
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200326105658-321c7798c5b2
 	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
@@ -67,7 +67,5 @@ replace (
 	github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309 // Required by Helm (inderectly by operator-sdk)
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8 // Using openshift/api 4.3
 )
-
-replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/host-operator
 require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200317080847-786ad7121001
+	github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200318175254-83627f297ee0
 	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
@@ -23,18 +23,15 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.1
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
-	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/h2non/gock.v1 v1.0.14
 	gopkg.in/yaml.v2 v2.2.8
-	k8s.io/api v0.17.3
-	k8s.io/apiextensions-apiserver v0.17.3
-	k8s.io/apimachinery v0.17.3
+	k8s.io/api v0.17.4
+	k8s.io/apiextensions-apiserver v0.17.4
+	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // indirect
-	k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab // indirect
 	sigs.k8s.io/controller-runtime v0.5.0
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 	sigs.k8s.io/yaml v1.2.0 // indirect
@@ -70,5 +67,7 @@ replace (
 	github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309 // Required by Helm (inderectly by operator-sdk)
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20190927182313-d4a64ec2cbd8 // Using openshift/api 4.3
 )
+
+replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50 h1:jKpOVK0
 github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200318175254-83627f297ee0 h1:DfP/FFGWcUeDH5+J/xHNKu1CQZePZ6UWJbjZlQv40tA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200318175254-83627f297ee0/go.mod h1:SNSE7G88BCuFeIZjW3ZYBFJFYarnznmBL4uXZcIslmw=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200326105658-321c7798c5b2 h1:mADUGseykJYfcfHS4cg5Y4uFOZ6yFifNIslr2UR0Zl4=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200326105658-321c7798c5b2/go.mod h1:aFe78p5WHC8c5XmMepuTIdh1Pix/pgF0ehuF6piJNzo=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/containerd/console v0.0.0-20170925154832-84eeaae905fa/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.0.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2
 github.com/codeready-toolchain/api v0.0.0-20200313034016-bd3872e24562/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/api v0.0.0-20200317080847-786ad7121001 h1:C/AGF8I/61990c7Jj/iqcC5aNZ6FvtPVKmUmFCzB8xk=
 github.com/codeready-toolchain/api v0.0.0-20200317080847-786ad7121001/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50 h1:jKpOVK06Vv2rt0tJD8mXL/0Qpjftx1Y9887n6baN9Xs=
+github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200318175254-83627f297ee0 h1:DfP/FFGWcUeDH5+J/xHNKu1CQZePZ6UWJbjZlQv40tA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200318175254-83627f297ee0/go.mod h1:SNSE7G88BCuFeIZjW3ZYBFJFYarnznmBL4uXZcIslmw=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
@@ -817,6 +819,8 @@ golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200320220750-118fecf932d8 h1:1+zQlQqEEhUeStBTi653GZAnAuivZq/2hz+Iz+OP7rg=
+golang.org/x/net v0.0.0-20200320220750-118fecf932d8/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -866,6 +870,8 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwg
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200321134203-328b4cd54aae h1:3tcmuaB7wwSZtelmiv479UjUB+vviwABz7a133ZwOKQ=
+golang.org/x/sys v0.0.0-20200321134203-328b4cd54aae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1060,6 +1066,8 @@ k8s.io/utils v0.0.0-20191114184206-e782cd3c129f h1:GiPwtSzdP43eI1hpPCbROQCCIgCui
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab h1:I3f2hcBrepGRXI1z4sukzAb8w1R4eqbsHrAsx06LGYM=
 k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+k8s.io/utils v0.0.0-20200322164244-327a8059b905 h1:bbO8bYwd3CdH0B2+xhhVShn6HPgpCLmWdYd95I9D/7w=
+k8s.io/utils v0.0.0-20200322164244-327a8059b905/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/go.sum
+++ b/go.sum
@@ -113,13 +113,8 @@ github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1w
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
-github.com/codeready-toolchain/api v0.0.0-20200313034016-bd3872e24562/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/api v0.0.0-20200317080847-786ad7121001 h1:C/AGF8I/61990c7Jj/iqcC5aNZ6FvtPVKmUmFCzB8xk=
-github.com/codeready-toolchain/api v0.0.0-20200317080847-786ad7121001/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50 h1:jKpOVK06Vv2rt0tJD8mXL/0Qpjftx1Y9887n6baN9Xs=
 github.com/codeready-toolchain/api v0.0.0-20200323155710-2cad93f41d50/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200318175254-83627f297ee0 h1:DfP/FFGWcUeDH5+J/xHNKu1CQZePZ6UWJbjZlQv40tA=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200318175254-83627f297ee0/go.mod h1:SNSE7G88BCuFeIZjW3ZYBFJFYarnznmBL4uXZcIslmw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200326105658-321c7798c5b2 h1:mADUGseykJYfcfHS4cg5Y4uFOZ6yFifNIslr2UR0Zl4=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200326105658-321c7798c5b2/go.mod h1:aFe78p5WHC8c5XmMepuTIdh1Pix/pgF0ehuF6piJNzo=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
@@ -819,8 +814,6 @@ golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ3zWWCCUR/j8Ifh45Ss=
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
-golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200320220750-118fecf932d8 h1:1+zQlQqEEhUeStBTi653GZAnAuivZq/2hz+Iz+OP7rg=
 golang.org/x/net v0.0.0-20200320220750-118fecf932d8/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -870,8 +863,6 @@ golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934 h1:u/E0NqCIWRDAo9WCFo6Ko49nj
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
-golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200321134203-328b4cd54aae h1:3tcmuaB7wwSZtelmiv479UjUB+vviwABz7a133ZwOKQ=
 golang.org/x/sys v0.0.0-20200321134203-328b4cd54aae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1066,8 +1057,6 @@ k8s.io/utils v0.0.0-20191010214722-8d271d903fe4 h1:Gi+/O1saihwDqnlmC8Vhv1M5Sp4+r
 k8s.io/utils v0.0.0-20191010214722-8d271d903fe4/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f h1:GiPwtSzdP43eI1hpPCbROQCCIgCuiMMNF8YUVLF3vJo=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab h1:I3f2hcBrepGRXI1z4sukzAb8w1R4eqbsHrAsx06LGYM=
-k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200322164244-327a8059b905 h1:bbO8bYwd3CdH0B2+xhhVShn6HPgpCLmWdYd95I9D/7w=
 k8s.io/utils v0.0.0-20200322164244-327a8059b905/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -1052,6 +1052,12 @@ data:
                 "apiVersion": "toolchain.dev.openshift.com/v1alpha1",
                 "kind": "UserSignup",
                 "metadata": {
+                  "annotations": {
+                    "toolchain.dev.openshift.com/user-email": "johnsmith@redhat.com"
+                  },
+                  "labels": {
+                    "toolchain.dev.openshift.com/email-hash": "57e46a4968bab87c552924607e46be82"
+                  },
                   "name": "1a03ecac-7c0b-44fc-b66d-12dd7fb21c40"
                 },
                 "spec": {

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -147,6 +147,11 @@ func (r *ReconcileMasterUserRecord) addFinalizer(logger logr.Logger, mur *toolch
 	return false, nil
 }
 
+// ensureUserAccount ensures that there's a UserAccount resource on the member cluster for the given `murAccount`.
+// If the UserAccount resource already exists, then this latter is synchronized using the given `murAccount` and the associated `mur` status is also updated to reflect
+// the UserAccount specs.
+// returns `true, nil` if a UserAccount was created on the member cluster, `false, nil` otherwise
+// return  `false, err` if an error occurred
 func (r *ReconcileMasterUserRecord) ensureUserAccount(logger logr.Logger, murAccount toolchainv1alpha1.UserAccountEmbedded, mur *toolchainv1alpha1.MasterUserRecord) (bool, error) {
 	// get & check member cluster
 	memberCluster, err := r.getMemberCluster(murAccount.TargetCluster)

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -86,8 +86,8 @@ type ReconcileMasterUserRecord struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileMasterUserRecord) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling MasterUserRecord")
+	logger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	logger.Info("Reconciling MasterUserRecord")
 
 	// Fetch the MasterUserRecord instance
 	mur := &toolchainv1alpha1.MasterUserRecord{}
@@ -100,90 +100,96 @@ func (r *ReconcileMasterUserRecord) Reconcile(request reconcile.Request) (reconc
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		reqLogger.Error(err, "unable to get MasterUserRecord")
+		logger.Error(err, "unable to get MasterUserRecord")
 		return reconcile.Result{}, err
 	}
+	logger.Info("found MasterUserRecord", "mur", mur)
 	// If the UserAccount is not being deleted, create or synchronize UserAccounts.
 	if !coputil.IsBeingDeleted(mur) {
 		// Add the finalizer if it is not present
-		if err := r.addFinalizer(mur, murFinalizerName); err != nil {
-			reqLogger.Error(err, "unable to add finalizer to MasterUserRecord")
+		if created, err := r.addFinalizer(logger, mur, murFinalizerName); err != nil {
+			logger.Error(err, "unable to add finalizer to MasterUserRecord")
 			return reconcile.Result{}, err
+		} else if created {
+			return reconcile.Result{Requeue: true}, nil
 		}
+		logger.Info("ensuring user accounts", "mur", mur)
 		for _, account := range mur.Spec.UserAccounts {
-			err = r.ensureUserAccount(reqLogger, account, mur)
+			err = r.ensureUserAccount(logger, account, mur)
 			if err != nil {
-				reqLogger.Error(err, "unable to synchronize with member UserAccount")
+				logger.Error(err, "unable to synchronize with member UserAccount")
 				return reconcile.Result{}, err
 			}
 		}
+		logger.Info("user accounts ensured", "mur", mur)
 
 		// If the UserAccount is being deleted, delete the UserAccounts in members.
 	} else if coputil.HasFinalizer(mur, murFinalizerName) {
-		if err = r.manageCleanUp(mur); err != nil {
-			reqLogger.Error(err, "unable to clean up MasterUserRecord as part of deletion")
+		if err = r.manageCleanUp(logger, mur); err != nil {
+			logger.Error(err, "unable to clean up MasterUserRecord as part of deletion")
 			return reconcile.Result{}, err
 		}
 	}
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileMasterUserRecord) addFinalizer(mur *toolchainv1alpha1.MasterUserRecord, finalizer string) error {
+func (r *ReconcileMasterUserRecord) addFinalizer(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, finalizer string) (bool, error) {
 	// Add the finalizer if it is not present
 	if !coputil.HasFinalizer(mur, finalizer) {
 		coputil.AddFinalizer(mur, finalizer)
 		if err := r.client.Update(context.TODO(), mur); err != nil {
-			return r.wrapErrorWithStatusUpdate(log, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToAddFinalizerReason), err,
+			return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToAddFinalizerReason), err,
 				"failed while updating with added finalizer")
 		}
+		logger.Info("MasterUserRecord now has finalizer", "mur", mur)
+		return true, nil
+	} else {
+		logger.Info("MasterUserRecord already has finalizer", "mur", mur)
 	}
-	return nil
+	return false, nil
 }
 
-func (r *ReconcileMasterUserRecord) ensureUserAccount(log logr.Logger, recAccount toolchainv1alpha1.UserAccountEmbedded, record *toolchainv1alpha1.MasterUserRecord) error {
+func (r *ReconcileMasterUserRecord) ensureUserAccount(logger logr.Logger, murAccount toolchainv1alpha1.UserAccountEmbedded, mur *toolchainv1alpha1.MasterUserRecord) error {
 	// get & check member cluster
-	memberCluster, err := r.getMemberCluster(recAccount.TargetCluster)
+	memberCluster, err := r.getMemberCluster(murAccount.TargetCluster)
 	if err != nil {
-		return r.wrapErrorWithStatusUpdate(log, record, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordTargetClusterNotReadyReason), err,
-			"failed to get the member cluster '%s'", recAccount.TargetCluster)
+		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordTargetClusterNotReadyReason), err,
+			"failed to get the member cluster '%s'", murAccount.TargetCluster)
 	}
 
 	// get UserAccount from member
-	nsdName := namespacedName(memberCluster.OperatorNamespace, record.Name)
+	nsdName := namespacedName(memberCluster.OperatorNamespace, mur.Name)
 	userAccount := &toolchainv1alpha1.UserAccount{}
-	err = memberCluster.Client.Get(context.TODO(), nsdName, userAccount)
-	if err != nil {
+	if err := memberCluster.Client.Get(context.TODO(), nsdName, userAccount); err != nil {
 		if errors.IsNotFound(err) {
 			// does not exist - should create
-			userAccount = newUserAccount(nsdName, recAccount.Spec, record.Spec)
-			if err := updateStatusConditions(r.client, record, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")); err != nil {
-				return err
-			}
+			userAccount = newUserAccount(nsdName, murAccount.Spec, mur.Spec)
 			if err := memberCluster.Client.Create(context.TODO(), userAccount); err != nil {
-				return r.wrapErrorWithStatusUpdate(log, record, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
-					"failed to create UserAccount in the member cluster '%s'", recAccount.TargetCluster)
+				return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
+					"failed to create UserAccount in the member cluster '%s'", murAccount.TargetCluster)
 			}
-			return nil
+			return updateStatusConditions(logger, r.client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
 		}
-		return r.wrapErrorWithStatusUpdate(log, record, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToGetUserAccountReason), err,
-			"failed to get userAccount '%s' from cluster '%s'", record.Name, recAccount.TargetCluster)
+		// another/unexpected error occurred while trying to fetch the user account on the member cluster
+		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToGetUserAccountReason), err,
+			"failed to get userAccount '%s' from cluster '%s'", mur.Name, murAccount.TargetCluster)
 	}
 
 	sync := Synchronizer{
-		record:            record,
+		record:            mur,
 		hostClient:        r.client,
 		memberCluster:     memberCluster,
 		memberUserAcc:     userAccount,
-		recordSpecUserAcc: recAccount,
-		log:               log,
+		recordSpecUserAcc: murAccount,
+		logger:            logger,
 	}
 	if err := sync.synchronizeSpec(); err != nil {
-		return r.wrapErrorWithStatusUpdate(log, record, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToSynchronizeUserAccountSpecReason), err,
-			"update of the UserAccount.spec in the cluster '%s' failed", recAccount.TargetCluster)
+		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToSynchronizeUserAccountSpecReason), err,
+			"update of the UserAccount.spec in the cluster '%s' failed", murAccount.TargetCluster)
 	}
 	if err := sync.synchronizeStatus(); err != nil {
-		err = errs.Wrapf(err, "update of the MasterUserRecord failed while synchronizing with UserAccount status from the cluster '%s'", recAccount.TargetCluster)
-		return r.wrapErrorWithStatusUpdate(log, record, r.useExistingConditionOfType(toolchainv1alpha1.ConditionReady), err, "")
+		err = errs.Wrapf(err, "update of the MasterUserRecord failed while synchronizing with UserAccount status from the cluster '%s'", murAccount.TargetCluster)
+		return r.wrapErrorWithStatusUpdate(logger, mur, r.useExistingConditionOfType(toolchainv1alpha1.ConditionReady), err, "")
 	}
 	return nil
 }
@@ -200,12 +206,14 @@ func (r *ReconcileMasterUserRecord) getMemberCluster(targetCluster string) (*clu
 	return fedCluster, nil
 }
 
+type statusUpdater func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error
+
 // wrapErrorWithStatusUpdate wraps the error and update the user account status. If the update failed then logs the error.
-func (r *ReconcileMasterUserRecord) wrapErrorWithStatusUpdate(logger logr.Logger, record *toolchainv1alpha1.MasterUserRecord, statusUpdater func(record *toolchainv1alpha1.MasterUserRecord, message string) error, err error, format string, args ...interface{}) error {
+func (r *ReconcileMasterUserRecord) wrapErrorWithStatusUpdate(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, updateStatus statusUpdater, err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
-	if err := statusUpdater(record, err.Error()); err != nil {
+	if err := updateStatus(logger, mur, err.Error()); err != nil {
 		logger.Error(err, "status update failed")
 	}
 	if format != "" {
@@ -214,17 +222,18 @@ func (r *ReconcileMasterUserRecord) wrapErrorWithStatusUpdate(logger logr.Logger
 	return err
 }
 
-func (r *ReconcileMasterUserRecord) setStatusFailed(reason string) func(record *toolchainv1alpha1.MasterUserRecord, message string) error {
-	return func(record *toolchainv1alpha1.MasterUserRecord, message string) error {
+func (r *ReconcileMasterUserRecord) setStatusFailed(reason string) statusUpdater {
+	return func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error {
 		return updateStatusConditions(
+			logger,
 			r.client,
-			record,
+			mur,
 			toBeNotReady(reason, message))
 	}
 }
 
-func (r *ReconcileMasterUserRecord) useExistingConditionOfType(condType toolchainv1alpha1.ConditionType) func(record *toolchainv1alpha1.MasterUserRecord, message string) error {
-	return func(mur *toolchainv1alpha1.MasterUserRecord, message string) error {
+func (r *ReconcileMasterUserRecord) useExistingConditionOfType(condType toolchainv1alpha1.ConditionType) statusUpdater {
+	return func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error {
 		cond := toolchainv1alpha1.Condition{Type: condType}
 		for _, con := range mur.Status.Conditions {
 			if con.Type == condType {
@@ -233,23 +242,24 @@ func (r *ReconcileMasterUserRecord) useExistingConditionOfType(condType toolchai
 			}
 		}
 		cond.Message = message
-		return updateStatusConditions(r.client, mur, cond)
+		return updateStatusConditions(logger, r.client, mur, cond)
 	}
 }
 
-func (r *ReconcileMasterUserRecord) manageCleanUp(mur *toolchainv1alpha1.MasterUserRecord) error {
+func (r *ReconcileMasterUserRecord) manageCleanUp(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord) error {
 	for _, ua := range mur.Spec.UserAccounts {
 		if err := r.deleteUserAccount(ua.TargetCluster, mur.Name); err != nil {
-			return r.wrapErrorWithStatusUpdate(log, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToDeleteUserAccountsReason), err,
+			return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToDeleteUserAccountsReason), err,
 				"failed to delete UserAccount in the member cluster '%s'", ua.TargetCluster)
 		}
 	}
 	// Remove finalizer from MasterUserRecord
 	coputil.RemoveFinalizer(mur, murFinalizerName)
 	if err := r.client.Update(context.Background(), mur); err != nil {
-		return r.wrapErrorWithStatusUpdate(log, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToRemoveFinalizerReason), err,
+		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToRemoveFinalizerReason), err,
 			"failed to update MasterUserRecord while deleting finalizer")
 	}
+	log.Info("Finalizer removed from MasterUserRecord")
 	return nil
 }
 
@@ -301,14 +311,16 @@ func toBeDisabled() toolchainv1alpha1.Condition {
 }
 
 // updateStatusConditions updates user account status conditions with the new conditions
-func updateStatusConditions(cl client.Client, record *toolchainv1alpha1.MasterUserRecord, newConditions ...toolchainv1alpha1.Condition) error {
+func updateStatusConditions(logger logr.Logger, cl client.Client, mur *toolchainv1alpha1.MasterUserRecord, newConditions ...toolchainv1alpha1.Condition) error {
 	var updated bool
-	record.Status.Conditions, updated = condition.AddOrUpdateStatusConditions(record.Status.Conditions, newConditions...)
+	mur.Status.Conditions, updated = condition.AddOrUpdateStatusConditions(mur.Status.Conditions, newConditions...)
 	if !updated {
 		// Nothing changed
+		logger.Info("MUR status conditions unchanged", "mur", mur)
 		return nil
 	}
-	return cl.Status().Update(context.TODO(), record)
+	logger.Info("updating MUR status conditions", "mur", mur)
+	return cl.Status().Update(context.TODO(), mur)
 }
 
 func newUserAccount(nsdName types.NamespacedName, spec toolchainv1alpha1.UserAccountSpecEmbedded, murSpec toolchainv1alpha1.MasterUserRecordSpec) *toolchainv1alpha1.UserAccount {

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -113,8 +113,8 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 	memberClient2 := test.NewFakeClient(t)
 	hostClient := test.NewFakeClient(t, mur)
 	memberClient.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
-		if _, ok := obj.(*routev1.Route); ok {
-			obj = &routev1.Route{
+		if obj, ok := obj.(*routev1.Route); ok {
+			*obj = routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "host",
 					Path: "console",
@@ -125,8 +125,8 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 		return memberClient.Client.Get(ctx, key, obj)
 	}
 	memberClient2.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
-		if _, ok := obj.(*routev1.Route); ok {
-			obj = &routev1.Route{
+		if obj, ok := obj.(*routev1.Route); ok {
+			*obj = routev1.Route{
 				Spec: routev1.RouteSpec{
 					Host: "host",
 					Path: "console",

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	uatest "github.com/codeready-toolchain/toolchain-common/pkg/test/useraccount"
+	"github.com/go-logr/logr"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,11 +29,62 @@ import (
 
 type getMemberCluster func(clusters ...clientForCluster) func(name string) (*cluster.FedCluster, bool)
 
+func TestAddFinalizer(t *testing.T) {
+
+	// given
+	logf.SetLogger(logf.ZapLogger(true))
+	s := apiScheme(t)
+
+	t.Run("ok", func(t *testing.T) {
+		mur := murtest.NewMasterUserRecord("john")
+		memberClient := test.NewFakeClient(t)
+		hostClient := test.NewFakeClient(t, mur)
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+			clusterClient(test.MemberClusterName, memberClient))
+
+		// when
+		result, err := cntrl.Reconcile(newMurRequest(mur))
+
+		// then
+		require.NoError(t, err)
+		require.True(t, result.Requeue)
+
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasNoConditions().
+			HasFinalizer()
+	})
+
+	t.Run("fails because it cannot add finalizer", func(t *testing.T) {
+		// given
+		mur := murtest.NewMasterUserRecord("john")
+		hostClient := test.NewFakeClient(t, mur)
+		memberClient := test.NewFakeClient(t)
+		hostClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+			return fmt.Errorf("unable to add finalizer to MUR %s", mur.Name)
+		}
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+			clusterClient(test.MemberClusterName, memberClient))
+
+		// when
+		_, err := cntrl.Reconcile(newMurRequest(mur))
+
+		// then
+		require.Error(t, err)
+		msg := "failed while updating with added finalizer: unable to add finalizer to MUR john"
+		assert.Contains(t, err.Error(), msg)
+
+		uatest.AssertThatUserAccount(t, "john", memberClient).DoesNotExist()
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordUnableToAddFinalizerReason, "unable to add finalizer to MUR john"))
+	})
+}
+
 func TestCreateUserAccountSuccessful(t *testing.T) {
 	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
 	mur := murtest.NewMasterUserRecord("john")
+	murtest.Modify(mur, murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
 	memberClient := test.NewFakeClient(t)
 	hostClient := test.NewFakeClient(t, mur)
 	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
@@ -43,7 +95,6 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
 		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec)
@@ -56,7 +107,7 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord("john", murtest.AdditionalAccounts("member2-cluster"))
+	mur := murtest.NewMasterUserRecord("john", murtest.AdditionalAccounts("member2-cluster"), murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
 	memberClient := test.NewFakeClient(t)
 	memberClient2 := test.NewFakeClient(t)
 	hostClient := test.NewFakeClient(t, mur)
@@ -84,7 +135,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord("john")
+	mur := murtest.NewMasterUserRecord("john", murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
 	hostClient := test.NewFakeClient(t, mur)
 
 	t.Run("when member cluster does not exist and UA hasn't been created yet", func(t *testing.T) {
@@ -169,7 +220,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		memberClient := test.NewFakeClient(t)
 		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
-		statusUpdater := func(mur *toolchainv1alpha1.MasterUserRecord, message string) error {
+		statusUpdater := func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error {
 			return fmt.Errorf("unable to update status")
 		}
 
@@ -211,7 +262,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		memberClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 			return fmt.Errorf("unable to update user account %s", mur.Name)
 		}
-		modifiedMur := murtest.NewMasterUserRecord("john")
+		modifiedMur := murtest.NewMasterUserRecord("john", murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
 		murtest.ModifyUaInMur(modifiedMur, test.MemberClusterName, murtest.TierName("admin"))
 		hostClient := test.NewFakeClient(t, modifiedMur)
 		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
@@ -232,18 +283,19 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordUnableToSynchronizeUserAccountSpecReason, "unable to update user account john"))
 	})
 
-	t.Run("status synchronization of the UserAccount & MasterUserRecord failed", func(t *testing.T) {
+	t.Run("status synchronization between UserAccount and MasterUserRecord failed", func(t *testing.T) {
 		// given
 		updatingCond := toBeNotReady("updating", "")
 		provisionedMur := murtest.NewMasterUserRecord("john",
+			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 			murtest.StatusCondition(updatingCond))
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(provisionedMur,
 			uatest.StatusCondition(toBeNotReady("somethingFailed", ""))), consoleRoute())
 
 		hostClient := test.NewFakeClient(t, provisionedMur)
-		// mock only once
+
 		hostClient.MockStatusUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
-			hostClient.MockStatusUpdate = nil
+			hostClient.MockStatusUpdate = nil // mock only once
 			return fmt.Errorf("unable to update MUR %s", provisionedMur.Name)
 		}
 		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
@@ -264,32 +316,11 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			HasStatusUserAccounts()
 	})
 
-	t.Run("creation of the UserAccount fails because it cannot add finalizer", func(t *testing.T) {
-		// given
-		hostClient := test.NewFakeClient(t, mur)
-		memberClient := test.NewFakeClient(t)
-		hostClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
-			return fmt.Errorf("unable to add finalizer to MUR %s", mur.Name)
-		}
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
-
-		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
-
-		// then
-		require.Error(t, err)
-		msg := "failed while updating with added finalizer: unable to add finalizer to MUR john"
-		assert.Contains(t, err.Error(), msg)
-
-		uatest.AssertThatUserAccount(t, "john", memberClient).DoesNotExist()
-		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-			HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordUnableToAddFinalizerReason, "unable to add finalizer to MUR john"))
-	})
-
 	t.Run("deletion of MasterUserRecord fails because it cannot remove finalizer", func(t *testing.T) {
 		// given
-		mur := murtest.NewMasterUserRecord("john", murtest.ToBeDeleted())
+		mur := murtest.NewMasterUserRecord("john",
+			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
+			murtest.ToBeDeleted())
 
 		hostClient := test.NewFakeClient(t, mur)
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
@@ -314,7 +345,9 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 
 	t.Run("deletion of the UserAccount failed", func(t *testing.T) {
 		// given
-		mur := murtest.NewMasterUserRecord("john", murtest.ToBeDeleted())
+		mur := murtest.NewMasterUserRecord("john",
+			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
+			murtest.ToBeDeleted())
 		hostClient := test.NewFakeClient(t, mur)
 
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
@@ -343,7 +376,9 @@ func TestModifyUserAccounts(t *testing.T) {
 	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord("john", murtest.StatusCondition(toBeProvisioned()),
+	mur := murtest.NewMasterUserRecord("john",
+		murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
+		murtest.StatusCondition(toBeProvisioned()),
 		murtest.AdditionalAccounts("member2-cluster", "member3-cluster"))
 
 	userAccount := uatest.NewUserAccountFromMur(mur)
@@ -390,6 +425,7 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 		// setup MUR that wil contain UserAccountStatusEmbedded fields for UserAccounts from "member2-cluster" and "member3-cluster" but will miss from test.MemberClusterName
 		// then the reconcile should add the misssing UserAccountStatusEmbedded for the missing test.MemberClusterName cluster without updating anything else
 		mur := murtest.NewMasterUserRecord("john",
+			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 			murtest.StatusCondition(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")),
 			murtest.AdditionalAccounts("member2-cluster", "member3-cluster"))
 
@@ -457,6 +493,7 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 		// MUR with ready condition set to false with an error
 		// all MUR.Status.UserAccount[] conditions are already in sync with the corresponding UserAccounts and set to Ready
 		mur := murtest.NewMasterUserRecord("john",
+			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 			murtest.StatusCondition(toBeNotReady(toolchainv1alpha1.MasterUserRecordTargetClusterNotReadyReason, "something went wrong")),
 			murtest.AdditionalAccounts("member2-cluster"))
 		userAccount := uatest.NewUserAccountFromMur(mur, uatest.StatusCondition(toBeProvisioned()), uatest.ResourceVersion("123abc"))
@@ -500,7 +537,9 @@ func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
 	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord("john", murtest.ToBeDeleted())
+	mur := murtest.NewMasterUserRecord("john",
+		murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
+		murtest.ToBeDeleted())
 	userAcc := uatest.NewUserAccountFromMur(mur)
 
 	memberClient := test.NewFakeClient(t, userAcc)
@@ -525,6 +564,7 @@ func TestDeleteMultipleUserAccountsViaMasterUserRecordBeingDeleted(t *testing.T)
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
 	mur := murtest.NewMasterUserRecord("john",
+		murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 		murtest.ToBeDeleted(), murtest.AdditionalAccounts("member2-cluster"))
 	userAcc := uatest.NewUserAccountFromMur(mur)
 
@@ -552,7 +592,9 @@ func TestDisablingMasterUserRecord(t *testing.T) {
 	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord("john", murtest.DisabledMur(true))
+	mur := murtest.NewMasterUserRecord("john",
+		murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
+		murtest.DisabledMur(true))
 	userAccount := uatest.NewUserAccountFromMur(mur, uatest.DisabledUa(false))
 	memberClient := test.NewFakeClient(t, userAccount, consoleRoute(), cheRoute(false))
 	hostClient := test.NewFakeClient(t, mur)

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -44,14 +44,12 @@ type Synchronizer struct {
 }
 
 // synchronizeSpec synhronizes the useraccount in the MasterUserRecord with the corresponding UserAccount on the member cluster.
-// returns `true, nil` if the user account was updated on the member cluster (and the MasterUserRecord's status was updated accordingly), `false, nil` otherwise
-// returns `false, err` if an error occurred.
-func (s *Synchronizer) synchronizeSpec() (bool, error) {
+func (s *Synchronizer) synchronizeSpec() error {
 
 	if !s.isSynchronized() {
 		s.logger.Info("synchronizing specs", "UserAccountSpecBase", s.recordSpecUserAcc.Spec.UserAccountSpecBase)
 		if err := updateStatusConditions(s.logger, s.hostClient, s.record, toBeNotReady(toolchainv1alpha1.MasterUserRecordUpdatingReason, "")); err != nil {
-			return false, err
+			return err
 		}
 		s.memberUserAcc.Spec.UserAccountSpecBase = s.recordSpecUserAcc.Spec.UserAccountSpecBase
 		s.memberUserAcc.Spec.Disabled = s.record.Spec.Disabled
@@ -60,13 +58,11 @@ func (s *Synchronizer) synchronizeSpec() (bool, error) {
 		err := s.memberCluster.Client.Update(context.TODO(), s.memberUserAcc)
 		if err != nil {
 			s.logger.Error(err, "synchronizing failed")
-			return false, err
+			return err
 		}
 		s.logger.Info("synchronizing complete")
-		return true, nil
 	}
-
-	return false, nil
+	return nil
 }
 
 func (s *Synchronizer) isSynchronized() bool {

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -44,7 +44,7 @@ type Synchronizer struct {
 }
 
 // synchronizeSpec synhronizes the useraccount in the MasterUserRecord with the corresponding UserAccount on the member cluster.
-// returns `true` if the user account was updated on the member cluster (and the MasterUserRecord's status was updated accordingly), `false` otherwise
+// returns `true, nil` if the user account was updated on the member cluster (and the MasterUserRecord's status was updated accordingly), `false, nil` otherwise
 // returns `false, err` if an error occurred.
 func (s *Synchronizer) synchronizeSpec() (bool, error) {
 

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -43,6 +43,9 @@ type Synchronizer struct {
 	logger            logr.Logger
 }
 
+// synchronizeSpec synhronizes the useraccount in the MasterUserRecord with the corresponding UserAccount on the member cluster.
+// returns `true` if the user account was updated on the member cluster (and the MasterUserRecord's status was updated accordingly), `false` otherwise
+// returns `false, err` if an error occurred.
 func (s *Synchronizer) synchronizeSpec() (bool, error) {
 
 	if !s.isSynchronized() {

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -110,7 +110,7 @@ func (s *Synchronizer) synchronizeStatus() error {
 	// Align readiness even if the user account statuses were not changed.
 	// We need to do it to cleanup outdated errors (for example if the target cluster was unavailable) if any
 	s.alignReadiness()
-	s.logger.Info("updating MUR status", "mur", s.record)
+	s.logger.Info("updating MUR status")
 	return s.hostClient.Status().Update(context.TODO(), s.record)
 }
 

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -43,12 +43,12 @@ type Synchronizer struct {
 	logger            logr.Logger
 }
 
-func (s *Synchronizer) synchronizeSpec() error {
+func (s *Synchronizer) synchronizeSpec() (bool, error) {
 
 	if !s.isSynchronized() {
 		s.logger.Info("synchronizing specs", "UserAccountSpecBase", s.recordSpecUserAcc.Spec.UserAccountSpecBase)
 		if err := updateStatusConditions(s.logger, s.hostClient, s.record, toBeNotReady(toolchainv1alpha1.MasterUserRecordUpdatingReason, "")); err != nil {
-			return err
+			return true, err
 		}
 		s.memberUserAcc.Spec.UserAccountSpecBase = s.recordSpecUserAcc.Spec.UserAccountSpecBase
 		s.memberUserAcc.Spec.Disabled = s.record.Spec.Disabled
@@ -57,12 +57,13 @@ func (s *Synchronizer) synchronizeSpec() error {
 		err := s.memberCluster.Client.Update(context.TODO(), s.memberUserAcc)
 		if err != nil {
 			s.logger.Error(err, "synchronizing failed")
-			return err
+			return true, err
 		}
 		s.logger.Info("synchronizing complete")
+		return true, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 func (s *Synchronizer) isSynchronized() bool {

--- a/pkg/controller/masteruserrecord/sync_test.go
+++ b/pkg/controller/masteruserrecord/sync_test.go
@@ -146,11 +146,10 @@ func TestSynchronizeSpec(t *testing.T) {
 	}
 
 	// when
-	synced, err := sync.synchronizeSpec()
+	err := sync.synchronizeSpec()
 
 	// then
 	require.NoError(t, err)
-	assert.True(t, synced)
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
 		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec)
@@ -275,12 +274,11 @@ func TestSynchronizeUserAccountFailed(t *testing.T) {
 		}
 
 		// when
-		synced, err := sync.synchronizeSpec()
+		err := sync.synchronizeSpec()
 
 		// then
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to update user account john")
-		assert.False(t, synced)
 	})
 
 	t.Run("status synchronization of the UserAccount & MasterUserRecord failed", func(t *testing.T) {

--- a/pkg/controller/masteruserrecord/sync_test.go
+++ b/pkg/controller/masteruserrecord/sync_test.go
@@ -146,11 +146,11 @@ func TestSynchronizeSpec(t *testing.T) {
 	}
 
 	// when
-	err := sync.synchronizeSpec()
+	synced, err := sync.synchronizeSpec()
 
 	// then
 	require.NoError(t, err)
-
+	assert.True(t, synced)
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
 		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec)
@@ -251,7 +251,7 @@ func TestSyncMurStatusWithUserAccountStatusWhenCompleted(t *testing.T) {
 
 func TestSynchronizeUserAccountFailed(t *testing.T) {
 	// given
-	l := logf.ZapLogger(true)
+	l := logf.ZapLogger(false)
 	apiScheme(t)
 
 	t.Run("spec synchronization of the UserAccount failed", func(t *testing.T) {
@@ -275,11 +275,12 @@ func TestSynchronizeUserAccountFailed(t *testing.T) {
 		}
 
 		// when
-		err := sync.synchronizeSpec()
+		synced, err := sync.synchronizeSpec()
 
 		// then
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to update user account john")
+		assert.False(t, synced)
 	})
 
 	t.Run("status synchronization of the UserAccount & MasterUserRecord failed", func(t *testing.T) {

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -243,11 +243,11 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 			}
 		} else {
 			// If there isn't an email-hash label, then the state is invalid
-			log.Info("missing label on usersignup", "label", toolchainv1alpha1.UserSignupUserEmailHashLabelKey, "username", instance.Spec.Username)
+			reqLogger.Info("missing label on usersignup", "label", toolchainv1alpha1.UserSignupUserEmailHashLabelKey, "username", instance.Spec.Username)
 			return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusMissingEmailHash)
 		}
 	} else {
-		log.Info("missing annotation on usersignup", "annotation", toolchainv1alpha1.UserSignupUserEmailAnnotationKey, "username", instance.Spec.Username)
+		reqLogger.Info("missing annotation on usersignup", "annotation", toolchainv1alpha1.UserSignupUserEmailAnnotationKey, "username", instance.Spec.Username)
 		return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusInvalidMissingUserEmailAnnotation)
 	}
 
@@ -407,7 +407,7 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 			Revision: nstemplateTier.Spec.ClusterResources.Revision,
 		}
 	} else {
-		log.Info("NSTemplateTier has no cluster resources", "name", nstemplateTier.Name)
+		logger.Info("NSTemplateTier has no cluster resources", "name", nstemplateTier.Name)
 	}
 	userAccounts := []toolchainv1alpha1.UserAccountEmbedded{
 		{

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -461,7 +461,6 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 			"Error creating MasterUserRecord")
 	}
 	logger.Info("Created MasterUserRecord", "Name", mur.Name, "TargetCluster", targetCluster)
-	logger.Info("Created MasterUserRecord", "mur", mur)
 	return nil
 }
 

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -243,11 +243,11 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 			}
 		} else {
 			// If there isn't an email-hash label, then the state is invalid
-			reqLogger.Info("missing label on usersignup", "label", toolchainv1alpha1.UserSignupUserEmailHashLabelKey, "username", instance.Spec.Username)
+			reqLogger.Info("missing label on usersignup", "label", toolchainv1alpha1.UserSignupUserEmailHashLabelKey)
 			return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusMissingEmailHash)
 		}
 	} else {
-		reqLogger.Info("missing annotation on usersignup", "annotation", toolchainv1alpha1.UserSignupUserEmailAnnotationKey, "username", instance.Spec.Username)
+		reqLogger.Info("missing annotation on usersignup", "annotation", toolchainv1alpha1.UserSignupUserEmailAnnotationKey)
 		return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusInvalidMissingUserEmailAnnotation)
 	}
 


### PR DESCRIPTION
add missing label and annotation on example user signup
refactored the code to pass the logger to the status updaters
using the same var name everywhere for consistency
refactoring the `IsSynchronized` logic and testing.

Updates https://issues.redhat.com/browse/CRT-459

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>