### PR TITLE
fix: migrate existing MURs from deprecated fields to TemplateRef field

### DIFF
--- a/pkg/controller/changetierrequest/changetierrequest_controller.go
+++ b/pkg/controller/changetierrequest/changetierrequest_controller.go
@@ -7,6 +7,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+	"github.com/codeready-toolchain/host-operator/pkg/controller/usersignup"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
@@ -141,28 +142,7 @@ func (r *ReconcileChangeTierRequest) changeTier(log logr.Logger, changeTierReque
 		return r.wrapErrorWithStatusUpdate(log, changeTierRequest, r.setStatusChangeFailed, err, "unable to get NSTemplateTier with name %s", changeTierRequest.Spec.TierName)
 	}
 
-	namespaces := make([]toolchainv1alpha1.NSTemplateSetNamespace, len(nsTemplateTier.Spec.Namespaces))
-	for i, ns := range nsTemplateTier.Spec.Namespaces {
-		namespaces[i] = toolchainv1alpha1.NSTemplateSetNamespace{
-			Type:        ns.Type,
-			Revision:    ns.Revision,
-			TemplateRef: ns.TemplateRef,
-		}
-	}
-	var clusterResources *toolchainv1alpha1.NSTemplateSetClusterResources
-	if nsTemplateTier.Spec.ClusterResources != nil {
-		clusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
-			Revision: nsTemplateTier.Spec.ClusterResources.Revision,
-			TemplateRef: nsTemplateTier.Spec.ClusterResources.TemplateRef,
-		}
-	} else {
-		log.Info("NSTemplateTier has no cluster resources", "name", nsTemplateTier.Name)
-	}
-	newNsTemplateSet := toolchainv1alpha1.NSTemplateSetSpec{
-		TierName:         changeTierRequest.Spec.TierName,
-		Namespaces:       namespaces,
-		ClusterResources: clusterResources,
-	}
+	newNsTemplateSet := usersignup.NewNSTemplateSetSpec(nsTemplateTier)
 	changed := false
 	for i, ua := range mur.Spec.UserAccounts {
 		if changeTierRequest.Spec.TargetCluster != "" {

--- a/pkg/controller/usersignup/masteruserrecord.go
+++ b/pkg/controller/usersignup/masteruserrecord.go
@@ -1,0 +1,92 @@
+package usersignup
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/templates/nstemplatetiers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func migrateMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, nstemplateTier *toolchainv1alpha1.NSTemplateTier) (bool, *toolchainv1alpha1.MasterUserRecord) {
+	changed := false
+	for uaIndex, userAccount := range mur.Spec.UserAccounts {
+		if userAccount.Spec.NSLimit == "" {
+			mur.Spec.UserAccounts[uaIndex].Spec.NSLimit = "default"
+			changed = true
+		}
+		nsTemplateSet := userAccount.Spec.NSTemplateSet
+		if nsTemplateSet.TierName == "" {
+			mur.Spec.UserAccounts[uaIndex].Spec.NSTemplateSet = NewNSTemplateSetSpec(nstemplateTier)
+			changed = true
+		} else {
+			for nsIndex, ns := range nsTemplateSet.Namespaces {
+				if ns.TemplateRef == "" {
+					ref := nstemplatetiers.NewTierTemplateName(nsTemplateSet.TierName, ns.Type, ns.Revision)
+					mur.Spec.UserAccounts[uaIndex].Spec.NSTemplateSet.Namespaces[nsIndex].TemplateRef = ref
+					changed = true
+				}
+			}
+			if nsTemplateSet.ClusterResources != nil && nsTemplateSet.ClusterResources.TemplateRef == "" {
+				ref := nstemplatetiers.NewTierTemplateName(nsTemplateSet.TierName, nstemplatetiers.ClusterResources, nsTemplateSet.ClusterResources.Revision)
+				mur.Spec.UserAccounts[uaIndex].Spec.NSTemplateSet.ClusterResources.TemplateRef = ref
+				changed = true
+			}
+		}
+	}
+	return changed, mur
+}
+
+func newMasterUserRecord(nstemplateTier *toolchainv1alpha1.NSTemplateTier, name, namespace, targetCluster, userSignupName string) *toolchainv1alpha1.MasterUserRecord {
+	return newMasterUserRecordWithNsSet(name, namespace, targetCluster, userSignupName, "default", NewNSTemplateSetSpec(nstemplateTier))
+}
+
+func NewNSTemplateSetSpec(nstemplateTier *toolchainv1alpha1.NSTemplateTier) toolchainv1alpha1.NSTemplateSetSpec {
+	namespaces := make([]toolchainv1alpha1.NSTemplateSetNamespace, len(nstemplateTier.Spec.Namespaces))
+	for i, ns := range nstemplateTier.Spec.Namespaces {
+		namespaces[i] = toolchainv1alpha1.NSTemplateSetNamespace{
+			Type:        ns.Type,
+			Revision:    ns.Revision,
+			TemplateRef: ns.TemplateRef,
+		}
+	}
+	var clusterResources *toolchainv1alpha1.NSTemplateSetClusterResources
+	if nstemplateTier.Spec.ClusterResources != nil {
+		clusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
+			Revision:    nstemplateTier.Spec.ClusterResources.Revision,
+			TemplateRef: nstemplateTier.Spec.ClusterResources.TemplateRef,
+		}
+	}
+	return toolchainv1alpha1.NSTemplateSetSpec{
+		TierName:         nstemplateTier.Name,
+		Namespaces:       namespaces,
+		ClusterResources: clusterResources,
+	}
+}
+
+func newMasterUserRecordWithNsSet(name, namespace, targetCluster, userSignupName, nsLimit string, nsTmplSet toolchainv1alpha1.NSTemplateSetSpec) *toolchainv1alpha1.MasterUserRecord {
+	userAccounts := []toolchainv1alpha1.UserAccountEmbedded{
+		{
+			TargetCluster: targetCluster,
+			Spec: toolchainv1alpha1.UserAccountSpecEmbedded{
+				UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{
+					NSLimit:       nsLimit,
+					NSTemplateSet: nsTmplSet,
+				},
+			},
+		},
+	}
+
+	labels := map[string]string{toolchainv1alpha1.MasterUserRecordUserIDLabelKey: userSignupName}
+
+	mur := &toolchainv1alpha1.MasterUserRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: toolchainv1alpha1.MasterUserRecordSpec{
+			UserAccounts: userAccounts,
+			UserID:       userSignupName,
+		},
+	}
+	return mur
+}

