### PR TITLE
Implement notification delivery in notification controller

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,6 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
-cloud.google.com/go v0.46.3 h1:AVXDdKsrtX33oR9fbCMu/+c1o8Ofjq6Ku/MInaLVg5Y=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.49.0 h1:CH+lkubJzcPYB1Ggupcq0+k8Ni2ILdG2lYjDIgavDBQ=
 cloud.google.com/go v0.49.0/go.mod h1:hGvAdzcWNbyuxS3nWhD7H2cIJxjRRTRLQVB0bdputVY=
@@ -28,7 +27,6 @@ github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxw
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v13.0.0+incompatible h1:56c11ykhsFSPNNQuS73Ri8h/ezqVhr2h6t9LJIEKVO0=
 github.com/Azure/go-autorest v13.0.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
-github.com/Azure/go-autorest/autorest v0.9.0 h1:MRvx8gncNaXJqOoLmhNjUAKh33JJF8LyxPhomEtOsjs=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest v0.9.3-0.20191028180845-3492b2aff503 h1:uUhdsDMg2GbFLF5GfQPtLMWd5vdDZSfqvqQp3waafxQ=
 github.com/Azure/go-autorest/autorest v0.9.3-0.20191028180845-3492b2aff503/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
@@ -124,7 +122,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v0.0.0-20181017004759-096ff4a8a059/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cespare/xxhash/v2 v2.1.0 h1:yTUvW7Vhb89inJ+8irsUqiWjh8iT6sQPZiQzI6ReGkA=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -247,7 +244,6 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQD
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -347,11 +343,9 @@ github.com/gobuffalo/logger v1.0.0/go.mod h1:2zbswyIUa45I+c+FLXuWl9zSWEiVuthsk8z
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
 github.com/gobuffalo/packr v1.30.1/go.mod h1:ljMyFO2EcrnzsHsN99cvbq055Y9OhRrIaviy289eRuk=
 github.com/gobuffalo/packr/v2 v2.5.1/go.mod h1:8f9c96ITobJlPzI44jj+4tHnEKNt0xXWSVlXRN9X1Iw=
-github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gocql/gocql v0.0.0-20190301043612-f6df8288f9b4/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
-github.com/gofrs/flock v0.7.1 h1:DP+LD/t0njgoPBvT5MJLeliUIVQR03hiKR6vezdwHlc=
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -492,7 +486,6 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.7.7/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
@@ -525,17 +518,13 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALr
 github.com/karrick/godirwalk v1.10.12/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
-github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -576,7 +565,6 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.6/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
-github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -597,7 +585,6 @@ github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
@@ -785,7 +772,6 @@ github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvH
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
@@ -804,7 +790,6 @@ github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
-github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
@@ -820,7 +805,6 @@ github.com/spf13/viper v1.6.1 h1:VPZzIkznI1YhVMRi6vNFLHSwhnhReBfgTxIPccpfdZk=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -1094,7 +1078,6 @@ golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e h1:qCZ8SbsZMjT0OuDPCEBxgLZic4NMj8Gj4vNXiTVRAaA=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770 h1:M9Fif0OxNji8w+HvmhVQ8KJtiZOsjU9RgslJGhn95XE=
 golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -1158,7 +1141,6 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1204,7 +1186,6 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -58,6 +58,9 @@ const (
 
 	// varMailgunSenderEmail specifies the host operator mailgun senders email
 	varMailgunSenderEmail = "mailgun.sender.email"
+
+	// varRegistrationServiceURL is the URL used to access the registration service
+	varRegistrationServiceURL = "registration.service.url"
 )
 
 // Config encapsulates the Viper configuration registry which stores the
@@ -129,6 +132,7 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(VarDurationBeforeChangeRequestDeletion, "24h")
 	c.host.SetDefault(varNotificationDeliveryService, NotificationDeliveryServiceMailgun)
 	c.host.SetDefault(varDurationBeforeNotificationDeletion, "24h")
