### PR TITLE
Allow access to cluster scoped toolchain resources

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -16,3 +16,9 @@ rules:
   verbs:
   - "get"
   - "create"
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - "*"
+  verbs:
+  - "*"

--- a/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
@@ -269,6 +269,12 @@ spec:
           verbs:
           - get
           - create
+        - apiGroups:
+          - toolchain.dev.openshift.com
+          resources:
+          - '*'
+          verbs:
+          - '*'
         serviceAccountName: host-operator
       deployments:
       - name: host-operator
@@ -358,12 +364,6 @@ spec:
           - kubefedclusters/status
           verbs:
           - update
-        - apiGroups:
-          - toolchain.dev.openshift.com
-          resources:
-          - '*'
-          verbs:
-          - '*'
         - apiGroups:
           - rbac.authorization.k8s.io
           - authorization.openshift.io

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -56,12 +56,6 @@ rules:
   verbs:
   - "update"
 - apiGroups:
-  - toolchain.dev.openshift.com
-  resources:
-  - "*"
-  verbs:
-  - "*"
-- apiGroups:
   - rbac.authorization.k8s.io
   - authorization.openshift.io
   resources:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -2036,6 +2036,12 @@ data:
                 verbs:
                 - get
                 - create
+              - apiGroups:
+                - toolchain.dev.openshift.com
+                resources:
+                - '*'
+                verbs:
+                - '*'
               serviceAccountName: host-operator
             deployments:
             - name: host-operator
@@ -2125,12 +2131,6 @@ data:
                 - kubefedclusters/status
                 verbs:
                 - update
-              - apiGroups:
-                - toolchain.dev.openshift.com
-                resources:
-                - '*'
-                verbs:
-                - '*'
               - apiGroups:
                 - rbac.authorization.k8s.io
                 - authorization.openshift.io


### PR DESCRIPTION
Since Idler is cluster scoped we need to move toolchain from role.yaml to cluster-role.yaml.
It should fix errors like this in hosted toolchain log: 
```
Failed to list *unstructured.Unstructured: idlers.toolchain.dev.openshift.com is forbidden: User "system:serviceaccount:xcoulon-host-17145616:host-operator" cannot list resource "idlers" in API group "toolchain.dev.openshift.com" at the cluster scope
```