--- a/pkg/controller/usersignup/masteruserrecord_test.go
+++ b/pkg/controller/usersignup/masteruserrecord_test.go
@@ -1,0 +1,198 @@
+package usersignup
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewMasterUserRecord(t *testing.T) {
+	t.Run("when clusterResources template is specified", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+
+		// when
+		mur := newMasterUserRecord(nSTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+
+		// then
+		assert.Equal(t, newExpectedMur(), *mur)
+	})
+
+	t.Run("when clusterResources template is NOT specified", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+		nSTemplateTier.Spec.ClusterResources = nil
+
+		// when
+		mur := newMasterUserRecord(nSTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+
+		// then
+		withoutClusterRes := newExpectedMur()
+		withoutClusterRes.Spec.UserAccounts[0].Spec.NSTemplateSet.ClusterResources = nil
+		assert.EqualValues(t, withoutClusterRes, *mur)
+	})
+}
+
+func TestNewNsTemplateSetSpec(t *testing.T) {
+	t.Run("when clusterResources template is specified", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+
+		// when
+		setSpec := NewNSTemplateSetSpec(nSTemplateTier)
+
+		// then
+		assert.Equal(t, newExpectedNsTemplateSetSpec(), setSpec)
+	})
+
+	t.Run("when clusterResources template is NOT specified", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+		nSTemplateTier.Spec.ClusterResources = nil
+
+		// when
+		setSpec := NewNSTemplateSetSpec(nSTemplateTier)
+
+		// then
+		withoutClusterRes := newExpectedNsTemplateSetSpec()
+		withoutClusterRes.ClusterResources = nil
+		assert.Equal(t, withoutClusterRes, setSpec)
+	})
+}
+
+func TestMigrateMurIfNecessary(t *testing.T) {
+	t.Run("when mur is the same", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+		mur := newMasterUserRecord(nSTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+
+		// when
+		changed, changedMur := migrateMurIfNecessary(mur, nSTemplateTier)
+
+		// then
+		assert.False(t, changed)
+		assert.Equal(t, newExpectedMur(), *changedMur)
+	})
+
+	t.Run("when mur is missing NsLimit", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+		mur := newMasterUserRecord(nSTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+		mur.Spec.UserAccounts[0].Spec.NSLimit = ""
+
+		// when
+		changed, changedMur := migrateMurIfNecessary(mur, nSTemplateTier)
+
+		// then
+		assert.True(t, changed)
+		assert.Equal(t, newExpectedMur(), *changedMur)
+	})
+
+	t.Run("when whole NSTemplateSet is missing", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+		mur := newMasterUserRecord(nSTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+		mur.Spec.UserAccounts[0].Spec.NSTemplateSet = v1alpha1.NSTemplateSetSpec{}
+
+		// when
+		changed, changedMur := migrateMurIfNecessary(mur, nSTemplateTier)
+
+		// then
+		assert.True(t, changed)
+		assert.Equal(t, newExpectedMur(), *changedMur)
+	})
+
+	t.Run("when NSTemplateSet is missing templateRefs", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+		mur := newMasterUserRecord(nSTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+		for index := range mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces {
+			mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces[index].TemplateRef = ""
+		}
+		mur.Spec.UserAccounts[0].Spec.NSTemplateSet.ClusterResources.TemplateRef = ""
+
+		// when
+		changed, changedMur := migrateMurIfNecessary(mur, nSTemplateTier)
+
+		// then
+		assert.True(t, changed)
+		assert.Equal(t, newExpectedMur(), *changedMur)
+	})
+
+	t.Run("when one namespace is missing and one is extra, but rest is fine, then doesn't change", func(t *testing.T) {
+		// given
+		nSTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
+		mur := newMasterUserRecord(nSTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+		mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces[0].Type = "cicd"
+		mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces[0].TemplateRef = "advanced-cicd-123abc1"
+		providedMur := mur.DeepCopy()
+
+		// when
+		changed, changedMur := migrateMurIfNecessary(mur, nSTemplateTier)
+
+		// then
+		assert.False(t, changed)
+		assert.Equal(t, *providedMur, *changedMur)
+	})
+}
+
+func newExpectedNsTemplateSetSpec() v1alpha1.NSTemplateSetSpec {
+	return v1alpha1.NSTemplateSetSpec{
+		TierName: "advanced",
+		Namespaces: []v1alpha1.NSTemplateSetNamespace{{
+			Type:        "dev",
+			Revision:    "123abc1",
+			Template:    "",
+			TemplateRef: "advanced-dev-123abc1",
+		},
+			{
+				Type:        "stage",
+				Revision:    "123abc2",
+				Template:    "",
+				TemplateRef: "advanced-stage-123abc2",
+			},
+			{
+				Type:        "extra",
+				Revision:    "123abc3",
+				Template:    "",
+				TemplateRef: "advanced-extra-123abc3",
+			},
+		},
+		ClusterResources: &v1alpha1.NSTemplateSetClusterResources{
+			Revision:    "654321b",
+			Template:    "",
+			TemplateRef: "advanced-clusterresources-654321b",
+		},
+	}
+}
+
+func newExpectedMur() v1alpha1.MasterUserRecord {
+	return v1alpha1.MasterUserRecord{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "johny",
+			Namespace: operatorNamespace,
+			Labels: map[string]string{
+				"toolchain.dev.openshift.com/user-id": "123456789",
+			},
+		},
+		Spec: v1alpha1.MasterUserRecordSpec{
+			UserID:        "123456789",
+			Banned:        false,
+			Disabled:      false,
+			Deprovisioned: false,
+			UserAccounts: []v1alpha1.UserAccountEmbedded{{
+				SyncIndex:     "",
+				TargetCluster: test.MemberClusterName,
+				Spec: v1alpha1.UserAccountSpecEmbedded{
+					UserAccountSpecBase: v1alpha1.UserAccountSpecBase{
+						NSLimit:       "default",
+						NSTemplateSet: newExpectedNsTemplateSetSpec(),
+					},
+				},
+			}},
+		},
+	}
+}

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/codeready-toolchain/host-operator/pkg/templates/nstemplatetiers"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -46,47 +47,39 @@ const (
 	operatorNamespace = "toolchain-host-operator"
 )
 
