### PR TITLE
using configuration for console and che routes and namespaces

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -281,11 +281,13 @@ func printConfig(cfg *configuration.Config) {
 	}
 	logWithValuesRegServ.Info("Registration Service configuration variables:")
 
-	logWithValuesHost := log.WithValues(
+	logWithValuesHost := log
+	logWithValuesHost = logWithValuesHost.WithValues(
 		"key", getHostEnvVarKey(configuration.VarDurationBeforeChangeRequestDeletion),
-		"value", cfg.GetDurationBeforeChangeTierRequestDeletion(),
-		"regURLKey", getHostEnvVarKey(configuration.VarRegistrationServiceURL),
-		"regURLValue", cfg.GetRegistrationServiceURL())
+		"value", cfg.GetDurationBeforeChangeTierRequestDeletion())
+
+	logWithValuesHost = logWithValuesHost.WithValues("key", getHostEnvVarKey(configuration.VarRegistrationServiceURL),
+		"value", cfg.GetRegistrationServiceURL())
 
 	logWithValuesHost.Info("Host Operator configuration variables:")
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -277,17 +277,13 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 func printConfig(cfg *configuration.Config) {
 	logWithValuesRegServ := log
 	for key, value := range cfg.GetAllRegistrationServiceParameters() {
-		logWithValuesRegServ = logWithValuesRegServ.WithValues("key", key, "value", value)
+		logWithValuesRegServ = logWithValuesRegServ.WithValues(key, value)
 	}
 	logWithValuesRegServ.Info("Registration Service configuration variables:")
 
-	logWithValuesHost := log
-	logWithValuesHost = logWithValuesHost.WithValues(
-		"key", getHostEnvVarKey(configuration.VarDurationBeforeChangeRequestDeletion),
-		"value", cfg.GetDurationBeforeChangeTierRequestDeletion())
-
-	logWithValuesHost = logWithValuesHost.WithValues("key", getHostEnvVarKey(configuration.VarRegistrationServiceURL),
-		"value", cfg.GetRegistrationServiceURL())
+	logWithValuesHost := log.WithValues(
+		getHostEnvVarKey(configuration.VarDurationBeforeChangeRequestDeletion), cfg.GetDurationBeforeChangeTierRequestDeletion(),
+		getHostEnvVarKey(configuration.VarRegistrationServiceURL), cfg.GetRegistrationServiceURL())
 
 	logWithValuesHost.Info("Host Operator configuration variables:")
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -277,13 +277,17 @@ func serveCRMetrics(cfg *rest.Config, operatorNs string) error {
 func printConfig(cfg *configuration.Config) {
 	logWithValuesRegServ := log
 	for key, value := range cfg.GetAllRegistrationServiceParameters() {
-		logWithValuesRegServ = logWithValuesRegServ.WithValues(key, value)
+		logWithValuesRegServ = logWithValuesRegServ.WithValues("key", key, "value", value)
 	}
 	logWithValuesRegServ.Info("Registration Service configuration variables:")
 
-	logWithValuesHost := log.WithValues(
-		getHostEnvVarKey(configuration.VarDurationBeforeChangeRequestDeletion), cfg.GetDurationBeforeChangeTierRequestDeletion(),
-		getHostEnvVarKey(configuration.VarRegistrationServiceURL), cfg.GetRegistrationServiceURL())
+	logWithValuesHost := log
+	logWithValuesHost = logWithValuesHost.WithValues(
+		"key", getHostEnvVarKey(configuration.VarDurationBeforeChangeRequestDeletion),
+		"value", cfg.GetDurationBeforeChangeTierRequestDeletion())
+
+	logWithValuesHost = logWithValuesHost.WithValues("key", getHostEnvVarKey(configuration.VarRegistrationServiceURL),
+		"value", cfg.GetRegistrationServiceURL())
 
 	logWithValuesHost.Info("Host Operator configuration variables:")
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -284,8 +284,8 @@ func printConfig(cfg *configuration.Config) {
 	logWithValuesHost := log.WithValues(
 		"key", getHostEnvVarKey(configuration.VarDurationBeforeChangeRequestDeletion),
 		"value", cfg.GetDurationBeforeChangeTierRequestDeletion(),
-		"key", getHostEnvVarKey(configuration.VarRegistrationServiceURL),
-		"value", cfg.GetRegistrationServiceURL())
+		"regURLKey", getHostEnvVarKey(configuration.VarRegistrationServiceURL),
+		"regURLValue", cfg.GetRegistrationServiceURL())
 
 	logWithValuesHost.Info("Host Operator configuration variables:")
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-sdk v0.17.1
+	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -690,6 +690,8 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfSeg=
+github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -84,6 +84,30 @@ const (
 	// defaultRegistrationServiceURL is the default location of the registration service
 	defaultRegistrationServiceURL = "https://registration.crt-placeholder.com"
 
+	// varConsoleNamespace is the console route namespace
+	varConsoleNamespace = "console.namespace"
+
+	// defaultConsoleNamespace is the default console route namespace
+	defaultConsoleNamespace = "openshift-console"
+
+	// varConsoleRouteName is the console route name
+	varConsoleRouteName = "console.route.name"
+
+	// defaultConsoleRouteName is the default console route name
+	defaultConsoleRouteName = "console"
+
+	// varCheNamespace is the che route namespace
+	varCheNamespace = "che.namespace"
+
+	// defaultCheNamespace is the default che route namespace
+	defaultCheNamespace = "toolchain-che"
+
+	// varCheRouteName is the che dashboard route
+	varCheRouteName = "che.route.name"
+
+	// defaultCheRouteName is the default che dashboard route
+	defaultCheRouteName = "che"
+
 	// varEnvironment specifies the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
 	varEnvironment = "environment"
 
@@ -221,6 +245,10 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varNotificationDeliveryService, NotificationDeliveryServiceMailgun)
 	c.host.SetDefault(varDurationBeforeNotificationDeletion, defaultDurationBeforeNotificationDeletion)
 	c.host.SetDefault(varRegistrationServiceURL, defaultRegistrationServiceURL)
+	c.host.SetDefault(varConsoleNamespace, defaultConsoleNamespace)
+	c.host.SetDefault(varConsoleRouteName, defaultConsoleRouteName)
+	c.host.SetDefault(varCheNamespace, defaultCheNamespace)
+	c.host.SetDefault(varCheRouteName, defaultCheRouteName)
 	c.host.SetDefault(varEnvironment, defaultEnvironment)
 	c.host.SetDefault(varMasterUserRecordUpdateFailureThreshold, 2) // allow 1 failure, try again and then give up if failed again
 }
@@ -268,6 +296,26 @@ func (c *Config) GetMailgunSenderEmail() string {
 // GetRegistrationServiceURL returns the URL of the registration service
 func (c *Config) GetRegistrationServiceURL() string {
 	return c.host.GetString(varRegistrationServiceURL)
+}
+
+// GetConsoleNamespace returns the console route namespace
+func (c *Config) GetConsoleNamespace() string {
+	return c.host.GetString(varConsoleNamespace)
+}
+
+// GetConsoleRouteName returns the console route name
+func (c *Config) GetConsoleRouteName() string {
+	return c.host.GetString(varConsoleRouteName)
+}
+
+// GetCheNamespace returns the Che route namespace
+func (c *Config) GetCheNamespace() string {
+	return c.host.GetString(varCheNamespace)
+}
+
+// GetCheRouteName returns the name of the Che dashboard route
+func (c *Config) GetCheRouteName() string {
+	return c.host.GetString(varCheRouteName)
 }
 
 // GetEnvironment returns the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -149,6 +149,11 @@ func TestLoadFromConfigMap(t *testing.T) {
 
 		// then
 		assert.Equal(t, "https://registration.crt-placeholder.com", config.GetRegistrationServiceURL())
+		assert.Equal(t, "console", config.GetConsoleRouteName())
+		assert.Equal(t, "openshift-console", config.GetConsoleNamespace())
+		assert.Equal(t, "che", config.GetCheRouteName())
+		assert.Equal(t, "toolchain-che", config.GetCheNamespace())
+
 	})
 	t.Run("env overwrite", func(t *testing.T) {
 		// given
@@ -162,6 +167,10 @@ func TestLoadFromConfigMap(t *testing.T) {
 			},
 			Data: map[string]string{
 				"registration.service.url": "test-url",
+				"console.namespace":        "test-console-namespace",
+				"console.route.name":       "test-console",
+				"che.namespace":            "test-che",
+				"che.route.name":           "test-che-route-name",
 				"test-test":                "test-test",
 			},
 		}
@@ -178,6 +187,14 @@ func TestLoadFromConfigMap(t *testing.T) {
 		// test env vars are parsed and created correctly
 		regServiceURL := os.Getenv("HOST_OPERATOR_REGISTRATION_SERVICE_URL")
 		assert.Equal(t, regServiceURL, "test-url")
+		consoleNamespace := os.Getenv("HOST_OPERATOR_CONSOLE_NAMESPACE")
+		assert.Equal(t, consoleNamespace, "test-console-namespace")
+		consoleRouteName := os.Getenv("HOST_OPERATOR_CONSOLE_ROUTE_NAME")
+		assert.Equal(t, consoleRouteName, "test-console")
+		cheNamespace := os.Getenv("HOST_OPERATOR_CHE_NAMESPACE")
+		assert.Equal(t, cheNamespace, "test-che")
+		cheRouteName := os.Getenv("HOST_OPERATOR_CHE_ROUTE_NAME")
+		assert.Equal(t, cheRouteName, "test-che-route-name")
 		testTest := os.Getenv("HOST_OPERATOR_TEST_TEST")
 		assert.Equal(t, testTest, "test-test")
 	})

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -157,7 +157,14 @@ func TestLoadFromConfigMap(t *testing.T) {
 	})
 	t.Run("env overwrite", func(t *testing.T) {
 		// given
-		restore := test.SetEnvVarAndRestore(t, "HOST_OPERATOR_CONFIG_MAP_NAME", "test-config")
+		restore := test.SetEnvVarsAndRestore(t,
+			test.Env("HOST_OPERATOR_CONFIG_MAP_NAME", "test-config"),
+			test.Env("HOST_OPERATOR_REGISTRATION_SERVICE_URL", ""),
+			test.Env("HOST_OPERATOR_CONSOLE_NAMESPACE", ""),
+			test.Env("HOST_OPERATOR_CONSOLE_ROUTE_NAME", ""),
+			test.Env("HOST_OPERATOR_CHE_NAMESPACE", ""),
+			test.Env("HOST_OPERATOR_CHE_ROUTE_NAME", ""),
+			test.Env("MEMBER_OPERATOR_TEST_TEST", ""))
 		defer restore()
 
 		configMap := &v1.ConfigMap{
@@ -168,8 +175,8 @@ func TestLoadFromConfigMap(t *testing.T) {
 			Data: map[string]string{
 				"registration.service.url": "test-url",
 				"console.namespace":        "test-console-namespace",
-				"console.route.name":       "test-console",
-				"che.namespace":            "test-che",
+				"console.route.name":       "test-console-route-name",
+				"che.namespace":            "test-che-namespace",
 				"che.route.name":           "test-che-route-name",
 				"test-test":                "test-test",
 			},
@@ -183,6 +190,10 @@ func TestLoadFromConfigMap(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, "test-url", config.GetRegistrationServiceURL())
+		assert.Equal(t, "test-console-namespace", config.GetConsoleNamespace())
+		assert.Equal(t, "test-console-route-name", config.GetConsoleRouteName())
+		assert.Equal(t, "test-che-namespace", config.GetCheNamespace())
+		assert.Equal(t, "test-che-route-name", config.GetCheRouteName())
 
 		// test env vars are parsed and created correctly
 		regServiceURL := os.Getenv("HOST_OPERATOR_REGISTRATION_SERVICE_URL")
@@ -190,9 +201,9 @@ func TestLoadFromConfigMap(t *testing.T) {
 		consoleNamespace := os.Getenv("HOST_OPERATOR_CONSOLE_NAMESPACE")
 		assert.Equal(t, consoleNamespace, "test-console-namespace")
 		consoleRouteName := os.Getenv("HOST_OPERATOR_CONSOLE_ROUTE_NAME")
-		assert.Equal(t, consoleRouteName, "test-console")
+		assert.Equal(t, consoleRouteName, "test-console-route-name")
 		cheNamespace := os.Getenv("HOST_OPERATOR_CHE_NAMESPACE")
-		assert.Equal(t, cheNamespace, "test-che")
+		assert.Equal(t, cheNamespace, "test-che-namespace")
 		cheRouteName := os.Getenv("HOST_OPERATOR_CHE_ROUTE_NAME")
 		assert.Equal(t, cheRouteName, "test-che-route-name")
 		testTest := os.Getenv("HOST_OPERATOR_TEST_TEST")

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -36,16 +36,17 @@ const (
 
 // Add creates a new MasterUserRecord Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, _ *configuration.Config) error {
-	return add(mgr, newReconciler(mgr))
+func Add(mgr manager.Manager, config *configuration.Config) error {
+	return add(mgr, newReconciler(mgr, config))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, config *configuration.Config) reconcile.Reconciler {
 	return &ReconcileMasterUserRecord{
 		client:                mgr.GetClient(),
 		scheme:                mgr.GetScheme(),
 		retrieveMemberCluster: cluster.GetFedCluster,
+		config:                config,
 	}
 }
 
@@ -78,6 +79,7 @@ type ReconcileMasterUserRecord struct {
 	client                client.Client
 	scheme                *runtime.Scheme
 	retrieveMemberCluster func(name string) (*cluster.FedCluster, bool)
+	config                *configuration.Config
 }
 
 // Reconcile reads that state of the cluster for a MasterUserRecord object and makes changes based on the state read
@@ -180,6 +182,7 @@ func (r *ReconcileMasterUserRecord) ensureUserAccount(logger logr.Logger, murAcc
 		recordSpecUserAcc: murAccount,
 		logger:            logger,
 		scheme:            r.scheme,
+		config:            r.config,
 	}
 	if err := sync.synchronizeSpec(); err != nil {
 		// note: if we got an error while sync'ing the spec, then we may not be able to update the MUR status it here neither.

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	uatest "github.com/codeready-toolchain/toolchain-common/pkg/test/useraccount"
-	"github.com/go-logr/logr"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -39,10 +39,8 @@ func TestAddFinalizer(t *testing.T) {
 		mur := murtest.NewMasterUserRecord(t, "john")
 		memberClient := test.NewFakeClient(t)
 		hostClient := test.NewFakeClient(t, mur)
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -65,14 +63,12 @@ func TestAddFinalizer(t *testing.T) {
 		hostClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 			return fmt.Errorf("unable to add finalizer to MUR %s", mur.Name)
 		}
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -93,14 +89,12 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 	require.NoError(t, murtest.Modify(mur, murtest.Finalizer("finalizer.toolchain.dev.openshift.com")))
 	memberClient := test.NewFakeClient(t)
 	hostClient := test.NewFakeClient(t, mur)
-	config, err := configuration.LoadConfig(hostClient)
-	require.NoError(t, err)
 
-	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
-	_, err = cntrl.Reconcile(newMurRequest(mur))
+	_, err := cntrl.Reconcile(newMurRequest(mur))
 
 	// then
 	require.NoError(t, err)
@@ -120,10 +114,8 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 	memberClient := test.NewFakeClient(t, consoleRoute())
 	memberClient2 := test.NewFakeClient(t, consoleRoute())
 	hostClient := test.NewFakeClient(t, mur)
-	config, err := configuration.LoadConfig(hostClient)
-	require.NoError(t, err)
 
-	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
 
 	// when reconciling
@@ -152,14 +144,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("when member cluster does not exist and UA hasn't been created yet", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(false, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -175,14 +165,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("when member cluster does not exist and UA was already created", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(false, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -196,14 +184,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("when member cluster is not ready and UA hasn't been created yet", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionFalse),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -219,14 +205,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("when member cluster is not ready and UA was already created", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionFalse),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -241,17 +225,15 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("status update of the MasterUserRecord failed", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 		statusUpdater := func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error {
 			return fmt.Errorf("unable to update status")
 		}
 
 		// when
-		err = cntrl.wrapErrorWithStatusUpdate(log, mur, statusUpdater,
+		err := cntrl.wrapErrorWithStatusUpdate(log, mur, statusUpdater,
 			apierros.NewBadRequest("oopsy woopsy"), "failed to create %s", "user bob")
 
 		// then
@@ -265,14 +247,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		memberClient.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			return fmt.Errorf("unable to create user account %s", mur.Name)
 		}
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -294,14 +274,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		modifiedMur := murtest.NewMasterUserRecord(t, "john", murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
 		murtest.ModifyUaInMur(modifiedMur, test.MemberClusterName, murtest.TierName("admin"))
 		hostClient := test.NewFakeClient(t, modifiedMur)
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(modifiedMur))
+		_, err := cntrl.Reconcile(newMurRequest(modifiedMur))
 
 		// then
 		require.Error(t, err)
@@ -330,14 +308,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			hostClient.MockStatusUpdate = nil // mock only once
 			return fmt.Errorf("unable to update MUR %s", provisionedMur.Name)
 		}
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(provisionedMur))
+		_, err := cntrl.Reconcile(newMurRequest(provisionedMur))
 
 		// then
 		require.Error(t, err)
@@ -362,14 +338,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		hostClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 			return fmt.Errorf("unable to remove finalizer from MUR %s", mur.Name)
 		}
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -392,14 +366,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		memberClient.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 			return fmt.Errorf("unable to delete user account %s", mur.Name)
 		}
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
 
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -433,15 +405,13 @@ func TestModifyUserAccounts(t *testing.T) {
 	memberClient2 := test.NewFakeClient(t, userAccount2, consoleRoute())
 	memberClient3 := test.NewFakeClient(t, userAccount3, consoleRoute())
 	hostClient := test.NewFakeClient(t, mur)
-	config, err := configuration.LoadConfig(hostClient)
-	require.NoError(t, err)
 
-	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
 		clusterClient("member3-cluster", memberClient3))
 
 	// when ensuring 1st account
-	_, err = cntrl.Reconcile(newMurRequest(mur))
+	_, err := cntrl.Reconcile(newMurRequest(mur))
 	// then
 	require.NoError(t, err)
 	uatest.AssertThatUserAccount(t, "john", memberClient).
@@ -509,14 +479,13 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 		memberClient3 := test.NewFakeClient(t, userAccount3, consoleRoute())
 
 		hostClient := test.NewFakeClient(t, mur)
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
 			clusterClient("member3-cluster", memberClient3))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.NoError(t, err)
@@ -568,14 +537,13 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 		memberClient := test.NewFakeClient(t, userAccount, consoleRoute())
 		memberClient2 := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur), consoleRoute())
-		config, err := configuration.LoadConfig(hostClient)
-		require.NoError(t, err)
-		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+
+		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient),
 			clusterClient("member2-cluster", memberClient2))
 
 		// when
-		_, err = cntrl.Reconcile(newMurRequest(mur))
+		_, err := cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		// the original error status should be cleaned
@@ -611,14 +579,12 @@ func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
 
 	memberClient := test.NewFakeClient(t, userAcc)
 	hostClient := test.NewFakeClient(t, mur)
-	config, err := configuration.LoadConfig(hostClient)
-	require.NoError(t, err)
 
-	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
-	_, err = cntrl.Reconcile(newMurRequest(mur))
+	_, err := cntrl.Reconcile(newMurRequest(mur))
 
 	// then
 	require.NoError(t, err)
@@ -641,14 +607,12 @@ func TestDeleteMultipleUserAccountsViaMasterUserRecordBeingDeleted(t *testing.T)
 	memberClient := test.NewFakeClient(t, userAcc)
 	memberClient2 := test.NewFakeClient(t, userAcc)
 	hostClient := test.NewFakeClient(t, mur)
-	config, err := configuration.LoadConfig(hostClient)
-	require.NoError(t, err)
 
-	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
 
 	// when
-	_, err = cntrl.Reconcile(newMurRequest(mur))
+	_, err := cntrl.Reconcile(newMurRequest(mur))
 
 	// then
 	require.NoError(t, err)
@@ -671,10 +635,8 @@ func TestDisablingMasterUserRecord(t *testing.T) {
 	userAccount := uatest.NewUserAccountFromMur(mur, uatest.DisabledUa(false))
 	memberClient := test.NewFakeClient(t, userAccount, consoleRoute(), cheRoute(false))
 	hostClient := test.NewFakeClient(t, mur)
-	config, err := configuration.LoadConfig(hostClient)
-	require.NoError(t, err)
 
-	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
@@ -700,7 +662,9 @@ func apiScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func newController(hostCl client.Client, s *runtime.Scheme, config *configuration.Config, getMemberCluster getMemberCluster, memberCl ...clientForCluster) ReconcileMasterUserRecord {
+func newController(hostCl client.Client, s *runtime.Scheme, getMemberCluster getMemberCluster, memberCl ...clientForCluster) ReconcileMasterUserRecord {
+	config, err := configuration.LoadConfig(hostCl)
+	require.NoError(t, err)
 	return ReconcileMasterUserRecord{
 		client:                hostCl,
 		scheme:                s,

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -40,7 +40,7 @@ func TestAddFinalizer(t *testing.T) {
 		memberClient := test.NewFakeClient(t)
 		hostClient := test.NewFakeClient(t, mur)
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -64,7 +64,7 @@ func TestAddFinalizer(t *testing.T) {
 			return fmt.Errorf("unable to add finalizer to MUR %s", mur.Name)
 		}
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -90,7 +90,7 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 	memberClient := test.NewFakeClient(t)
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
@@ -115,7 +115,7 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 	memberClient2 := test.NewFakeClient(t, consoleRoute())
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
 
 	// when reconciling
@@ -145,7 +145,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -166,7 +166,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -185,7 +185,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -206,7 +206,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -226,7 +226,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 		statusUpdater := func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error {
 			return fmt.Errorf("unable to update status")
@@ -248,7 +248,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			return fmt.Errorf("unable to create user account %s", mur.Name)
 		}
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -275,7 +275,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		murtest.ModifyUaInMur(modifiedMur, test.MemberClusterName, murtest.TierName("admin"))
 		hostClient := test.NewFakeClient(t, modifiedMur)
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -309,7 +309,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			return fmt.Errorf("unable to update MUR %s", provisionedMur.Name)
 		}
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -339,7 +339,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			return fmt.Errorf("unable to remove finalizer from MUR %s", mur.Name)
 		}
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -367,7 +367,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			return fmt.Errorf("unable to delete user account %s", mur.Name)
 		}
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -406,7 +406,7 @@ func TestModifyUserAccounts(t *testing.T) {
 	memberClient3 := test.NewFakeClient(t, userAccount3, consoleRoute())
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
 		clusterClient("member3-cluster", memberClient3))
 
@@ -480,7 +480,7 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 		hostClient := test.NewFakeClient(t, mur)
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
 			clusterClient("member3-cluster", memberClient3))
 
@@ -538,7 +538,7 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 		memberClient := test.NewFakeClient(t, userAccount, consoleRoute())
 		memberClient2 := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur), consoleRoute())
 
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient),
 			clusterClient("member2-cluster", memberClient2))
 
@@ -580,7 +580,7 @@ func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
 	memberClient := test.NewFakeClient(t, userAcc)
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
@@ -608,7 +608,7 @@ func TestDeleteMultipleUserAccountsViaMasterUserRecordBeingDeleted(t *testing.T)
 	memberClient2 := test.NewFakeClient(t, userAcc)
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
 
 	// when
@@ -636,7 +636,7 @@ func TestDisablingMasterUserRecord(t *testing.T) {
 	memberClient := test.NewFakeClient(t, userAccount, consoleRoute(), cheRoute(false))
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
@@ -662,7 +662,7 @@ func apiScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func newController(hostCl client.Client, s *runtime.Scheme, getMemberCluster getMemberCluster, memberCl ...clientForCluster) ReconcileMasterUserRecord {
+func newController(t *testing.T, hostCl client.Client, s *runtime.Scheme, getMemberCluster getMemberCluster, memberCl ...clientForCluster) ReconcileMasterUserRecord {
 	config, err := configuration.LoadConfig(hostCl)
 	require.NoError(t, err)
 	return ReconcileMasterUserRecord{

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
+	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
@@ -30,7 +31,6 @@ import (
 type getMemberCluster func(clusters ...clientForCluster) func(name string) (*cluster.FedCluster, bool)
 
 func TestAddFinalizer(t *testing.T) {
-
 	// given
 	logf.SetLogger(logf.ZapLogger(true))
 	s := apiScheme(t)
@@ -39,7 +39,10 @@ func TestAddFinalizer(t *testing.T) {
 		mur := murtest.NewMasterUserRecord(t, "john")
 		memberClient := test.NewFakeClient(t)
 		hostClient := test.NewFakeClient(t, mur)
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
@@ -62,11 +65,14 @@ func TestAddFinalizer(t *testing.T) {
 		hostClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 			return fmt.Errorf("unable to add finalizer to MUR %s", mur.Name)
 		}
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -87,11 +93,14 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 	require.NoError(t, murtest.Modify(mur, murtest.Finalizer("finalizer.toolchain.dev.openshift.com")))
 	memberClient := test.NewFakeClient(t)
 	hostClient := test.NewFakeClient(t, mur)
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	config, err := configuration.LoadConfig(hostClient)
+	require.NoError(t, err)
+
+	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
-	_, err := cntrl.Reconcile(newMurRequest(mur))
+	_, err = cntrl.Reconcile(newMurRequest(mur))
 
 	// then
 	require.NoError(t, err)
@@ -111,7 +120,10 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 	memberClient := test.NewFakeClient(t, consoleRoute())
 	memberClient2 := test.NewFakeClient(t, consoleRoute())
 	hostClient := test.NewFakeClient(t, mur)
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	config, err := configuration.LoadConfig(hostClient)
+	require.NoError(t, err)
+
+	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
 
 	// when reconciling
@@ -140,11 +152,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("when member cluster does not exist and UA hasn't been created yet", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
-		cntrl := newController(hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(false, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -160,11 +175,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("when member cluster does not exist and UA was already created", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
-		cntrl := newController(hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(false, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -178,11 +196,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("when member cluster is not ready and UA hasn't been created yet", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionFalse),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -198,11 +219,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("when member cluster is not ready and UA was already created", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionFalse),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -217,14 +241,17 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	t.Run("status update of the MasterUserRecord failed", func(t *testing.T) {
 		// given
 		memberClient := test.NewFakeClient(t)
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 		statusUpdater := func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error {
 			return fmt.Errorf("unable to update status")
 		}
 
 		// when
-		err := cntrl.wrapErrorWithStatusUpdate(log, mur, statusUpdater,
+		err = cntrl.wrapErrorWithStatusUpdate(log, mur, statusUpdater,
 			apierros.NewBadRequest("oopsy woopsy"), "failed to create %s", "user bob")
 
 		// then
@@ -238,11 +265,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		memberClient.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			return fmt.Errorf("unable to create user account %s", mur.Name)
 		}
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -264,11 +294,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		modifiedMur := murtest.NewMasterUserRecord(t, "john", murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
 		murtest.ModifyUaInMur(modifiedMur, test.MemberClusterName, murtest.TierName("admin"))
 		hostClient := test.NewFakeClient(t, modifiedMur)
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(modifiedMur))
+		_, err = cntrl.Reconcile(newMurRequest(modifiedMur))
 
 		// then
 		require.Error(t, err)
@@ -297,11 +330,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			hostClient.MockStatusUpdate = nil // mock only once
 			return fmt.Errorf("unable to update MUR %s", provisionedMur.Name)
 		}
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(provisionedMur))
+		_, err = cntrl.Reconcile(newMurRequest(provisionedMur))
 
 		// then
 		require.Error(t, err)
@@ -326,11 +362,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		hostClient.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 			return fmt.Errorf("unable to remove finalizer from MUR %s", mur.Name)
 		}
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -353,11 +392,14 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		memberClient.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 			return fmt.Errorf("unable to delete user account %s", mur.Name)
 		}
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.Error(t, err)
@@ -391,13 +433,15 @@ func TestModifyUserAccounts(t *testing.T) {
 	memberClient2 := test.NewFakeClient(t, userAccount2, consoleRoute())
 	memberClient3 := test.NewFakeClient(t, userAccount3, consoleRoute())
 	hostClient := test.NewFakeClient(t, mur)
+	config, err := configuration.LoadConfig(hostClient)
+	require.NoError(t, err)
 
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
 		clusterClient("member3-cluster", memberClient3))
 
 	// when ensuring 1st account
-	_, err := cntrl.Reconcile(newMurRequest(mur))
+	_, err = cntrl.Reconcile(newMurRequest(mur))
 	// then
 	require.NoError(t, err)
 	uatest.AssertThatUserAccount(t, "john", memberClient).
@@ -465,12 +509,14 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 		memberClient3 := test.NewFakeClient(t, userAccount3, consoleRoute())
 
 		hostClient := test.NewFakeClient(t, mur)
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
 			clusterClient("member3-cluster", memberClient3))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		require.NoError(t, err)
@@ -522,12 +568,14 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 		memberClient := test.NewFakeClient(t, userAccount, consoleRoute())
 		memberClient2 := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur), consoleRoute())
-		cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+		config, err := configuration.LoadConfig(hostClient)
+		require.NoError(t, err)
+		cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 			clusterClient(test.MemberClusterName, memberClient),
 			clusterClient("member2-cluster", memberClient2))
 
 		// when
-		_, err := cntrl.Reconcile(newMurRequest(mur))
+		_, err = cntrl.Reconcile(newMurRequest(mur))
 
 		// then
 		// the original error status should be cleaned
@@ -563,11 +611,14 @@ func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
 
 	memberClient := test.NewFakeClient(t, userAcc)
 	hostClient := test.NewFakeClient(t, mur)
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	config, err := configuration.LoadConfig(hostClient)
+	require.NoError(t, err)
+
+	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
-	_, err := cntrl.Reconcile(newMurRequest(mur))
+	_, err = cntrl.Reconcile(newMurRequest(mur))
 
 	// then
 	require.NoError(t, err)
@@ -590,11 +641,14 @@ func TestDeleteMultipleUserAccountsViaMasterUserRecordBeingDeleted(t *testing.T)
 	memberClient := test.NewFakeClient(t, userAcc)
 	memberClient2 := test.NewFakeClient(t, userAcc)
 	hostClient := test.NewFakeClient(t, mur)
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	config, err := configuration.LoadConfig(hostClient)
+	require.NoError(t, err)
+
+	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
 
 	// when
-	_, err := cntrl.Reconcile(newMurRequest(mur))
+	_, err = cntrl.Reconcile(newMurRequest(mur))
 
 	// then
 	require.NoError(t, err)
@@ -617,7 +671,10 @@ func TestDisablingMasterUserRecord(t *testing.T) {
 	userAccount := uatest.NewUserAccountFromMur(mur, uatest.DisabledUa(false))
 	memberClient := test.NewFakeClient(t, userAccount, consoleRoute(), cheRoute(false))
 	hostClient := test.NewFakeClient(t, mur)
-	cntrl := newController(hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
+	config, err := configuration.LoadConfig(hostClient)
+	require.NoError(t, err)
+
+	cntrl := newController(hostClient, s, config, newGetMemberCluster(true, v1.ConditionTrue),
 		clusterClient(test.MemberClusterName, memberClient))
 
 	// when
@@ -643,11 +700,12 @@ func apiScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func newController(hostCl client.Client, s *runtime.Scheme, getMemberCluster getMemberCluster, memberCl ...clientForCluster) ReconcileMasterUserRecord {
+func newController(hostCl client.Client, s *runtime.Scheme, config *configuration.Config, getMemberCluster getMemberCluster, memberCl ...clientForCluster) ReconcileMasterUserRecord {
 	return ReconcileMasterUserRecord{
 		client:                hostCl,
 		scheme:                s,
 		retrieveMemberCluster: getMemberCluster(memberCl...),
+		config:                config,
 	}
 }
 


### PR DESCRIPTION
We have to move
https://github.com/codeready-toolchain/host-operator/blob/master/pkg/controller/masteruserrecord/sync.go#L29-L30
and
https://github.com/codeready-toolchain/host-operator/blob/master/pkg/controller/masteruserrecord/sync.go#L178
to configuration so we can customize them via ConfigMap.

It's needed for OSD integration.

Jira: https://issues.redhat.com/browse/CRT-745
Related PR: https://github.com/codeready-toolchain/toolchain-infra/pull/28/files