### PR TITLE
Provisioned time for MUR

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -195,6 +195,10 @@ spec:
               x-kubernetes-list-map-keys:
               - type
               x-kubernetes-list-type: map
+            provisionedTime:
+              description: The timestamp when the user was provisioned
+              format: date-time
+              type: string
             userAccounts:
               description: The status of user accounts in the member clusters which
                 belong to this MasterUserRecord

--- a/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain_v1alpha1_masteruserrecord_crd.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain_v1alpha1_masteruserrecord_crd.yaml
@@ -195,6 +195,10 @@ spec:
               x-kubernetes-list-map-keys:
               - type
               x-kubernetes-list-type: map
+            provisionedTime:
+              description: The timestamp when the user was provisioned
+              format: date-time
+              type: string
             userAccounts:
               description: The status of user accounts in the member clusters which
                 belong to this MasterUserRecord

--- a/go.mod
+++ b/go.mod
@@ -40,4 +40,9 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
+replace (
+	github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c
+	github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20200807030047-818bbcc6bf33
+)
+
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -40,9 +40,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
-replace (
-	github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c
-	github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20200807030047-818bbcc6bf33
-)
+replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
 	github.com/alecthomas/colour v0.1.0 // indirect
 	github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c // indirect
-	github.com/codeready-toolchain/api v0.0.0-20200805071634-c62858ce3204
+	github.com/codeready-toolchain/api v0.0.0-20200810164016-1a79a0101726
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
@@ -39,7 +39,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.17.4 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200204173128-addea2498afe // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
-
-replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e h1:Kcf3urGnhPCnneAAe9ewmikCtj/H5huxgdMBaDvlDs4=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e/go.mod h1:gGWlFDAr0VScx9t8Prhz46LiYd0bAhNclraz6lGLV0Q=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -746,8 +748,6 @@ github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c h1:B9oMPdf6Wd06H9u63e7TgDrs6n6JbqFFEWdX3wURaXs=
 github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
-github.com/rajivnathan/toolchain-common v0.0.0-20200807030047-818bbcc6bf33 h1:ODHEhvrnUmrhfY5GTpUd6Y+lp+nehYa4KOnvn2BM0+M=
-github.com/rajivnathan/toolchain-common v0.0.0-20200807030047-818bbcc6bf33/go.mod h1:ECoRLI1BFGFEtnifNwLwd5I8SMwzkS9KKd5HchcK4sw=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,6 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20200805071634-c62858ce3204 h1:eI4iTTEW1YF3FUNVIHxZPYeCiAyFOQL4uxh3VI5TwVY=
-github.com/codeready-toolchain/api v0.0.0-20200805071634-c62858ce3204/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e h1:Kcf3urGnhPCnneAAe9ewmikCtj/H5huxgdMBaDvlDs4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e/go.mod h1:gGWlFDAr0VScx9t8Prhz46LiYd0bAhNclraz6lGLV0Q=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -748,6 +744,10 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c h1:B9oMPdf6Wd06H9u63e7TgDrs6n6JbqFFEWdX3wURaXs=
+github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
+github.com/rajivnathan/toolchain-common v0.0.0-20200807030047-818bbcc6bf33 h1:ODHEhvrnUmrhfY5GTpUd6Y+lp+nehYa4KOnvn2BM0+M=
+github.com/rajivnathan/toolchain-common v0.0.0-20200807030047-818bbcc6bf33/go.mod h1:ECoRLI1BFGFEtnifNwLwd5I8SMwzkS9KKd5HchcK4sw=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,9 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/codeready-toolchain/api v0.0.0-20200805071634-c62858ce3204/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
+github.com/codeready-toolchain/api v0.0.0-20200810164016-1a79a0101726 h1:u6rs73dgVnDlqo9aVd0G5e4J+fXsM67ZkjVrbe0lNlY=
+github.com/codeready-toolchain/api v0.0.0-20200810164016-1a79a0101726/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e h1:Kcf3urGnhPCnneAAe9ewmikCtj/H5huxgdMBaDvlDs4=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e/go.mod h1:gGWlFDAr0VScx9t8Prhz46LiYd0bAhNclraz6lGLV0Q=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -746,8 +749,6 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c h1:B9oMPdf6Wd06H9u63e7TgDrs6n6JbqFFEWdX3wURaXs=
-github.com/rajivnathan/api v0.0.0-20200805154153-997c3ad9c93c/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -381,6 +381,10 @@ data:
                     x-kubernetes-list-map-keys:
                     - type
                     x-kubernetes-list-type: map
+                  provisionedTime:
+                    description: The timestamp when the user was provisioned
+                    format: date-time
+                    type: string
                   userAccounts:
                     description: The status of user accounts in the member clusters which
                       belong to this MasterUserRecord

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -232,6 +232,13 @@ func (s *Synchronizer) alignReadiness() (bool, error) {
 	}
 
 	s.record.Status.Conditions, _ = condition.AddOrUpdateStatusConditions(s.record.Status.Conditions, toBeProvisioned())
