### PR TITLE
feat: let users view cluster-scoped Tekton resources

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/cluster.yaml
@@ -27,6 +27,17 @@ objects:
       annotations:
         openshift.io/requester: ${USERNAME}
       labels: null
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${USERNAME}-tekton-view
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tekton-view
+  subjects:
+  - kind: User
+    name: ${USERNAME}
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basic/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/basic/cluster.yaml
@@ -27,6 +27,17 @@ objects:
       annotations:
         openshift.io/requester: ${USERNAME}
       labels: null
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${USERNAME}-tekton-view
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tekton-view
+  subjects:
+  - kind: User
+    name: ${USERNAME}
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/team/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/team/cluster.yaml
@@ -27,6 +27,17 @@ objects:
       annotations:
         openshift.io/requester: ${USERNAME}
       labels: null
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${USERNAME}-tekton-view
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tekton-view
+  subjects:
+  - kind: User
+    name: ${USERNAME}
 parameters:
 - name: USERNAME
   required: true

--- a/test/templates/nstemplatetiers/advanced/cluster.yaml
+++ b/test/templates/nstemplatetiers/advanced/cluster.yaml
@@ -20,6 +20,17 @@ objects:
       annotations:
         openshift.io/requester: ${USERNAME}
       labels: null
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${USERNAME}-tekton-view
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tekton-view
+  subjects:
+  - kind: User
+    name: ${USERNAME}
 parameters:
 - name: USERNAME
   required: true

--- a/test/templates/nstemplatetiers/basic/cluster.yaml
+++ b/test/templates/nstemplatetiers/basic/cluster.yaml
@@ -20,6 +20,17 @@ objects:
       annotations:
         openshift.io/requester: ${USERNAME}
       labels: null
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${USERNAME}-tekton-view
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tekton-view
+  subjects:
+  - kind: User
+    name: ${USERNAME}
 parameters:
 - name: USERNAME
   required: true

--- a/test/templates/nstemplatetiers/team/cluster.yaml
+++ b/test/templates/nstemplatetiers/team/cluster.yaml
@@ -20,6 +20,17 @@ objects:
       annotations:
         openshift.io/requester: ${USERNAME}
       labels: null
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: ${USERNAME}-tekton-view
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tekton-view
+  subjects:
+  - kind: User
+    name: ${USERNAME}
 parameters:
 - name: USERNAME
   required: true


### PR DESCRIPTION
Adds `ClusterRoleBinding` to the cluster resources (for all tiers). The binding bings `ClusterRole` `tekton-view` to the user so he can view cluster-scoped Tekton resources.
The ClusterRole `tekton-view` should be available in the member cluster: https://github.com/codeready-toolchain/toolchain-infra/pull/20

Paired PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/120