### PR TITLE
add notification condition to mur

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/host-operator
 require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49
+	github.com/codeready-toolchain/api v0.0.0-20200506130228-a821d9c227f1
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200427080755-4d31a88fd82c
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
@@ -31,8 +31,6 @@ require (
 
 // Pinned to kubernetes-1.16.2
 replace (
-    // TODO: tina remove this
-    github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49 => github.com/tinakurian/api v0.0.0-20200505154630-c9659c388982
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 
 // Pinned to kubernetes-1.16.2
 replace (
+    // TODO: tina remove this
+    github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49 => ../api
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 // Pinned to kubernetes-1.16.2
 replace (
     // TODO: tina remove this
-    github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49 => ../api
+    github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49 => github.com/tinakurian/api v0.0.0-20200505154630-c9659c388982
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
 github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb h1:jKoTRIPS80hYsFlZs6fIYXcuvr7fbz1y28xbFuTj0Pc=
 github.com/codeready-toolchain/api v0.0.0-20200402215020-c7a5434db5fb/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49 h1:A1QJx5ZrTFnQVbBYuiS6bqnFcPy7xS3fIpzrmEvKbdQ=
-github.com/codeready-toolchain/api v0.0.0-20200403111848-efd1f59b2e49/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/codeready-toolchain/api v0.0.0-20200506130228-a821d9c227f1 h1:QlZeSc0rKbUEA4L2Z1EH6Q9Ckr2UrPdYumEmF2YO5W0=
+github.com/codeready-toolchain/api v0.0.0-20200506130228-a821d9c227f1/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200427080755-4d31a88fd82c h1:c1suJM+TOWx8U1YBje24F8C3KPX1rmnYXNqmqorouSE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200427080755-4d31a88fd82c/go.mod h1:OhMfZoXLHTu4b6pXxWd6MAuCoT0OcKYiDZdEn3oCPGI=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -310,6 +310,14 @@ func toBeDisabled() toolchainv1alpha1.Condition {
 	}
 }
 
+func toBeProvisionedNotificationCreated() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.MasterUserRecordProvisioningNotificationCreated,
+		Status: corev1.ConditionTrue,
+		Reason: toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreatedReason,
+	}
+}
+
 // updateStatusConditions updates user account status conditions with the new conditions
 func updateStatusConditions(logger logr.Logger, cl client.Client, mur *toolchainv1alpha1.MasterUserRecord, newConditions ...toolchainv1alpha1.Condition) error {
 	var updated bool

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -318,11 +318,12 @@ func toBeProvisionedNotificationCreated() toolchainv1alpha1.Condition {
 	}
 }
 
-func toBeProvisionedNotificationFailed() toolchainv1alpha1.Condition {
+func toBeProvisionedNotificationFailed(msg string) toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
-		Type:   toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreated,
-		Status: corev1.ConditionFalse,
-		Reason: toolchainv1alpha1.MasterUserRecordNotificationCRCreationFailedReason,
+		Type:    toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreated,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.MasterUserRecordNotificationCRCreationFailedReason,
+		Message: msg,
 	}
 }
 

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -312,9 +312,17 @@ func toBeDisabled() toolchainv1alpha1.Condition {
 
 func toBeProvisionedNotificationCreated() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
-		Type:   toolchainv1alpha1.MasterUserRecordProvisioningNotificationCreated,
+		Type:   toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreated,
 		Status: corev1.ConditionTrue,
-		Reason: toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreatedReason,
+		Reason: toolchainv1alpha1.MasterUserRecordNotificationCRCreatedReason,
+	}
+}
+
+func toBeProvisionedNotificationFailed() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreated,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.MasterUserRecordNotificationCRCreationFailedReason,
 	}
 }
 


### PR DESCRIPTION
In order to track the status of the user provisioned notification, we need to add a new Status condition to MasterUserRecord.

This PR adds the conditions for both provisioned notification created and provisioned notification failed. 

Jira: https://issues.redhat.com/browse/CRT-521