### PR TITLE
fixing string replace to handle . and -

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -114,7 +114,7 @@ func loadFromSecret(cl client.Client) error {
 
 	// get secrets and set environment variables
 	for key, value := range secret.Data {
-		secretKey := HostEnvPrefix + "_" + (strings.ToUpper(strings.ReplaceAll(key, "-", "_")))
+		secretKey := HostEnvPrefix + "_" + (strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, ".", "_"), "-", "_")))
 		err = os.Setenv(secretKey, string(value))
 		if err != nil {
 			return err

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -1,6 +1,7 @@
 package configuration_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
@@ -81,9 +82,9 @@ func TestLoadFromSecret(t *testing.T) {
 				Namespace: "toolchain-host-operator",
 			},
 			Data: map[string][]byte{
-				"mailgun-domain":       []byte("test-domain"),
+				"mailgun.domain":       []byte("test-domain"),
 				"mailgun-api-key":      []byte("test-api-key"),
-				"mailgun-sender-email": []byte("test-sender-email"),
+				"mailgun-sender.email": []byte("test-sender-email"),
 			},
 		}
 
@@ -97,6 +98,14 @@ func TestLoadFromSecret(t *testing.T) {
 		assert.Equal(t, "test-domain", config.GetMailgunDomain())
 		assert.Equal(t, "test-api-key", config.GetMailgunAPIKey())
 		assert.Equal(t, "test-sender-email", config.GetMailgunSenderEmail())
+
+		// test env vars are parsed and created correctly
+		apiKey := os.Getenv("HOST_OPERATOR_MAILGUN_API_KEY")
+		assert.Equal(t, apiKey, "test-api-key")
+		domain := os.Getenv("HOST_OPERATOR_MAILGUN_DOMAIN")
+		assert.Equal(t, domain, "test-domain")
+		senderEmail := os.Getenv("HOST_OPERATOR_MAILGUN_SENDER_EMAIL")
+		assert.Equal(t, senderEmail, "test-sender-email")
 	})
 
 	t.Run("secret not found", func(t *testing.T) {


### PR DESCRIPTION
Currently secret env vars are not properly created. The code replaces "-" instead of "." causing env var names such as `HOST_OPERATOR_MAILGUN.DOMAIN." Instead this should be `HOST_OPERATOR_MAILGUN_DOMAIN`

This PR is to handle replacing both "." and "-" with "_"