### PR TITLE
chore: replace ius-release package in Dockerfile.tools

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -13,7 +13,7 @@ ENV LANG=en_US.utf8 \
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/host-operator
 
 RUN yum install epel-release -y \
-    && yum install  https://centos7.iuscommunity.org/ius-release.rpm -y \
+    && yum install https://repo.ius.io/ius-release-el7.rpm -y \
     && yum install --enablerepo=centosplus -y --quiet \
     findutils \
     git224-all \


### PR DESCRIPTION
Replace CentOS ius-release package. See iusrepo/announce#18

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>