### PR TITLE
chore: balance values in LimitRanges/Quotas to fit in memory/cpu limits

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
@@ -64,8 +64,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 250m
-        memory: 1Gi
+        cpu: 150m
+        memory: 750Mi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
@@ -32,8 +32,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 250m
-        memory: 1Gi
+        cpu: 150m
+        memory: 750Mi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/team/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/team/cluster.yaml
@@ -11,10 +11,10 @@ objects:
     quota:
       hard:
         limits.cpu: 2000m
-        limits.memory: 10Gi
+        limits.memory: 15Gi
         limits.ephemeral-storage: 5Gi
         requests.cpu: 2000m
-        requests.memory: 10Gi
+        requests.memory: 15Gi
         requests.storage: 5Gi
         requests.ephemeral-storage: 5Gi
         persistentvolumeclaims: "2"

--- a/deploy/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_dev.yaml
@@ -64,8 +64,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 500m
-        memory: 2Gi
+        cpu: 150m
+        memory: 1Gi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_stage.yaml
@@ -64,8 +64,8 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 500m
-        memory: 2Gi
+        cpu: 150m
+        memory: 1Gi
       defaultRequest:
         cpu: 100m
         memory: 64Mi

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -218,11 +218,9 @@ func TestNewNSTemplateTier(t *testing.T) {
 						cpuLimit := "150m"
 						memoryLimit := "512Mi"
 						if tier == "team" {
-							cpuLimit = "500m"
-							memoryLimit = "2Gi"
-						} else if ns.Type == "dev" {
-							cpuLimit = "250m"
 							memoryLimit = "1Gi"
+						} else if ns.Type == "dev" {
+							memoryLimit = "750Mi"
 						}
 						containsObj(t, ns.Template, fmt.Sprintf(`{"apiVersion":"v1","kind":"LimitRange","metadata":{"name":"resource-limits","namespace":"${USERNAME}-%s"},"spec":{"limits":[{"default":{"cpu":"%s","memory":"%s"},"defaultRequest":{"cpu":"100m","memory":"64Mi"},"type":"Container"}]}}`, ns.Type, cpuLimit, memoryLimit))
 
@@ -250,7 +248,7 @@ func TestNewNSTemplateTier(t *testing.T) {
 				memoryLimit := "7Gi"
 				if tier == "team" {
 					cpuLimit = "2000m"
-					memoryLimit = "10Gi"
+					memoryLimit = "15Gi"
 				}
 				assert.Len(t, actual.Spec.ClusterResources.Template.Objects, 1)
 				containsObj(t, actual.Spec.ClusterResources.Template, fmt.Sprintf(`{"apiVersion":"quota.openshift.io/v1","kind":"ClusterResourceQuota","metadata":{"name":"for-${USERNAME}"},"spec":{"quota":{"hard":{"configmaps":"100","limits.cpu":"%[1]s","limits.ephemeral-storage":"5Gi","limits.memory":"%[2]s","persistentvolumeclaims":"2","pods":"100","replicationcontrollers":"100","requests.cpu":"%[1]s","requests.ephemeral-storage":"5Gi","requests.memory":"%[2]s","requests.storage":"5Gi","secrets":"100","services":"100"}},"selector":{"annotations":{"openshift.io/requester":"${USERNAME}"},"labels":null}}}`, cpuLimit, memoryLimit))


### PR DESCRIPTION
My explanation for the values:
We need to take into account that if we aggregate all values taken from the running pods/containers, then the resulting values cannot exceed the values set in `ClusterResourceQuotas`:
* basic/advanced:
   * cpu: 1750m
   * memory: 7Gi
* team:
   * cpu: 2000m
   * memory: 15Gi (increased from 10Gi to have some cushion - we will be able to run tasks that eat more memory in parallel) 

In addition, when there is an `EventListener` running in the namespace, it immediately takes the default values (we run 2 EventListeners in our codeready-toolchain-dev namespace). That lowers the memory/millicpu that has left for the actual Pipelines/Tasks. 

Then, the actual `TaskRun` contains (apart from the steps) also some additional init/internal containers (eg. for cloning repo, creating a directory or exporting image digest) - these containers also take the default values (since there is nothing set by default).

Counting this together, we can expect that there will be always at least 3 or 4 containers running plus the containers processing the steps. It can be even more in the case of our pipelines running in codeready-toolchain-dev namespace.

Thus, I had to change a few values:
* I decreased the `cpu` limit in all tiers to `150m`, otherwise, we could easily hit the quota limit so no pod would be initialized - that was exactly the root cause of the failure in our pipelines - there were too many pods with too many of the milicores set in their limits
* I decreased the `memory` limit for dev namespace in basic/advanced tiers to 750Mi so there is a possibility to run two TaskRuns in parallel.
* After checking the Prometheus/Grafana metrics I decreased the `memory` limit in team tier to 1Gi - it should be enough in a combination with this PR: https://github.com/codeready-toolchain/toolchain-cicd/pull/10/ - In the PR I merged steps into a single step (where it was possible) and used increased limits for the steps where it is needed - for the rest the default 1Gi should be enough. I more or less tested it and it was working fine.
* As I mentioned above, I increased the memory in ClusterResourceQuota of the team tier to 15Gi to feel a bit more relaxed and to have some cushion.

Paired PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/103