-var basicNSTemplateTier = &toolchainv1alpha1.NSTemplateTier{
-	ObjectMeta: metav1.ObjectMeta{
-		Namespace: operatorNamespace,
-		Name:      "basic",
-	},
-	Spec: toolchainv1alpha1.NSTemplateTierSpec{
-		Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
-			{
-				Type:        "code",
-				Revision:    "123456a",
-				TemplateRef: "basic-code-123456a",
-				Template:    templatev1.Template{
-					// does not need to be filled
-				},
-			},
-			{
-				Type:        "dev",
-				Revision:    "123456b",
-				TemplateRef: "basic-dev-123456b",
-				Template:    templatev1.Template{
-					// does not need to be filled
-				},
-			},
-			{
-				Type:        "stage",
-				Revision:    "123456c",
-				TemplateRef: "basic-stage-123456c",
-				Template:    templatev1.Template{
-					// does not need to be filled
-				},
-			},
-		},
-		ClusterResources: &toolchainv1alpha1.NSTemplateTierClusterResources{
-			Revision:    "654321b",
-			TemplateRef: "basic-clusterresources-654321b",
+func newNsTemplateTier(tierName, clusterRevision string, nsTypes ...string) *toolchainv1alpha1.NSTemplateTier {
+	namespaces := make([]toolchainv1alpha1.NSTemplateTierNamespace, len(nsTypes))
+	for i, nsType := range nsTypes {
+		revision := fmt.Sprintf("123abc%d", i+1)
+		namespaces[i] = toolchainv1alpha1.NSTemplateTierNamespace{
+			Type:        nsType,
+			Revision:    revision,
+			TemplateRef: nstemplatetiers.NewTierTemplateName(tierName, nsType, revision),
 			Template:    templatev1.Template{
 				// does not need to be filled
 			},
+		}
+	}
+
+	return &toolchainv1alpha1.NSTemplateTier{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: operatorNamespace,
+			Name:      tierName,
 		},
-	},
+		Spec: toolchainv1alpha1.NSTemplateTierSpec{
+			Namespaces: namespaces,
+			ClusterResources: &toolchainv1alpha1.NSTemplateTierClusterResources{
+				Revision:    clusterRevision,
+				TemplateRef: nstemplatetiers.NewTierTemplateName(tierName, "clusterresources", clusterRevision),
+				Template:    templatev1.Template{
+					// does not need to be filled
+				},
+			},
+		},
+	}
 }
