### PR TITLE
fix: recreate UserAccount when deleted (on purpose or by accident)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20200810164016-1a79a0101726
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200820134850-9992bf96839d
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/codeready-toolchain/api v0.0.0-20200805071634-c62858ce3204/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
 github.com/codeready-toolchain/api v0.0.0-20200810164016-1a79a0101726 h1:u6rs73dgVnDlqo9aVd0G5e4J+fXsM67ZkjVrbe0lNlY=
 github.com/codeready-toolchain/api v0.0.0-20200810164016-1a79a0101726/go.mod h1:/tMojFnmqPoMCjgq1me9lC5jF5zCgcGhtoIp6Q+sRGw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e h1:Kcf3urGnhPCnneAAe9ewmikCtj/H5huxgdMBaDvlDs4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200805073859-f231c3ee728e/go.mod h1:gGWlFDAr0VScx9t8Prhz46LiYd0bAhNclraz6lGLV0Q=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200820134850-9992bf96839d h1:z0Ls14N806KMaNAOs4IHNilT5yDQXhTPNwnFiHm1Wjs=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200820134850-9992bf96839d/go.mod h1:gGWlFDAr0VScx9t8Prhz46LiYd0bAhNclraz6lGLV0Q=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -3,14 +3,17 @@ package masteruserrecord
 import (
 	"context"
 	"fmt"
+	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
 	errs "github.com/pkg/errors"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 	coputil "github.com/redhat-cop/operator-utils/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -113,9 +116,12 @@ func (r *ReconcileMasterUserRecord) Reconcile(request reconcile.Request) (reconc
 		}
 		logger.Info("ensuring user accounts")
 		for _, account := range mur.Spec.UserAccounts {
-			if err := r.ensureUserAccount(logger, account, mur); err != nil {
+			requeue, err := r.ensureUserAccount(logger, account, mur)
+			if err != nil {
 				logger.Error(err, "unable to synchronize with member UserAccount")
 				return reconcile.Result{}, err
+			} else if requeue {
+				return reconcile.Result{Requeue: true, RequeueAfter: 3 * time.Second}, err // waiting for a few seconds to give time to the member cluster to finish its deletions
 			}
 		}
 		// If the UserAccount is being deleted, delete the UserAccounts in members.
@@ -147,11 +153,12 @@ func (r *ReconcileMasterUserRecord) addFinalizer(logger logr.Logger, mur *toolch
 // ensureUserAccount ensures that there's a UserAccount resource on the member cluster for the given `murAccount`.
 // If the UserAccount resource already exists, then this latter is synchronized using the given `murAccount` and the associated `mur` status is also updated to reflect
 // the UserAccount specs.
-func (r *ReconcileMasterUserRecord) ensureUserAccount(logger logr.Logger, murAccount toolchainv1alpha1.UserAccountEmbedded, mur *toolchainv1alpha1.MasterUserRecord) error {
+// Returns `true, nil` if there is a need for requeing (eg, if the remote UserAccount is being deleted and the controller should wait until the deletion is complete)
+func (r *ReconcileMasterUserRecord) ensureUserAccount(logger logr.Logger, murAccount toolchainv1alpha1.UserAccountEmbedded, mur *toolchainv1alpha1.MasterUserRecord) (bool, error) {
 	// get & check member cluster
 	memberCluster, err := r.getMemberCluster(murAccount.TargetCluster)
 	if err != nil {
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordTargetClusterNotReadyReason), err,
+		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordTargetClusterNotReadyReason), err,
 			"failed to get the member cluster '%s'", murAccount.TargetCluster)
 	}
 
@@ -163,14 +170,19 @@ func (r *ReconcileMasterUserRecord) ensureUserAccount(logger logr.Logger, murAcc
 			// does not exist - should create
 			userAccount = newUserAccount(nsdName, murAccount.Spec, mur.Spec)
 			if err := memberCluster.Client.Create(context.TODO(), userAccount); err != nil {
-				return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
+				return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
 					"failed to create UserAccount in the member cluster '%s'", murAccount.TargetCluster)
 			}
-			return updateStatusConditions(logger, r.client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
+			return false, updateStatusConditions(logger, r.client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
 		}
 		// another/unexpected error occurred while trying to fetch the user account on the member cluster
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToGetUserAccountReason), err,
+		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToGetUserAccountReason), err,
 			"failed to get userAccount '%s' from cluster '%s'", mur.Name, murAccount.TargetCluster)
+	}
+	// if the UserAccount is being deleted (by accident?), then we should wait until is has been totally deleted, and this controller will recreate it again
+	if util.IsBeingDeleted(userAccount) {
+		logger.Info("UserAccount is being deleted. Waiting until deletion is complete", "member_cluster", memberCluster.Name)
+		return true, updateStatusConditions(logger, r.client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
 	}
 
 	sync := Synchronizer{
@@ -185,17 +197,17 @@ func (r *ReconcileMasterUserRecord) ensureUserAccount(logger logr.Logger, murAcc
 	}
 	if err := sync.synchronizeSpec(); err != nil {
 		// note: if we got an error while sync'ing the spec, then we may not be able to update the MUR status it here neither.
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToSynchronizeUserAccountSpecReason), err,
+		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToSynchronizeUserAccountSpecReason), err,
 			"update of the UserAccount.spec in the cluster '%s' failed", murAccount.TargetCluster)
 	}
 	if err := sync.synchronizeStatus(); err != nil {
 		err = errs.Wrapf(err, "update of the MasterUserRecord failed while synchronizing with UserAccount status from the cluster '%s'", murAccount.TargetCluster)
 		// note: if we got an error while updating the status, then we probably can't update it here neither.
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.useExistingConditionOfType(toolchainv1alpha1.ConditionReady), err, "")
+		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.useExistingConditionOfType(toolchainv1alpha1.ConditionReady), err, "")
 	}
 	// nothing done and no error occurred
 	logger.Info("user account on member cluster was already in sync", "target_cluster", murAccount.TargetCluster)
