### PR TITLE
chore: move constant containing clusterresources type name to api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
 
+replace github.com/codeready-toolchain/api => github.com/MatousJobanek/api v0.0.0-20200522133924-2408f876684f
+
 // Pinned to kubernetes-1.16.2
 replace (
 	k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/host-operator
 require (
 	cloud.google.com/go v0.46.3 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200519085052-34d2a9c4a8e9
+	github.com/codeready-toolchain/api v0.0.0-20200525084630-00f2f69b8984
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200512115123-99be69ae5627
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
@@ -32,8 +32,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.5.0
 	sigs.k8s.io/kubefed v0.1.0-rc6.0.20200224204536-6207193c49f7
 )
-
-replace github.com/codeready-toolchain/api => github.com/MatousJobanek/api v0.0.0-20200522133924-2408f876684f
 
 // Pinned to kubernetes-1.16.2
 replace (

--- a/go.sum
+++ b/go.sum
@@ -48,10 +48,6 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/sprig/v3 v3.0.0/go.mod h1:NEUY/Qq8Gdm2xgYA+NwJM6wmfdRV9xkh8h/Rld20R0U=
 github.com/Masterminds/sprig/v3 v3.0.2/go.mod h1:oesJ8kPONMONaZgtiHNzUShJbksypC5kWczhZAf6+aU=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
-github.com/MatousJobanek/api v0.0.0-20200522133356-eea0eb5e8dbf h1:52yhRt+Ih9zsSx34YCfe8OjH5O3Moc2YryvPCrXQIQA=
-github.com/MatousJobanek/api v0.0.0-20200522133356-eea0eb5e8dbf/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/MatousJobanek/api v0.0.0-20200522133924-2408f876684f h1:64lcShY7pc2GHQyops097voOKM4q2P8k9cdv6oYkD/Q=
-github.com/MatousJobanek/api v0.0.0-20200522133924-2408f876684f/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
@@ -121,8 +117,8 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
 github.com/codeready-toolchain/api v0.0.0-20200506130228-a821d9c227f1 h1:QlZeSc0rKbUEA4L2Z1EH6Q9Ckr2UrPdYumEmF2YO5W0=
 github.com/codeready-toolchain/api v0.0.0-20200506130228-a821d9c227f1/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
-github.com/codeready-toolchain/api v0.0.0-20200519085052-34d2a9c4a8e9 h1:lDpk5qG4SXK3NnTnMgzvEg6IKEpzl04s/ovflLOmf5A=
-github.com/codeready-toolchain/api v0.0.0-20200519085052-34d2a9c4a8e9/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/codeready-toolchain/api v0.0.0-20200525084630-00f2f69b8984 h1:kPV/ry8FtX4vgpleSvZeky1i4MyT8BeywKik26mTHpo=
+github.com/codeready-toolchain/api v0.0.0-20200525084630-00f2f69b8984/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200512115123-99be69ae5627 h1:qpR2o75PxN1Bc4Fk0yRp7YA8/agiWIZdza6vaT78REw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200512115123-99be69ae5627/go.mod h1:pmctc+VbhA/VR2lOVWW1W/nSAWnTCIL6ed/5cKqgbeg=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,10 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/sprig/v3 v3.0.0/go.mod h1:NEUY/Qq8Gdm2xgYA+NwJM6wmfdRV9xkh8h/Rld20R0U=
 github.com/Masterminds/sprig/v3 v3.0.2/go.mod h1:oesJ8kPONMONaZgtiHNzUShJbksypC5kWczhZAf6+aU=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
+github.com/MatousJobanek/api v0.0.0-20200522133356-eea0eb5e8dbf h1:52yhRt+Ih9zsSx34YCfe8OjH5O3Moc2YryvPCrXQIQA=
+github.com/MatousJobanek/api v0.0.0-20200522133356-eea0eb5e8dbf/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/MatousJobanek/api v0.0.0-20200522133924-2408f876684f h1:64lcShY7pc2GHQyops097voOKM4q2P8k9cdv6oYkD/Q=
+github.com/MatousJobanek/api v0.0.0-20200522133924-2408f876684f/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=

--- a/pkg/controller/changetierrequest/changetierrequest_controller_test.go
+++ b/pkg/controller/changetierrequest/changetierrequest_controller_test.go
@@ -283,7 +283,7 @@ func NewNSTemplateTier(tierName, revision, clusterResourcesRevision string, nsTy
 	if clusterResourcesRevision != "" {
 		clusterResources = &v1alpha1.NSTemplateTierClusterResources{
 			Revision:    clusterResourcesRevision,
-			TemplateRef: nstemplatetiers.NewTierTemplateName(tierName, nstemplatetiers.ClusterResources, clusterResourcesRevision),
+			TemplateRef: nstemplatetiers.NewTierTemplateName(tierName, "clusterresources", clusterResourcesRevision),
 		}
 	}
 	return &v1alpha1.NSTemplateTier{

--- a/pkg/controller/usersignup/masteruserrecord.go
+++ b/pkg/controller/usersignup/masteruserrecord.go
@@ -26,7 +26,7 @@ func migrateMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, nstemplateTi
 				}
 			}
 			if nsTemplateSet.ClusterResources != nil && nsTemplateSet.ClusterResources.TemplateRef == "" {
-				ref := nstemplatetiers.NewTierTemplateName(nsTemplateSet.TierName, nstemplatetiers.ClusterResources, nsTemplateSet.ClusterResources.Revision)
+				ref := nstemplatetiers.NewTierTemplateName(nsTemplateSet.TierName, toolchainv1alpha1.ClusterResourcesTemplateType, nsTemplateSet.ClusterResources.Revision)
 				mur.Spec.UserAccounts[uaIndex].Spec.NSTemplateSet.ClusterResources.TemplateRef = ref
 				changed = true
 			}

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
@@ -23,11 +23,6 @@ import (
 
 var log = logf.Log.WithName("templates")
 
-const (
-	// ClusterResources the key to retrieve the cluster resources template
-	ClusterResources string = "clusterResources" // TODO: move in API and remove duplicate in https://github.com/codeready-toolchain/member-operator/blob/master/pkg/controller/nstemplateset/nstemplatetier.go#L18
-)
-
 // CreateOrUpdateResources generates the NSTemplateTier resources from the namespace templates,
 // then uses the manager's client to create or update the resources on the cluster.
 func CreateOrUpdateResources(s *runtime.Scheme, client client.Client, namespace string, assets assets.Assets) error {
@@ -184,7 +179,7 @@ func newTierTemplates(decoder runtime.Decoder, namespace string, templatesByTier
 		}
 		// cluster resources templates
 		if tmpls.clusterTemplate != nil {
-			tierTmpl, err := newTierTemplate(decoder, namespace, tier, ClusterResources, *tmpls.clusterTemplate)
+			tierTmpl, err := newTierTemplate(decoder, namespace, tier, toolchainv1alpha1.ClusterResourcesTemplateType, *tmpls.clusterTemplate)
 			if err != nil {
 				return nil, err
 			}
@@ -305,7 +300,7 @@ func newNSTemplateTier(decoder runtime.Decoder, namespace, tier string, tmpls te
 		result.Spec.ClusterResources = &toolchainv1alpha1.NSTemplateTierClusterResources{
 			Revision:    tmpls.clusterTemplate.revision,
 			Template:    *tmplObj,
-			TemplateRef: NewTierTemplateName(tier, ClusterResources, tmpls.clusterTemplate.revision), // link to the TierTemplate resource, whose name is: `<tierName>-<nsType>-<revision>`
+			TemplateRef: NewTierTemplateName(tier, toolchainv1alpha1.ClusterResourcesTemplateType, tmpls.clusterTemplate.revision), // link to the TierTemplate resource, whose name is: `<tierName>-<nsType>-<revision>`
 		}
 	}
 	return result, nil

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -314,7 +314,7 @@ func TestNewTierTemplate(t *testing.T) {
 					switch actual.Spec.Type {
 					case "dev", "code", "stage":
 						assertNamespaceTemplate(t, decoder, actual.Spec.Template, actual.Spec.TierName, actual.Spec.Type)
-					case "clusterResources":
+					case "clusterresources":
 						assertClusterResourcesTemplate(t, decoder, actual.Spec.Template, actual.Spec.TierName)
 					default:
 						t.Errorf("unexpected kind of template: '%s'", actual.Spec.Type)
@@ -349,7 +349,7 @@ func TestNewTierTemplate(t *testing.T) {
 					switch actual.Spec.Type {
 					case "dev", "code", "stage":
 						assertTestNamespaceTemplate(t, decoder, actual.Spec.Template, actual.Spec.TierName, actual.Spec.Type)
-					case "clusterResources":
+					case "clusterresources":
 						assertTestClusteResourcesTemplate(t, decoder, actual.Spec.Template, actual.Spec.TierName)
 					default:
 						t.Errorf("unexpected kind of template: '%s'", actual.Spec.Type)


### PR DESCRIPTION
Move constant containing type name of a template that contains cluster-scoped resources into the api repo. In addition, I made the string lower case since the name of the resource shouldn't contain any capital letter anyway.

depends on https://github.com/codeready-toolchain/api/pull/140