+
+var basicNSTemplateTier = newNsTemplateTier("basic", "654321b", "code", "dev", "stage")
 
 func TestUserSignupCreateMUROk(t *testing.T) {
 	// given
@@ -117,14 +110,14 @@ func TestUserSignupCreateMUROk(t *testing.T) {
 	for _, ns := range mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces {
 		switch ns.Type {
 		case "code":
-			assert.Equal(t, "123456a", ns.Revision)
-			assert.Equal(t, "basic-code-123456a", ns.TemplateRef)
+			assert.Equal(t, "123abc1", ns.Revision)
+			assert.Equal(t, "basic-code-123abc1", ns.TemplateRef)
 		case "dev":
-			assert.Equal(t, "123456b", ns.Revision)
-			assert.Equal(t, "basic-dev-123456b", ns.TemplateRef)
+			assert.Equal(t, "123abc2", ns.Revision)
+			assert.Equal(t, "basic-dev-123abc2", ns.TemplateRef)
 		case "stage":
-			assert.Equal(t, "123456c", ns.Revision)
-			assert.Equal(t, "basic-stage-123456c", ns.TemplateRef)
+			assert.Equal(t, "123abc3", ns.Revision)
+			assert.Equal(t, "basic-stage-123abc3", ns.TemplateRef)
 		default:
 			t.Fatalf("unexpected namespace type: %s", ns.Type)
 		}
@@ -179,22 +172,22 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	assert.Contains(t, mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces,
 		toolchainv1alpha1.NSTemplateSetNamespace{
 			Type:        "code",
-			Revision:    "123456a",
-			TemplateRef: "basic-code-123456a",
+			Revision:    "123abc1",
+			TemplateRef: "basic-code-123abc1",
 			Template:    "",
 		})
 	assert.Contains(t, mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces,
 		toolchainv1alpha1.NSTemplateSetNamespace{
 			Type:        "dev",
-			Revision:    "123456b",
-			TemplateRef: "basic-dev-123456b",
+			Revision:    "123abc2",
+			TemplateRef: "basic-dev-123abc2",
 			Template:    "",
 		})
 	assert.Contains(t, mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces,
 		toolchainv1alpha1.NSTemplateSetNamespace{
 			Type:        "stage",
-			Revision:    "123456c",
-			TemplateRef: "basic-stage-123456c",
+			Revision:    "123abc3",
+			TemplateRef: "basic-stage-123abc3",
 			Template:    "",
 		})
 	require.NotNil(t, mur.Spec.UserAccounts[0].Spec.NSTemplateSet.ClusterResources)
@@ -362,20 +355,14 @@ func TestUserSignupFailedMissingNSTemplateTier(t *testing.T) {
 	createMemberCluster(r.client, "member1", ready)
 	defer clearMemberClusters(r.client)
 	// when
-	res, err := r.Reconcile(req)
+	_, err := r.Reconcile(req)
 	// then
 	// error reported, and request is requeued and userSignup status was updated
 	require.Error(t, err)
-	assert.Equal(t, reconcile.Result{Requeue: true}, res)
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	t.Logf("usersignup status: %+v", userSignup.Status)
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
-		v1alpha1.Condition{
-			Type:   v1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
-			Reason: "ApprovedAutomatically",
-		},
 		v1alpha1.Condition{
 			Type:    v1alpha1.UserSignupComplete,
 			Status:  v1.ConditionFalse,
@@ -393,7 +380,7 @@ func TestUserSignupFailedNoClusterReady(t *testing.T) {
 			Approved: false,
 		},
 	}
-	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, configMap(configuration.UserApprovalPolicyAutomatic))
+	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, configMap(configuration.UserApprovalPolicyAutomatic), basicNSTemplateTier)
 	createMemberCluster(r.client, "member1", notReady)
 	createMemberCluster(r.client, "member2", notReady)
 	defer clearMemberClusters(r.client)
@@ -428,7 +415,7 @@ func TestUserSignupFailedNoClusterWithCapacityAvailable(t *testing.T) {
 			Approved: false,
 		},
 	}
-	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, configMap(configuration.UserApprovalPolicyAutomatic))
+	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, configMap(configuration.UserApprovalPolicyAutomatic), basicNSTemplateTier)
 	createMemberCluster(r.client, "member1", ready, capacityExhausted)
 	createMemberCluster(r.client, "member2", ready, capacityExhausted)
 	defer clearMemberClusters(r.client)
