### PR TITLE
chore: optimize limits across tiers

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -70,8 +70,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 300m
-        memory: 1400Mi
+        cpu: 150m
+        memory: 512Mi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
@@ -40,8 +40,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 300m
-        memory: 1400Mi
+        cpu: 250m
+        memory: 1Gi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
@@ -40,8 +40,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 300m
-        memory: 1400Mi
+        cpu: 150m
+        memory: 512Mi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_code.yaml
@@ -70,8 +70,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 300m
-        memory: 1400Mi
+        cpu: 150m
+        memory: 512Mi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
@@ -40,8 +40,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 300m
-        memory: 1400Mi
+        cpu: 250m
+        memory: 1Gi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
@@ -40,8 +40,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 300m
-        memory: 1400Mi
+        cpu: 150m
+        memory: 512Mi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/team/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/team/cluster.yaml
@@ -14,11 +14,11 @@ objects:
   spec:
     quota:
       hard:
-        limits.cpu: 1750m
-        limits.memory: 7Gi
+        limits.cpu: 2000m
+        limits.memory: 10Gi
         limits.ephemeral-storage: 5Gi
-        requests.cpu: 1750m
-        requests.memory: 7Gi
+        requests.cpu: 2000m
+        requests.memory: 10Gi
         requests.storage: 5Gi
         requests.ephemeral-storage: 5Gi
         persistentvolumeclaims: "2"

--- a/deploy/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_dev.yaml
@@ -70,7 +70,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 400m
+        cpu: 500m
         memory: 2Gi
       defaultRequest:
         cpu: 100m

--- a/deploy/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_stage.yaml
@@ -70,7 +70,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 400m
+        cpu: 500m
         memory: 2Gi
       defaultRequest:
         cpu: 100m


### PR DESCRIPTION
change/optimize limits across tiers. We agreed on these numbers:

### basic/advanced
* **code/stage** (the original values)
  * cpu: 150m
  * memory: 512Mi
* **dev** (enough for running pipeline tutorials)
  * cpu: 250m
  * memory: 1Gi

### team
* **dev/stage**
  * cpu: 500m
  * memory: 2Gi
* **cluster**
  * cpu: 2000m
  * memory: 10Gi

paired PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/97