### PR TITLE
Set the default Che limits to 1 core to speed up workspace creation

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -64,11 +64,11 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 1000m
         memory: 512Mi
       defaultRequest:
-        cpu: 10m
-        memory: 64Mi
+        cpu: 60m
+        memory: 307Mi
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:

--- a/deploy/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_code.yaml
@@ -64,11 +64,11 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 1000m
         memory: 512Mi
       defaultRequest:
-        cpu: 10m
-        memory: 64Mi
+        cpu: 60m
+        memory: 307Mi
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -217,12 +217,19 @@ func TestNewNSTemplateTier(t *testing.T) {
 						// LimitRange
 						cpuLimit := "150m"
 						memoryLimit := "512Mi"
+						memoryRequest := "64Mi"
+						cpuRequest := "10m"
+						if ns.Type == "code" {
+							cpuLimit = "1000m"
+							cpuRequest = "60m"
+							memoryRequest = "307Mi"
+						}
 						if tier == "team" {
 							memoryLimit = "1Gi"
 						} else if ns.Type == "dev" {
 							memoryLimit = "750Mi"
 						}
-						containsObj(t, ns.Template, fmt.Sprintf(`{"apiVersion":"v1","kind":"LimitRange","metadata":{"name":"resource-limits","namespace":"${USERNAME}-%s"},"spec":{"limits":[{"default":{"cpu":"%s","memory":"%s"},"defaultRequest":{"cpu":"10m","memory":"64Mi"},"type":"Container"}]}}`, ns.Type, cpuLimit, memoryLimit))
+						containsObj(t, ns.Template, fmt.Sprintf(`{"apiVersion":"v1","kind":"LimitRange","metadata":{"name":"resource-limits","namespace":"${USERNAME}-%s"},"spec":{"limits":[{"default":{"cpu":"%s","memory":"%s"},"defaultRequest":{"cpu":"%s","memory":"%s"},"type":"Container"}]}}`, ns.Type, cpuLimit, memoryLimit, cpuRequest, memoryRequest))
 
 						// NetworkPolicies
 						containsObj(t, ns.Template, fmt.Sprintf(`{"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"name":"allow-same-namespace","namespace":"${USERNAME}-%s"},"spec":{"ingress":[{"from":[{"podSelector":{}}]}],"podSelector":{}}}`, ns.Type))


### PR DESCRIPTION
https://github.com/codeready-toolchain/host-operator/pull/197 helped to speed up Che workspace/IDE. But it turned out that there are two pods managed by Che:
- first pod is created by Che which starts a workspace.
- as the result of the first pod another pod (workspace pod) is created.

The starting pod doesn't specify limits so our default limits from the limit range is used. I took the new numbers from che.openshift.io. It's 1 core of CPU and 512Mi of RAM. That seems to help to speed up the che ws start.
The second pod (the workspace itself) is already fast enough after applying https://github.com/codeready-toolchain/host-operator/pull/197 and https://github.com/codeready-toolchain/toolchain-infra/pull/15

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/107