### PR TITLE
chore: remove KubeFed from role

### DIFF
--- a/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
@@ -379,18 +379,6 @@ spec:
           - get
           - create
         - apiGroups:
-          - core.kubefed.io
-          resources:
-          - kubefedclusters
-          verbs:
-          - '*'
-        - apiGroups:
-          - core.kubefed.io
-          resources:
-          - kubefedclusters/status
-          verbs:
-          - update
-        - apiGroups:
           - rbac.authorization.k8s.io
           - authorization.openshift.io
           resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -44,18 +44,6 @@ rules:
   - "get"
   - "create"
 - apiGroups:
-  - core.kubefed.io
-  resources:
-  - kubefedclusters
-  verbs:
-  - "*"
-- apiGroups:
-  - core.kubefed.io
-  resources:
-  - kubefedclusters/status
-  verbs:
-  - "update"
-- apiGroups:
   - rbac.authorization.k8s.io
   - authorization.openshift.io
   resources:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -2369,18 +2369,6 @@ data:
                 - get
                 - create
               - apiGroups:
-                - core.kubefed.io
-                resources:
-                - kubefedclusters
-                verbs:
-                - '*'
-              - apiGroups:
-                - core.kubefed.io
-                resources:
-                - kubefedclusters/status
-                verbs:
-                - update
-              - apiGroups:
                 - rbac.authorization.k8s.io
                 - authorization.openshift.io
                 resources:


### PR DESCRIPTION
Since we migrated to ToolchainCluster CRD then the operator doesn't need the permissions to access/modify the KubeFed resources