### PR TITLE
adding update permissions to registration-service.yaml

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -25,6 +25,7 @@ objects:
       verbs:
       - create
       - get
+      - update
     - apiGroups:
       - toolchain.dev.openshift.com
       resources:


### PR DESCRIPTION
we forgot to add this to the host-operator. it was only added to the registration-service:  https://github.com/codeready-toolchain/registration-service/blob/master/deploy/registration-service.yaml#L28