### PR TITLE
fix: start metrics server at operator startup

### DIFF
--- a/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
@@ -343,6 +343,7 @@ spec:
           resources:
           - pods
           - services
+          - services/finalizers
           - endpoints
           - persistentvolumeclaims
           - events
@@ -363,6 +364,13 @@ spec:
           - deployments
           verbs:
           - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - get
+          - create
         - apiGroups:
           - apps
           resourceNames:

--- a/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
@@ -370,6 +370,7 @@ spec:
           - replicasets
           verbs:
           - get
+          - list
           - create
         - apiGroups:
           - apps

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -35,6 +35,7 @@ rules:
   - replicasets
   verbs:
   - "get"
+  - "list"
   - "create"
 - apiGroups:
   - apps

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -8,6 +8,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events
@@ -28,6 +29,13 @@ rules:
   - deployments
   verbs:
   - "*"
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - "get"
+  - "create"
 - apiGroups:
   - apps
   resources:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -2344,6 +2344,7 @@ data:
                 resources:
                 - pods
                 - services
+                - services/finalizers
                 - endpoints
                 - persistentvolumeclaims
                 - events
@@ -2364,6 +2365,13 @@ data:
                 - deployments
                 verbs:
                 - '*'
+              - apiGroups:
+                - apps
+                resources:
+                - replicasets
+                verbs:
+                - get
+                - create
               - apiGroups:
                 - apps
                 resourceNames:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -2371,6 +2371,7 @@ data:
                 - replicasets
                 verbs:
                 - get
+                - list
                 - create
               - apiGroups:
                 - apps


### PR DESCRIPTION
A couple of permissions were missing, which resulted
in the following errors:
```
{"level":"info","msg":"Could not create metrics Service","error":"failed to initialize service object for metrics: replicasets.apps \"host-operator-849b9cccc4\" is forbidden: User \"system:serviceaccount:xcoulon-host-12182550:host-operator\" cannot get resource \"replicasets\" in API group \"apps\" in the namespace \"xcoulon-host-12182550\""}
```
and then
```
{"level":"info","msg":"Could not create ServiceMonitor object","error":"servicemonitors.monitoring.coreos.com \"host-operator-metrics\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```

E2E tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/142

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
