### PR TITLE
Fix no members case in toolchainstatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200717175027-3b8c7e68e409
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd h1:G54EWvJPeJer/p07NuKKMYmXKscSnQcRMTH63AzWN+w=
 github.com/codeready-toolchain/api v0.0.0-20200715195555-28ba37e37ddd/go.mod h1:uh4hKem1mo1TE66qtuA5ZV3orpsKJNufWCSE0uPSES8=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d h1:N9CxG2CBZk4JQsFR5lI96Km0dNBNIgxBWlCRB/UooB0=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200715201956-5cea174a453d/go.mod h1:IC9kx4UmJCII7dEmH2ChvgGYcmZ/o9P6F/b89UvEHOw=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200717175027-3b8c7e68e409 h1:bJKnAvg4FCeWfQWI3Yacngi1TvdsMAKH6bF7wxF1mEk=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200717175027-3b8c7e68e409/go.mod h1:IC9kx4UmJCII7dEmH2ChvgGYcmZ/o9P6F/b89UvEHOw=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller.go
@@ -255,6 +255,7 @@ func (r *ReconcileToolchainStatus) membersHandleStatus(reqLogger logr.Logger, to
 			MemberStatus: memberStatus,
 		}
 		members = append(members, noMemberClusterStatus)
+		toolchainStatus.Status.Members = members
 		return err
 	}
 	for _, cluster := range memberClusters {
@@ -395,8 +396,8 @@ func (s regServiceSubstatusHandler) addRegistrationServiceHealthStatus(reqLogger
 	}
 
 	// bad response
-	if resp.StatusCode != http.StatusOK || resp.Body == nil {
-		err = errs.Wrap(fmt.Errorf("bad response from registration service: %+v", resp), errMsgRegistrationServiceNotReady)
+	if resp.StatusCode != http.StatusOK {
+		err = errs.Wrap(fmt.Errorf("bad response from %s : statusCode=%d", registrationServiceHealthURL, resp.StatusCode), errMsgRegistrationServiceNotReady)
 		errCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusRegServiceNotReadyReason, err.Error())
 		toolchainStatus.Status.RegistrationService.Health.Conditions = []toolchainv1alpha1.Condition{*errCondition}
 		return err

--- a/test/toolchainstatus_assertions.go
+++ b/test/toolchainstatus_assertions.go
@@ -46,10 +46,24 @@ func (a *ToolchainStatusAssertion) HasCondition(expected toolchainv1alpha1.Condi
 	return a
 }
 
-func (a *ToolchainStatusAssertion) HasHostOperatorConditionErrorMsg(expected string) *ToolchainStatusAssertion {
+func (a *ToolchainStatusAssertion) HasHostOperatorStatus(expected toolchainv1alpha1.HostOperatorStatus) *ToolchainStatusAssertion {
 	err := a.loadToolchainStatus()
 	require.NoError(a.t, err)
-	require.Len(a.t, a.toolchainStatus.Status.HostOperator.Conditions, 1)
-	require.Equal(a.t, expected, a.toolchainStatus.Status.HostOperator.Conditions[0].Message)
+	require.NotNil(a.t, *a.toolchainStatus.Status.HostOperator)
+	test.AssertHostOperatorStatusMatch(a.t, *a.toolchainStatus.Status.HostOperator, expected)
+	return a
+}
+
+func (a *ToolchainStatusAssertion) HasMemberStatus(expected toolchainv1alpha1.Member) *ToolchainStatusAssertion {
+	err := a.loadToolchainStatus()
+	require.NoError(a.t, err)
+	test.AssertMembersMatch(a.t, a.toolchainStatus.Status.Members, expected)
+	return a
+}
+
+func (a *ToolchainStatusAssertion) HasRegistrationServiceStatus(expected toolchainv1alpha1.HostRegistrationServiceStatus) *ToolchainStatusAssertion {
+	err := a.loadToolchainStatus()
+	require.NoError(a.t, err)
+	test.AssertRegistrationServiceStatusMatch(a.t, *a.toolchainStatus.Status.RegistrationService, expected)
 	return a
 }


### PR DESCRIPTION
If there is a problem with a member cluster it may not be listed in the the cluster cache. In the toolchainstatus code it falls under the no member clusters found case. In this case the status object is being created but it is not being added to the toolchainstatus. The fix is simply to add it to the toolchainstatus. Also, the unit tests were only checking the overall status only, they should be updated to check the individual component statuses as well.

Related issue: https://issues.redhat.com/browse/CRT-731