### PR TITLE
chore: add target push-to-quay-staging for pushing new operator bundle

### DIFF
--- a/make/manifests.mk
+++ b/make/manifests.mk
@@ -1,5 +1,4 @@
 
-PATH_TO_PUSH_NIGHTLY_FILE=scripts/push-to-quay-nightly.sh
 PATH_TO_CD_GENERATE_FILE=scripts/generate-cd-release-manifests.sh
 PATH_TO_PUSH_APP_FILE=scripts/push-manifests-as-app.sh
 PATH_TO_BUNDLE_FILE=scripts/push-bundle-and-index-image.sh
@@ -13,6 +12,10 @@ INDEX_IMAGE?=hosted-toolchain-index
 .PHONY: push-to-quay-nightly
 ## Creates a new version of CSV and pushes it to quay
 push-to-quay-nightly: generate-cd-release-manifests push-manifests-as-app recover-operator-dir
+
+.PHONY: push-to-quay-staging
+## Creates a new version of operator bundle, adds it into an index and pushes it to quay
+push-to-quay-staging: generate-cd-release-manifests push-bundle-and-index-image recover-operator-dir
 
 .PHONY: generate-cd-release-manifests
 ## Generates a new version of operator manifests


### PR DESCRIPTION
add target `push-to-quay-staging` for easy building & pushing new operator bundle locally 