+	c.host.SetDefault(varRegistrationServiceURL, "https://registration.crt-placeholder.com")
 }
 
 // GetDurationBeforeChangeRequestDeletion returns the timeout before a complete TierChangeRequest will be deleted.
@@ -159,6 +163,11 @@ func (c *Config) GetMailgunAPIKey() string {
 // GetMailgunSenderEmail returns the host operator mailgun sender's email address
 func (c *Config) GetMailgunSenderEmail() string {
 	return c.host.GetString(varMailgunSenderEmail)
+}
+
+// GetRegistrationServiceURL returns the URL of the registration service
+func (c *Config) GetRegistrationServiceURL() string {
+	return c.host.GetString(varRegistrationServiceURL)
 }
 
 // GetAllRegistrationServiceParameters returns the map with key-values pairs of parameters that have REGISTRATION_SERVICE prefix

--- a/pkg/controller/notification/mailgun_notification_delivery_service.go
+++ b/pkg/controller/notification/mailgun_notification_delivery_service.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/mailgun/mailgun-go/v4"
 	"time"
+
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 type MailgunDeliveryError struct {

--- a/pkg/controller/notification/mailgun_notification_delivery_service.go
+++ b/pkg/controller/notification/mailgun_notification_delivery_service.go
@@ -82,7 +82,8 @@ func (s *MailgunNotificationDeliveryService) Send(ctx context.Context, notificat
 	}
 
 	// The message object allows you to add attachments and Bcc recipients
-	message := s.Mailgun.NewMessage(s.SenderEmail, subject, body, notificationCtx.FullEmailAddress())
+	message := s.Mailgun.NewMessage(s.SenderEmail, subject, "", notificationCtx.FullEmailAddress())
+	message.SetHtml(body)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()

--- a/pkg/controller/notification/mailgun_notification_delivery_service_test.go
+++ b/pkg/controller/notification/mailgun_notification_delivery_service_test.go
@@ -31,7 +31,7 @@ func TestMailgunNotificationDeliveryService(t *testing.T) {
 		UserID:      "jsmith123",
 		FirstName:   "John",
 		LastName:    "Smith",
-		Email:       "jsmith@redhat.com",
+		UserEmail:   "jsmith@redhat.com",
 		CompanyName: "Red Hat",
 	}
 

--- a/pkg/controller/notification/notification_context.go
+++ b/pkg/controller/notification/notification_context.go
@@ -2,9 +2,12 @@ package notification
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -45,9 +48,10 @@ func NewNotificationContext(client client.Client, userID, namespace string, conf
 		notificationCtx.UserEmail = emailLbl
 	}
 
-	if config != nil {
-		notificationCtx.RegistrationURL = config.GetRegistrationServiceURL()
+	if config == nil {
+		return nil, errors.New("configuration was not provided")
 	}
+	notificationCtx.RegistrationURL = config.GetRegistrationServiceURL()
 
 	return notificationCtx, nil
 }

--- a/pkg/controller/notification/notification_context_test.go
+++ b/pkg/controller/notification/notification_context_test.go
@@ -3,8 +3,11 @@ package notification
 import (
 	"crypto/md5"
 	"encoding/hex"
-	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
@@ -64,11 +67,20 @@ func TestNotificationContext(t *testing.T) {
 
 	t.Run("full email address", func(t *testing.T) {
 		// when
-		notificationCtx, err := NewNotificationContext(client, userSignup.Name, operatorNamespace, nil)
+		notificationCtx, err := NewNotificationContext(client, userSignup.Name, operatorNamespace, config)
 
 		// then
 		require.NoError(t, err)
 		require.Equal(t, "John Smith<jsmith@redhat.com>", notificationCtx.FullEmailAddress())
+	})
+
+	t.Run("no configuration provided", func(t *testing.T) {
+		// when
+		_, err := NewNotificationContext(client, userSignup.Name, operatorNamespace, nil)
+
+		// then
+		require.Error(t, err)
+		assert.Equal(t, "configuration was not provided", err.Error())
 	})
 }
 

--- a/pkg/controller/notification/notification_controller.go
+++ b/pkg/controller/notification/notification_controller.go
@@ -119,6 +119,7 @@ func (r *ReconcileNotification) Reconcile(request reconcile.Request) (reconcile.
 			r.setStatusNotificationContextError, err, "failed to create notification context")
 	}
 
+	// if the environment is set to e2e do not attempt sending via mailgun
 	if r.config.GetEnvironment() != "e2e-tests" {
 		// Send the notification via the configured delivery service
 		err = r.deliveryService.Send(context.Background(), notCtx, notification.Spec.Template)

--- a/pkg/controller/notification/notification_controller.go
+++ b/pkg/controller/notification/notification_controller.go
@@ -162,8 +162,10 @@ func (r *ReconcileNotification) checkTransitionTimeAndDelete(log logr.Logger, no
 	return false, diff, nil
 }
 
+type statusUpdater func(notification *toolchainv1alpha1.Notification, message string) error
+
 func (r *ReconcileNotification) wrapErrorWithStatusUpdate(logger logr.Logger, notification *toolchainv1alpha1.Notification,
-	statusUpdater func(notification *toolchainv1alpha1.Notification, message string) error, err error, format string, args ...interface{}) error {
+	statusUpdater statusUpdater, err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
@@ -228,7 +230,7 @@ func (r *ReconcileNotification) setStatusNotificationSent(notification *toolchai
 }
 
 func (r *ReconcileNotification) updateStatus(logger logr.Logger, notification *toolchainv1alpha1.Notification,
-	statusUpdater func(notification *toolchainv1alpha1.Notification, msg string) error) error {
+	statusUpdater statusUpdater) error {
 
 	if err := statusUpdater(notification, ""); err != nil {
 		logger.Error(err, "status update failed")

--- a/pkg/controller/notification/notification_controller.go
+++ b/pkg/controller/notification/notification_controller.go
@@ -127,9 +127,11 @@ func (r *ReconcileNotification) Reconcile(request reconcile.Request) (reconcile.
 			return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, notification,
 				r.setStatusNotificationDeliveryError, err, "failed to send notification")
 		}
+		reqLogger.Info("Notification has been sent")
+	} else {
+		reqLogger.Info("Notification has been skipped")
 	}
 
-	reqLogger.Info("Notification has been sent")
 	return reconcile.Result{
 		Requeue:      true,
 		RequeueAfter: r.config.GetDurationBeforeNotificationDeletion(),

--- a/pkg/controller/notification/notification_controller.go
+++ b/pkg/controller/notification/notification_controller.go
@@ -119,11 +119,13 @@ func (r *ReconcileNotification) Reconcile(request reconcile.Request) (reconcile.
 			r.setStatusNotificationContextError, err, "failed to create notification context")
 	}
 
-	// Send the notification via the configured delivery service
-	err = r.deliveryService.Send(context.Background(), notCtx, notification.Spec.Template)
-	if err != nil {
-		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, notification,
-			r.setStatusNotificationDeliveryError, err, "failed to send notification")
+	if r.config.GetEnvironment() != "e2e-tests" {
+		// Send the notification via the configured delivery service
+		err = r.deliveryService.Send(context.Background(), notCtx, notification.Spec.Template)
+		if err != nil {
+			return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, notification,
+				r.setStatusNotificationDeliveryError, err, "failed to send notification")
+		}
 	}
 
 	reqLogger.Info("Notification has been sent")

--- a/pkg/controller/notification/notification_controller.go
+++ b/pkg/controller/notification/notification_controller.go
@@ -113,7 +113,7 @@ func (r *ReconcileNotification) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	// Send the notification - first create the notification context
-	notCtx, err := NewNotificationContext(r.client, notification.Spec.UserID, request.Namespace)
+	notCtx, err := NewNotificationContext(r.client, notification.Spec.UserID, request.Namespace, r.config)
 	if err != nil {
 		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, notification,
 			r.setStatusNotificationContextError, err, "failed to create notification context")
@@ -123,7 +123,7 @@ func (r *ReconcileNotification) Reconcile(request reconcile.Request) (reconcile.
 	err = r.deliveryService.Send(context.Background(), notCtx, notification.Spec.Template)
 	if err != nil {
 		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, notification,
-			r.setStatusNotificationDeliveryError, err, "failed to deliver notification")
+			r.setStatusNotificationDeliveryError, err, "failed to send notification")
 	}
 
 	reqLogger.Info("Notification has been sent")

--- a/pkg/controller/notification/notification_controller.go
+++ b/pkg/controller/notification/notification_controller.go
@@ -137,7 +137,9 @@ func (r *ReconcileNotification) Reconcile(request reconcile.Request) (reconcile.
 // the duration before the notification should be deleted. If so, the notification is deleted.
 // Returns bool indicating if the notification was deleted, the time before the notification
 // can be deleted and error
-func (r *ReconcileNotification) checkTransitionTimeAndDelete(log logr.Logger, notification *toolchainv1alpha1.Notification, completeCond toolchainv1alpha1.Condition) (bool, time.Duration, error) {
+func (r *ReconcileNotification) checkTransitionTimeAndDelete(log logr.Logger, notification *toolchainv1alpha1.Notification,
+	completeCond toolchainv1alpha1.Condition) (bool, time.Duration, error) {
+
 	log.Info("the Notification is sent so we can deal with its deletion")
 	timeSinceCompletion := time.Since(completeCond.LastTransitionTime.Time)
 
@@ -155,7 +157,8 @@ func (r *ReconcileNotification) checkTransitionTimeAndDelete(log logr.Logger, no
 	return false, diff, nil
 }
 
-func (r *ReconcileNotification) wrapErrorWithStatusUpdate(logger logr.Logger, notification *toolchainv1alpha1.Notification, statusUpdater func(notification *toolchainv1alpha1.Notification, message string) error, err error, format string, args ...interface{}) error {
+func (r *ReconcileNotification) wrapErrorWithStatusUpdate(logger logr.Logger, notification *toolchainv1alpha1.Notification,
+	statusUpdater func(notification *toolchainv1alpha1.Notification, message string) error, err error, format string, args ...interface{}) error {
 	if err == nil {
 		return nil
 	}
@@ -220,7 +223,7 @@ func (r *ReconcileNotification) setStatusNotificationSent(notification *toolchai
 }
 
 func (r *ReconcileNotification) updateStatus(logger logr.Logger, notification *toolchainv1alpha1.Notification,
-	statusUpdater func(notification *toolchainv1alpha1.Notification, message string) error) error {
+	statusUpdater func(notification *toolchainv1alpha1.Notification, msg string) error) error {
 
 	if err := statusUpdater(notification, ""); err != nil {
 		logger.Error(err, "status update failed")

--- a/pkg/controller/notification/notification_controller_test.go
+++ b/pkg/controller/notification/notification_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/codeready-toolchain/host-operator/pkg/templates/notificationtemplates"
+	ntest "github.com/codeready-toolchain/host-operator/test/notification"
 	"github.com/mailgun/mailgun-go/v4"
 	events2 "github.com/mailgun/mailgun-go/v4/events"
 	"k8s.io/apimachinery/pkg/types"
@@ -45,7 +46,7 @@ func TestNotificationSuccess(t *testing.T) {
 	t.Run("will not do anything and return requeue with shorter duration that 10s", func(t *testing.T) {
 		// given
 		notification := newNotification("jane", "")
-		notification.Status.Conditions = []v1alpha1.Condition{toBeSent()}
+		notification.Status.Conditions = []v1alpha1.Condition{sentCond()}
 		ds, _ := mockDeliveryService(defaultTemplateLoader())
 		controller, request, cl := newController(t, notification, ds)
 
@@ -57,13 +58,14 @@ func TestNotificationSuccess(t *testing.T) {
 		assert.True(t, result.Requeue)
 		assert.True(t, result.RequeueAfter < cast.ToDuration("10s"))
 		assert.True(t, result.RequeueAfter > cast.ToDuration("1s"))
-		AssertThatNotificationHasCondition(t, cl, notification.Name, toBeSent())
+		ntest.AssertThatNotification(t, notification.Name, cl).
+			HasConditions(sentCond())
 	})
 
 	t.Run("sent notification deleted when deletion timeout passed", func(t *testing.T) {
 		// given
 		notification := newNotification("jane", "")
-		notification.Status.Conditions = []v1alpha1.Condition{toBeSent()}
+		notification.Status.Conditions = []v1alpha1.Condition{sentCond()}
 		notification.Status.Conditions[0].LastTransitionTime = v1.Time{Time: time.Now().Add(-cast.ToDuration("10s"))}
 		ds, _ := mockDeliveryService(defaultTemplateLoader())
 		controller, request, cl := newController(t, notification, ds)
@@ -85,7 +87,7 @@ func TestNotificationSentFailure(t *testing.T) {
 	t.Run("will return an error since it cannot delete the Notification after successfully sending", func(t *testing.T) {
 		// given
 		notification := newNotification("abc123", "")
-		notification.Status.Conditions = []v1alpha1.Condition{toBeSent()}
+		notification.Status.Conditions = []v1alpha1.Condition{sentCond()}
 		notification.Status.Conditions[0].LastTransitionTime = v1.Time{Time: time.Now().Add(-cast.ToDuration("10s"))}
 
 		ds, _ := mockDeliveryService(defaultTemplateLoader())
@@ -101,8 +103,8 @@ func TestNotificationSentFailure(t *testing.T) {
 		require.Error(t, err)
 		require.False(t, result.Requeue)
 		assert.Equal(t, err.Error(), "failed to delete notification: unable to delete Notification object 'notification-name': error")
-
-		AssertThatNotificationHasCondition(t, cl, notification.Name, toBeSent(), toBeDeletionError("unable to delete Notification object 'notification-name': error"))
+		ntest.AssertThatNotification(t, notification.Name, cl).
+			HasConditions(sentCond(), deletionCond("unable to delete Notification object 'notification-name': error"))
 	})
 }
 
@@ -199,13 +201,8 @@ func TestNotificationDelivery(t *testing.T) {
 		err = client.Get(context.TODO(), key, instance)
 		require.NoError(t, err)
 
-		test.AssertConditionsMatch(t, instance.Status.Conditions,
-			v1alpha1.Condition{
-				Type:   v1alpha1.NotificationSent,
-				Status: corev1.ConditionTrue,
-				Reason: v1alpha1.NotificationSentReason,
-			},
-		)
+		ntest.AssertThatNotification(t, instance.Name, client).
+			HasConditions(sentCond())
 	})
 
 	t.Run("test notification delivery fails for invalid user ID", func(t *testing.T) {
@@ -230,14 +227,8 @@ func TestNotificationDelivery(t *testing.T) {
 		err = client.Get(context.TODO(), key, instance)
 		require.NoError(t, err)
 
-		test.AssertConditionsMatch(t, instance.Status.Conditions,
-			v1alpha1.Condition{
-				Type:    v1alpha1.NotificationSent,
-				Status:  corev1.ConditionFalse,
-				Reason:  v1alpha1.NotificationContextErrorReason,
-				Message: "usersignups.toolchain.dev.openshift.com \"abc123\" not found",
-			},
-		)
+		ntest.AssertThatNotification(t, instance.Name, client).
+			HasConditions(contextErrorCond("usersignups.toolchain.dev.openshift.com \"abc123\" not found"))
 
 	})
 
@@ -273,15 +264,8 @@ func TestNotificationDelivery(t *testing.T) {
 		err = client.Get(context.TODO(), key, instance)
 		require.NoError(t, err)
 
-		test.AssertConditionsMatch(t, instance.Status.Conditions,
-			v1alpha1.Condition{
-				Type:    v1alpha1.NotificationSent,
-				Status:  corev1.ConditionFalse,
-				Reason:  v1alpha1.NotificationDeliveryErrorReason,
-				Message: "delivery error",
-			},
-		)
-
+		ntest.AssertThatNotification(t, instance.Name, client).
+			HasConditions(deliveryErrorCond("delivery error"))
 	})
 }
 
@@ -313,14 +297,7 @@ func AssertThatNotificationIsDeleted(t *testing.T, cl client.Client, name string
 	assert.IsType(t, v1.StatusReasonNotFound, apierrors.ReasonForError(err))
 }
 
-func AssertThatNotificationHasCondition(t *testing.T, cl client.Client, name string, condition ...v1alpha1.Condition) {
-	notification := &v1alpha1.Notification{}
-	err := cl.Get(context.TODO(), test.NamespacedName(test.HostOperatorNs, name), notification)
-	require.NoError(t, err)
-	test.AssertConditionsMatch(t, notification.Status.Conditions, condition...)
-}
-
-func toBeSent() v1alpha1.Condition {
+func sentCond() v1alpha1.Condition {
 	return v1alpha1.Condition{
 		Type:               v1alpha1.NotificationSent,
 		Status:             apiv1.ConditionTrue,
@@ -329,7 +306,25 @@ func toBeSent() v1alpha1.Condition {
 	}
 }
 
-func toBeDeletionError(msg string) v1alpha1.Condition {
+func deliveryErrorCond(msg string) v1alpha1.Condition {
+	return v1alpha1.Condition{
+		Type:    v1alpha1.NotificationSent,
+		Status:  corev1.ConditionFalse,
+		Reason:  v1alpha1.NotificationDeliveryErrorReason,
+		Message: msg,
+	}
+}
+
+func contextErrorCond(msg string) v1alpha1.Condition {
+	return v1alpha1.Condition{
+		Type:    v1alpha1.NotificationSent,
+		Status:  corev1.ConditionFalse,
+		Reason:  v1alpha1.NotificationContextErrorReason,
+		Message: msg,
+	}
+}
+
+func deletionCond(msg string) v1alpha1.Condition {
 	return v1alpha1.Condition{
 		Type:               v1alpha1.NotificationDeletionError,
 		Status:             apiv1.ConditionTrue,

--- a/pkg/controller/notification/notification_controller_test.go
+++ b/pkg/controller/notification/notification_controller_test.go
@@ -95,10 +95,11 @@ func TestNotificationSentFailure(t *testing.T) {
 		}
 
 		// when
-		_, err := controller.Reconcile(request)
+		result, err := controller.Reconcile(request)
 
 		// then
 		require.Error(t, err)
+		require.False(t, result.Requeue)
 		assert.Equal(t, err.Error(), "failed to delete notification: unable to delete Notification object 'notification-name': error")
 
 		AssertThatNotificationHasCondition(t, cl, notification.Name, toBeSent(), toBeDeletionError("unable to delete Notification object 'notification-name': error"))
@@ -127,10 +128,11 @@ func TestNotificationDelivery(t *testing.T) {
 		controller, request, client := newController(t, notification, ds, userSignup)
 
 		// when
-		_, err := controller.Reconcile(request)
+		result, err := controller.Reconcile(request)
 
 		// then
 		require.NoError(t, err)
+		require.True(t, result.Requeue)
 
 		// Load the reconciled notification
 		key := types.NamespacedName{
@@ -182,10 +184,11 @@ func TestNotificationDelivery(t *testing.T) {
 		controller, request, client := newController(t, notification, nil, userSignup)
 
 		// when
-		_, err := controller.Reconcile(request)
+		result, err := controller.Reconcile(request)
 
 		// then
 		require.NoError(t, err)
+		require.True(t, result.Requeue)
 
 		// Load the reconciled notification
 		key := types.NamespacedName{
@@ -211,10 +214,11 @@ func TestNotificationDelivery(t *testing.T) {
 		controller, request, client := newController(t, notification, ds)
 
 		// when
-		_, err := controller.Reconcile(request)
+		result, err := controller.Reconcile(request)
 
 		// then
 		require.Error(t, err)
+		require.False(t, result.Requeue)
 		require.Equal(t, "failed to create notification context: usersignups.toolchain.dev.openshift.com \"abc123\" not found", err.Error())
 
 		// Load the reconciled notification
@@ -253,10 +257,11 @@ func TestNotificationDelivery(t *testing.T) {
 		controller, request, client := newController(t, notification, mds, userSignup)
 
 		// when
-		_, err := controller.Reconcile(request)
+		result, err := controller.Reconcile(request)
 
 		// then
 		require.Error(t, err)
+		require.False(t, result.Requeue)
 		require.Equal(t, "failed to send notification: delivery error", err.Error())
 
 		// Load the reconciled notification

--- a/pkg/controller/notification/notification_delivery_service_test.go
+++ b/pkg/controller/notification/notification_delivery_service_test.go
@@ -109,7 +109,7 @@ func TestBaseNotificationDeliveryServiceGenerateContent(t *testing.T) {
 		UserID:      "jsmith",
 		FirstName:   "John",
 		LastName:    "Smith",
-		Email:       "jsmith@redhat.com",
+		UserEmail:   "jsmith@redhat.com",
 		CompanyName: "Red Hat",
 	}
 
@@ -135,7 +135,7 @@ func TestBaseNotificationDeliveryServiceGenerateContent(t *testing.T) {
 
 	t.Run("test content generation with notification context for full email", func(t *testing.T) {
 		// when
-		def := "{{.FirstName}} {{.LastName}}<{{.Email}}>"
+		def := "{{.FirstName}} {{.LastName}}<{{.UserEmail}}>"
 		content, err := baseService.GenerateContent(nCtx, def)
 
 		// then

--- a/test/notification/assertion.go
+++ b/test/notification/assertion.go
@@ -1,0 +1,41 @@
+package notification
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Assertion struct {
+	notification   *toolchainv1alpha1.Notification
+	client         client.Client
+	namespacedName types.NamespacedName
+	t              test.T
+}
+
+func (a *Assertion) loadNotificationAssertion() error {
+	notification := &toolchainv1alpha1.Notification{}
+	err := a.client.Get(context.TODO(), a.namespacedName, notification)
+	a.notification = notification
+	return err
+}
+
+func AssertThatNotification(t test.T, name string, client client.Client) *Assertion {
+	return &Assertion{
+		client:         client,
+		namespacedName: test.NamespacedName(test.HostOperatorNs, name),
+		t:              t,
+	}
+}
+
+func (a *Assertion) HasConditions(expected ...toolchainv1alpha1.Condition) *Assertion {
+	err := a.loadNotificationAssertion()
+	require.NoError(a.t, err)
+	test.AssertConditionsMatch(a.t, a.notification.Status.Conditions, expected...)
+	return a
+}


### PR DESCRIPTION
This PR implements notification delivery within the notification controller.  The `newReconciler()` function now creates a new notification delivery service factory which uses the configuration to determine which type of delivery service to create.  Currently we support **mailgun** (for production use) and **mock** (for testing).  Depending on which is configured, the delivery service will be created as part of the NotificationReconciler.

Fixes https://issues.redhat.com/browse/CRT-678