-	return nil
+	return false, nil
 }
 
 func (r *ReconcileMasterUserRecord) getMemberCluster(targetCluster string) (*cluster.CachedToolchainCluster, error) {

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -182,7 +182,7 @@ func (r *ReconcileMasterUserRecord) ensureUserAccount(logger logr.Logger, murAcc
 	// if the UserAccount is being deleted (by accident?), then we should wait until is has been totally deleted, and this controller will recreate it again
 	if util.IsBeingDeleted(userAccount) {
 		logger.Info("UserAccount is being deleted. Waiting until deletion is complete", "member_cluster", memberCluster.Name)
-		return true, updateStatusConditions(logger, r.client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
+		return true, updateStatusConditions(logger, r.client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "recovering deleted UserAccount"))
 	}
 
 	sync := Synchronizer{

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -153,7 +153,7 @@ func TestRequeueWhenUserAccountDeleted(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	assert.True(t, result.Requeue)
-
+	assert.Equal(t, 3 * time.Second, result.RequeueAfter)
 }
 
 func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
@@ -153,7 +154,7 @@ func TestRequeueWhenUserAccountDeleted(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	assert.True(t, result.Requeue)
-	assert.Equal(t, 3 * time.Second, result.RequeueAfter)
+	assert.Equal(t, 3*time.Second, result.RequeueAfter)
 }
 
 func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {

--- a/pkg/controller/nstemplatetier/nstemplatetier_controller.go
+++ b/pkg/controller/nstemplatetier/nstemplatetier_controller.go
@@ -3,7 +3,6 @@ package nstemplatetier
 import (
 	"context"
 	"fmt"
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
@@ -144,7 +143,7 @@ func (r *NSTemplateTierReconciler) ensureStatusUpdateRecord(logger logr.Logger, 
 	// if there was no previous status:
 	if len(tier.Status.Updates) == 0 {
 		tier.Status.Updates = append(tier.Status.Updates, toolchainv1alpha1.NSTemplateTierHistory{
-			StartTime: metav1.NewTime(time.Now()),
+			StartTime: metav1.Now(),
 			Hash:      hash,
 		})
 		return true, r.client.Status().Update(context.TODO(), tier)
@@ -159,7 +158,7 @@ func (r *NSTemplateTierReconciler) ensureStatusUpdateRecord(logger logr.Logger, 
 	tier.Status.Updates[len(tier.Status.Updates)-1].FailedAccounts = nil
 	logger.Info("Adding a new entry in tier.status.updates")
 	tier.Status.Updates = append(tier.Status.Updates, toolchainv1alpha1.NSTemplateTierHistory{
-		StartTime: metav1.NewTime(time.Now()),
+		StartTime: metav1.Now(),
 		Hash:      hash,
 	})
 	return true, r.client.Status().Update(context.TODO(), tier)

--- a/pkg/controller/nstemplatetier/nstemplatetier_controller_test.go
+++ b/pkg/controller/nstemplatetier/nstemplatetier_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
@@ -195,7 +194,7 @@ func TestReconcile(t *testing.T) {
 			// check that no TemplateUpdateRequest was created
 			turtest.AssertThatTemplateUpdateRequests(t, cl).TotalCount(0)
 			// also check that the tier `status.updates` was updated with a new entry
-			now := metav1.NewTime(time.Now())
+			now := metav1.Now()
 			tiertest.AssertThatNSTemplateTier(t, basicTier.Name, cl).
 				HasStatusUpdatesItems(1).
 				// at this point, all the counters are '0'

--- a/test/templateupdaterequest/templateupdaterequest.go
+++ b/test/templateupdaterequest/templateupdaterequest.go
@@ -2,7 +2,6 @@ package templateupdaterequest
 
 import (
 	"fmt"
-	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -67,7 +66,7 @@ var _ Option = DeletionTimestamp("")
 
 func (d DeletionTimestamp) applyToTemplateUpdateRequest(r *toolchainv1alpha1.TemplateUpdateRequest) {
 	if r.Name == string(d) {
-		deletionTS := metav1.NewTime(time.Now())
+		deletionTS := metav1.Now()
 		r.DeletionTimestamp = &deletionTS
 	}
 }


### PR DESCRIPTION
When ensuring the UserAccounts for the MasterUserRecord exist, if one
is being deleted, then the controller will requeue (with a delay),
which should give time to the member cluster to finish deleting
the resources. Then, during the new reconcile loop, the
MasterUserRecord controller will recreate the UserAccount.

Also, small refactorings (func name and using `metav1.Now()`
as a shorthand)

E2E Tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/146

Fixes https://issues.redhat.com/browse/CRT-778

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
