### PR TITLE
adding environment variable

### DIFF
--- a/deploy/env/e2e-tests.yaml
+++ b/deploy/env/e2e-tests.yaml
@@ -15,3 +15,4 @@ registration-service:
 host-operator:
   duration-before-change-request-deletion: '5s'
   duration-before-notification-deletion: '5s'
+  environment: 'e2e-tests'

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -61,6 +61,9 @@ const (
 
 	// varRegistrationServiceURL is the URL used to access the registration service
 	varRegistrationServiceURL = "registration.service.url"
+
+	// varEnvironment specifies the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
+	varEnvironment = "environment"
 )
 
 // Config encapsulates the Viper configuration registry which stores the
@@ -187,6 +190,7 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varNotificationDeliveryService, NotificationDeliveryServiceMailgun)
 	c.host.SetDefault(varDurationBeforeNotificationDeletion, "24h")
 	c.host.SetDefault(varRegistrationServiceURL, "https://registration.crt-placeholder.com")
+	c.host.SetDefault(varEnvironment, "dev")
 }
 
 // GetDurationBeforeChangeRequestDeletion returns the timeout before a complete TierChangeRequest will be deleted.
@@ -222,6 +226,11 @@ func (c *Config) GetMailgunSenderEmail() string {
 // GetRegistrationServiceURL returns the URL of the registration service
 func (c *Config) GetRegistrationServiceURL() string {
 	return c.host.GetString(varRegistrationServiceURL)
+}
+
+// GetEnvironment returns the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
+func (c *Config) GetEnvironment() string {
+	return c.host.GetString(varEnvironment)
 }
 
 // GetAllRegistrationServiceParameters returns the map with key-values pairs of parameters that have REGISTRATION_SERVICE prefix

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -27,8 +27,12 @@ const (
 
 // host-operator constants
 const (
-	// VarDurationBeforeChangeRequestDeletion specificies the duration before a change request is deleted
+
+	// VarDurationBeforeChangeRequestDeletion specifies the duration before a change request is deleted
 	VarDurationBeforeChangeRequestDeletion = "duration.before.change.request.deletion"
+
+	// defaultDurationBeforeDeletion is the time before a resource is deleted
+	defaultDurationBeforeDeletion = "24h"
 
 	// ToolchainConfigMapUserApprovalPolicy is a key for a user approval policy that should be used
 	ToolchainConfigMapUserApprovalPolicy = "user-approval-policy"
@@ -45,6 +49,7 @@ const (
 	// NotificationDeliveryServiceMailgun is the notification delivery service to use during production
 	NotificationDeliveryServiceMailgun = "mailgun"
 
+	// varNotificationDeliveryService specifies the duration before a notification is deleted
 	varNotificationDeliveryService = "notification.delivery.service"
 
 	// varDurationBeforeNotificationDeletion specifies the duration before a notification will be deleted
@@ -62,8 +67,14 @@ const (
 	// varRegistrationServiceURL is the URL used to access the registration service
 	varRegistrationServiceURL = "registration.service.url"
 
+	// defaultRegistrationServiceURL is the default location of the registration service
+	defaultRegistrationServiceURL = "https://registration.crt-placeholder.com"
+
 	// varEnvironment specifies the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
 	varEnvironment = "environment"
+
+	// defaultEnvironment is the default host-operator environment
+	defaultEnvironment = "prod"
 )
 
 // Config encapsulates the Viper configuration registry which stores the
@@ -186,11 +197,11 @@ func createHostEnvVarKey(key string) string {
 
 func (c *Config) setConfigDefaults() {
 	c.host.SetTypeByDefaultValue(true)
-	c.host.SetDefault(VarDurationBeforeChangeRequestDeletion, "24h")
+	c.host.SetDefault(VarDurationBeforeChangeRequestDeletion, defaultDurationBeforeDeletion)
 	c.host.SetDefault(varNotificationDeliveryService, NotificationDeliveryServiceMailgun)
-	c.host.SetDefault(varDurationBeforeNotificationDeletion, "24h")
-	c.host.SetDefault(varRegistrationServiceURL, "https://registration.crt-placeholder.com")
-	c.host.SetDefault(varEnvironment, "dev")
+	c.host.SetDefault(varDurationBeforeNotificationDeletion, defaultDurationBeforeDeletion)
+	c.host.SetDefault(varRegistrationServiceURL, defaultRegistrationServiceURL)
+	c.host.SetDefault(varEnvironment, defaultEnvironment)
 }
 
 // GetDurationBeforeChangeRequestDeletion returns the timeout before a complete TierChangeRequest will be deleted.

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -61,11 +61,18 @@ func TestGetAllRegistrationServiceParameters(t *testing.T) {
 }
 
 func TestEnvironment(t *testing.T) {
-	restore := test.SetEnvVarAndRestore(t, "HOST_OPERATOR_ENVIRONMENT", "e2e-test")
-	defer restore()
+	t.Run("default", func(t *testing.T) {
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, "prod", config.GetEnvironment())
+	})
 
-	config := getDefaultConfiguration(t)
-	assert.Equal(t, "e2e-test", config.GetEnvironment())
+	t.Run("env overwrite", func(t *testing.T) {
+		restore := test.SetEnvVarAndRestore(t, "HOST_OPERATOR_ENVIRONMENT", "e2e-test")
+		defer restore()
+
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, "e2e-test", config.GetEnvironment())
+	})
 }
 
 func TestLoadFromSecret(t *testing.T) {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -60,6 +60,14 @@ func TestGetAllRegistrationServiceParameters(t *testing.T) {
 	})
 }
 
+func TestEnvironment(t *testing.T) {
+	restore := test.SetEnvVarAndRestore(t, "HOST_OPERATOR_ENVIRONMENT", "e2e-test")
+	defer restore()
+
+	config := getDefaultConfiguration(t)
+	assert.Equal(t, "e2e-test", config.GetEnvironment())
+}
+
 func TestLoadFromSecret(t *testing.T) {
 	restore := test.SetEnvVarAndRestore(t, "WATCH_NAMESPACE", "toolchain-host-operator")
 	defer restore()


### PR DESCRIPTION
Adding environment variable for host-operator in order to help write end-to-end tests for the notification service.

This env var will be used to determine whether or not we should even attempt sending a notification depending on the environment. In the e2e-environment it is not easily possible to test the notification service. Since we cannot expose the secret for end-to-end tests and setting up a mock server is not as easily do-able, we can instead set up an environment variable. If the environment variable is set to `e2e` then we will bypass sending the notification via mailgun and proceed onwards to set the notification status to `sent` and verify that the notification is deleted after the deletion timestamp has elapsed. 