@@ -588,7 +575,7 @@ func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 		},
 	}
 
-	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, configMap(configuration.UserApprovalPolicyManual))
+	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, configMap(configuration.UserApprovalPolicyManual), basicNSTemplateTier)
 
 	createMemberCluster(r.client, "member1", ready)
 	defer clearMemberClusters(r.client)
@@ -694,7 +681,7 @@ func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 		},
 	}
 
-	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, emptyConfigMap())
+	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, emptyConfigMap(), basicNSTemplateTier)
 
 	res, err := r.Reconcile(req)
 	require.NoError(t, err)
@@ -1468,7 +1455,7 @@ func TestUserSignupWithMultipleExistingMURNotOK(t *testing.T) {
 		},
 	}
 
-	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, mur, mur2, configMap(configuration.UserApprovalPolicyAutomatic))
+	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, mur, mur2, configMap(configuration.UserApprovalPolicyAutomatic), basicNSTemplateTier)
 
 	createMemberCluster(r.client, "member1", ready)
 	defer clearMemberClusters(r.client)
@@ -1504,7 +1491,7 @@ func TestUserSignupNoMembersAvailableFails(t *testing.T) {
 		},
 	}
 
-	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, configMap(configuration.UserApprovalPolicyAutomatic))
+	r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, configMap(configuration.UserApprovalPolicyAutomatic), basicNSTemplateTier)
 
 	_, err := r.Reconcile(req)
 	require.Error(t, err)
