### PR TITLE
feat: make the ToolchainStatus requeue time configurable

### DIFF
--- a/deploy/env/e2e-tests.yaml
+++ b/deploy/env/e2e-tests.yaml
@@ -5,3 +5,4 @@ host-operator:
   duration-before-change-request-deletion: '5s'
   duration-before-notification-deletion: '5s'
   environment: 'e2e-tests'
+  toolchainstatus-refresh-time: '1s'

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -116,6 +116,12 @@ const (
 
 	// varMasterUserRecordUpdateFailureThreshold specifies the number allowed failures before stopping trying to update a MasterUserRecord
 	varMasterUserRecordUpdateFailureThreshold = "masteruserrecord.update.failure.threshold"
+
+	// varToolchainStatusRefreshTime specifies how often the ToolchainStatus should load and refresh the current hosted-toolchain status
+	varToolchainStatusRefreshTime = "toolchainstatus.refresh.time"
+
+	// defaultToolchainStatusRefreshTime is the default refresh period for ToolchainStatus
+	defaultToolchainStatusRefreshTime = "5s"
 )
 
 // Config encapsulates the Viper configuration registry which stores the
@@ -187,6 +193,7 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varCheRouteName, defaultCheRouteName)
 	c.host.SetDefault(varEnvironment, defaultEnvironment)
 	c.host.SetDefault(varMasterUserRecordUpdateFailureThreshold, 2) // allow 1 failure, try again and then give up if failed again
+	c.host.SetDefault(varToolchainStatusRefreshTime, defaultToolchainStatusRefreshTime)
 }
 
 // GetToolchainStatusName returns the configured name of the member status resource
@@ -262,6 +269,11 @@ func (c *Config) GetEnvironment() string {
 // GetMasterUserRecordUpdateFailureThreshold returns the number of allowed failures before stopping trying to update a MasterUserRecord
 func (c *Config) GetMasterUserRecordUpdateFailureThreshold() int {
 	return c.host.GetInt(varMasterUserRecordUpdateFailureThreshold)
+}
+
+// GetToolchainStatusRefreshTime returns the time how often the ToolchainStatus should load and refresh the current hosted-toolchain status
+func (c *Config) GetToolchainStatusRefreshTime() time.Duration {
+	return c.host.GetDuration(varToolchainStatusRefreshTime)
 }
 
 // GetAllRegistrationServiceParameters returns a map with key-values pairs of parameters that have REGISTRATION_SERVICE prefix

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -264,3 +264,26 @@ func TestGetToolchainStatusName(t *testing.T) {
 		assert.Equal(t, testName, config.GetToolchainStatusName())
 	})
 }
+
+func TestGetToolchainStatusRefreshTime(t *testing.T) {
+	key := configuration.HostEnvPrefix + "_" + "TOOLCHAINSTATUS_REFRESH_TIME"
+	resetFunc := test.UnsetEnvVarAndRestore(t, key)
+	defer resetFunc()
+
+	t.Run("default", func(t *testing.T) {
+		resetFunc := test.UnsetEnvVarAndRestore(t, key)
+		defer resetFunc()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, cast.ToDuration("5s"), config.GetToolchainStatusRefreshTime())
+	})
+
+	t.Run("env overwrite", func(t *testing.T) {
+		restore := test.SetEnvVarAndRestore(t, key, "1s")
+		defer restore()
+
+		restore = test.SetEnvVarAndRestore(t, configuration.HostEnvPrefix+"_"+"ANY_CONFIG", "20s")
+		defer restore()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, cast.ToDuration("1s"), config.GetToolchainStatusRefreshTime())
+	})
+}

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/host-operator/pkg/controller/registrationservice"
@@ -33,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var requeueResult = reconcile.Result{RequeueAfter: defaultRequeueTime}
+var requeueResult = reconcile.Result{RequeueAfter: 5 * time.Second}
 
 const (
 	defaultHostOperatorName        = "host-operator"


### PR DESCRIPTION
makes the ToolchainStatus requeue time configurable - this will be used in e2e tests to shorter the time we need to wait for the update of the ToolchainStatus resource. For now, there is no such a check/wait but I'll introduce it in e2e tetsts for the counter PR: https://github.com/codeready-toolchain/host-operator/pull/276