### PR TITLE
fix: get metrics only for Toolchain CRDs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	api "github.com/codeready-toolchain/api/pkg/apis"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/host-operator/pkg/controller"
@@ -238,7 +239,7 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 	// The function below returns a list of filtered operator/CR specific GVKs. For more control, override the GVK list below
 	// with your own custom logic. Note that if you are adding third party API schemas, probably you will need to
 	// customize this implementation to avoid permissions issues.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(api.AddToScheme)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When getting the metrics, we have to use the schema builder taken from the api repo. The reason is that the schema builder adds only our toolchain CRDs + KubeFed api. The schema builder in host operator adds api also for additional groups and our ServiceAccount doesn't have enough permissions to list all of them. That's why we have a lot of `Failed to list *unstructured.Unstructured:` errors in our logs nowadays. 