@@ -1987,4 +1974,61 @@ func TestChangedCompliantUsername(t *testing.T) {
 
 	// the CompliantUsername and MUR name should now match
 	require.Equal(t, userSignup.Status.CompliantUsername, mur.Name)
+}
+
+func TestMigrateMur(t *testing.T) {
+	// given
+	userSignup := &v1alpha1.UserSignup{
+		ObjectMeta: newObjectMeta("foo", "foo@redhat.com"),
+		Spec: v1alpha1.UserSignupSpec{
+			Username:      "foo@redhat.com",
+			Approved:      true,
+			TargetCluster: "east",
+		},
+	}
+	mur := newMasterUserRecord(basicNSTemplateTier, "foo", operatorNamespace, "east", "foo")
+	expectedMur := mur.DeepCopy()
+	expectedMur.Generation = 1
+	expectedMur.ResourceVersion = "1"
+
+	// remove templateRef fields
+	for index := range mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces {
+		mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces[index].TemplateRef = ""
+	}
+	mur.Spec.UserAccounts[0].Spec.NSTemplateSet.ClusterResources.TemplateRef = ""
+
+	t.Run("add missing templateRef fields", func(t *testing.T) {
+		// given
+		r, req, _ := prepareReconcile(t, userSignup.Name, userSignup, basicNSTemplateTier, mur)
+
+		// when
+		_, err := r.Reconcile(req)
+
+		// then verify that the MUR exists and is complete
+		require.NoError(t, err)
+		murs := &v1alpha1.MasterUserRecordList{}
+		err = r.client.List(context.TODO(), murs)
+		require.NoError(t, err)
+		require.Len(t, murs.Items, 1)
+		assert.Equal(t, *expectedMur, murs.Items[0])
+	})
+
+	t.Run("fails while updating mur that is missing templateRef fields", func(t *testing.T) {
+		// given
+		r, req, fakeClient := prepareReconcile(t, userSignup.Name, userSignup, basicNSTemplateTier, mur)
+		fakeClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		_, err := r.Reconcile(req)
+
+		// then verify that the MUR exists and is complete
+		require.Error(t, err)
+		murs := &v1alpha1.MasterUserRecordList{}
+		err = r.client.List(context.TODO(), murs)
+		require.NoError(t, err)
+		require.Len(t, murs.Items, 1)
+		assert.NotEqual(t, *expectedMur, murs.Items[0])
+	})
 }


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/CRT-659

In the current running clusters, there are already some users provisioned but their MUR instances still contain only `Revision` and `Type` fields filled and not `TemplateRef` - this is still empty.
We need to migrate all existing users to use the `TemplateRef` field otherwise we are not able to start deployment of member operator (that is caused by another issue in member-operator)

There is no way to create e2e tests for it - we cannot create MUR without TeplateRef field filled since the field is mandatory. But I tested it locally and everything worked fine - the MUR (and all related resources) was updated so it contains `TemplateRef` field set