### PR TITLE
Prevent privilege escalation in user namespaces

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -30,7 +30,13 @@ objects:
         - roles
         - rolebindings
       verbs:
-        - '*'
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:

--- a/deploy/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_code.yaml
@@ -30,7 +30,13 @@ objects:
         - roles
         - rolebindings
       verbs:
-        - '*'
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:

--- a/deploy/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_dev.yaml
@@ -30,7 +30,13 @@ objects:
     - roles
     - rolebindings
     verbs:
-    - '*'
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:

--- a/deploy/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_stage.yaml
@@ -30,7 +30,13 @@ objects:
     - roles
     - rolebindings
     verbs:
-    - '*'
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -235,7 +235,7 @@ func TestNewNSTemplateTier(t *testing.T) {
 						if kind == "code" || tier == "team" {
 							require.Len(t, ns.Template.Objects, 8)
 							// Role & RoleBinding with additional permissions to edit roles/rolebindings
-							containsObj(t, ns.Template, fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"labels":{"toolchain.dev.openshift.com/provider":"codeready-toolchain"},"name":"rbac-edit","namespace":"${USERNAME}-%s"},"rules":[{"apiGroups":["authorization.openshift.io","rbac.authorization.k8s.io"],"resources":["roles","rolebindings"],"verbs":["*"]}]}`, ns.Type))
+							containsObj(t, ns.Template, fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"labels":{"toolchain.dev.openshift.com/provider":"codeready-toolchain"},"name":"rbac-edit","namespace":"${USERNAME}-%s"},"rules":[{"apiGroups":["authorization.openshift.io","rbac.authorization.k8s.io"],"resources":["roles","rolebindings"],"verbs":["get","list","watch","create","update","patch","delete"]}]}`, ns.Type))
 							containsObj(t, ns.Template, fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"labels":{"toolchain.dev.openshift.com/provider":"codeready-toolchain"},"name":"user-rbac-edit","namespace":"${USERNAME}-%s"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"rbac-edit"},"subjects":[{"kind":"User","name":"${USERNAME}"}]}`, ns.Type))
 						} else {
 							require.Len(t, ns.Template.Objects, 6)


### PR DESCRIPTION
Instead of allowing `"*"` verbs for `role/rolebinding` resources in user namespaces we should explicitly allow all verbs but `"escalate" `.
Since `"*"` also includes `"escalate"` it allows users to escalate privileges and create roles/rolebindings  with permissions the user doesn't already have. User would be able to modify limitranges for example.
With this change users won't be able to escalate permissions.

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/98