+
+	// set ProvisionedTime if it is not already set, this information will be used for things like the start time for automatic user deactivation.
+	// the MUR status can change from provisioned to something else and back to provisioned but the time should only be set the first time.
+	if s.record.Status.ProvisionedTime == nil {
+		s.record.Status.ProvisionedTime = &v1.Time{Time: time.Now()}
+	}
+
 	if condition.IsNotTrue(s.record.Status.Conditions, toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreated) {
 		notification := &toolchainv1alpha1.Notification{
 			ObjectMeta: v1.ObjectMeta{

--- a/pkg/controller/masteruserrecord/sync_test.go
+++ b/pkg/controller/masteruserrecord/sync_test.go
@@ -165,7 +165,8 @@ func TestSynchronizeStatus(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
+		expectedProvisionedTime := metav1.Time{}
+		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, expectedProvisionedTime, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
 	})
 
 	t.Run("failed on the host side", func(t *testing.T) {
@@ -214,7 +215,8 @@ func TestSyncMurStatusWithUserAccountStatusWhenUpdated(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordUpdatingReason, ""))
+		expectedProvisionedTime := metav1.Time{}
+		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, expectedProvisionedTime, toBeNotReady(toolchainv1alpha1.MasterUserRecordUpdatingReason, ""))
 	})
 
 	t.Run("failed on the host side", func(t *testing.T) {
@@ -262,7 +264,8 @@ func TestSyncMurStatusWithUserAccountStatusWhenDisabled(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, toBeDisabled())
+		expectedProvisionedTime := metav1.Time{}
+		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, expectedProvisionedTime, toBeDisabled())
 	})
 
 	t.Run("failed on the host side", func(t *testing.T) {
@@ -310,7 +313,30 @@ func TestSyncMurStatusWithUserAccountStatusWhenCompleted(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, toBeProvisioned(), toBeProvisionedNotificationCreated())
+		expectedProvisionedTime := metav1.Now()
+		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, expectedProvisionedTime, toBeProvisioned(), toBeProvisionedNotificationCreated())
+	})
+
+	t.Run("ProvisionedTime should not be updated when synced more than once", func(t *testing.T) {
+		// given
+		hostClient := test.NewFakeClient(t, mur)
+		sync, memberClient := prepareSynchronizer(t, userAccount, mur, hostClient)
+
+		// when
+		err1 := sync.synchronizeStatus() // 1st sync should not change anything, including ProvisionedTime in MUR
+		initialProvisionedTime := sync.record.Status.ProvisionedTime
+
+		expectedProvisionedTime := metav1.Now()
+		verifySyncMurStatusWithUserAccountStatus(t, memberClient, hostClient, userAccount, mur, expectedProvisionedTime, toBeProvisioned(), toBeProvisionedNotificationCreated())
+
+		// mock changed MUR before syncing again
+		murtest.Modify(mur, murtest.StatusCondition(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")))
+		err2 := sync.synchronizeStatus() // 2nd sync should update the status but not the ProvisionedTime in the MUR
+
+		// then
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.True(t, initialProvisionedTime.Time.Equal(sync.record.Status.ProvisionedTime.Time)) // timestamp should be the same
 	})
 
 	t.Run("failed on the host side when doing update", func(t *testing.T) {
@@ -665,7 +691,7 @@ func prepareSynchronizer(t *testing.T, userAccount *toolchainv1alpha1.UserAccoun
 	}, memberClient
 }
 
-func verifySyncMurStatusWithUserAccountStatus(t *testing.T, memberClient, hostClient client.Client, userAccount *toolchainv1alpha1.UserAccount, mur *toolchainv1alpha1.MasterUserRecord, expMurCon ...toolchainv1alpha1.Condition) {
+func verifySyncMurStatusWithUserAccountStatus(t *testing.T, memberClient, hostClient client.Client, userAccount *toolchainv1alpha1.UserAccount, mur *toolchainv1alpha1.MasterUserRecord, expectedProvisionedTime metav1.Time, expMurCon ...toolchainv1alpha1.Condition) {
 	userAccountCondition := userAccount.Status.Conditions[0]
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
@@ -681,7 +707,8 @@ func verifySyncMurStatusWithUserAccountStatus(t *testing.T, memberClient, hostCl
 			ConsoleURL:      "https://console.member-cluster/",
 			CheDashboardURL: "http://che-toolchain-che.member-cluster/",
 		}).
-		AllUserAccountsHaveCondition(userAccountCondition)
+		AllUserAccountsHaveCondition(userAccountCondition).
+		HasExpectedProvisionedTime(expectedProvisionedTime)
 }
 
 func newMemberCluster(cl client.Client) *cluster.CachedToolchainCluster {


### PR DESCRIPTION
This PR adds the following
- generated files for the new MUR.Status.ProvisionedTime field
- logic to set the ProvisionedTime field on the first time the MUR goes to Provisioned status
- unit tests

Related PRs:
    - https://github.com/codeready-toolchain/api/pull/176
    - https://github.com/codeready-toolchain/toolchain-common/pull/122