### PR TITLE
Deactivation controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20200909202915-e74d6da8a04a
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200914140500-5543daea3180
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.3.0+incompatible
@@ -36,7 +36,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20200911192942-a848038112a5
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20200911131810-cc8c18de1f57
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200914140500-5543daea3180
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200914220109-fa9ff58ae598
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.3.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,6 @@ replace (
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20200911192942-a848038112a5
+
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/codeready-toolchain/api v0.0.0-20200827094533-2721a660825a/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
 github.com/codeready-toolchain/api v0.0.0-20200911131810-cc8c18de1f57 h1:DbLr7jCX1qtd/shp9GE2MbAs6msENX8EBwcyhHF1y7E=
 github.com/codeready-toolchain/api v0.0.0-20200911131810-cc8c18de1f57/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200914140500-5543daea3180 h1:oEuHD1k6u4pEvQ6FinEcmFU1VY70hCVd/Y9clx/az1k=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200914140500-5543daea3180/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200914220109-fa9ff58ae598 h1:HgidgF76fQ/yOzAqg4x1C/gJvbhRqAutnTpwW+vnqcM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200914220109-fa9ff58ae598/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/codeready-toolchain/api v0.0.0-20200827094533-2721a660825a/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
 github.com/codeready-toolchain/api v0.0.0-20200909202915-e74d6da8a04a h1:c3Dorc8F0aXIfVEQUWpNVusEeLIVIh9hhT6+K4jUNcQ=
 github.com/codeready-toolchain/api v0.0.0-20200909202915-e74d6da8a04a/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886 h1:q+oeKCBgOij4NeO12YizGPOU/PNXPWNP39T8qXzOXzM=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200903074939-0e6cc580a886/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200914140500-5543daea3180 h1:oEuHD1k6u4pEvQ6FinEcmFU1VY70hCVd/Y9clx/az1k=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200914140500-5543daea3180/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -770,8 +770,6 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/toolchain-common v0.0.0-20200911192942-a848038112a5 h1:PHiZQswjY3MRSY6I9jNIkoBo9hUTaBMWSWi7wjdtEjg=
-github.com/rajivnathan/toolchain-common v0.0.0-20200911192942-a848038112a5/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/go.sum
+++ b/go.sum
@@ -770,6 +770,8 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/toolchain-common v0.0.0-20200911192942-a848038112a5 h1:PHiZQswjY3MRSY6I9jNIkoBo9hUTaBMWSWi7wjdtEjg=
+github.com/rajivnathan/toolchain-common v0.0.0-20200911192942-a848038112a5/go.mod h1:eSq/DethrsL9Gv0uHP3gd5F1/IXebjFh437bQydL1zo=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776 h1:b4BUvzMzkoRJvEbs1J3GaewlHzjxYYxVfuy8/DOU9zo=
 github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776/go.mod h1:K9f0vBA2bBiDyg9bsGDUojdwdhwUvHKX5QW0B+brWgo=

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -122,6 +122,12 @@ const (
 
 	// defaultToolchainStatusRefreshTime is the default refresh period for ToolchainStatus
 	defaultToolchainStatusRefreshTime = "5s"
+
+	// varDeactivationDomainsExcluded is a string of space-separated domains that should be excluded from automatic user deactivation
+	varDeactivationDomainsExcluded = "deactivation.domains.excluded"
+
+	// defaultDeactivationDomainsExcluded is the default set of domains that should be excluded from automatic user deactivation
+	defaultDeactivationDomainsExcluded = "@redhat.com"
 )
 
 // Config encapsulates the Viper configuration registry which stores the
@@ -194,6 +200,7 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varEnvironment, defaultEnvironment)
 	c.host.SetDefault(varMasterUserRecordUpdateFailureThreshold, 2) // allow 1 failure, try again and then give up if failed again
 	c.host.SetDefault(varToolchainStatusRefreshTime, defaultToolchainStatusRefreshTime)
+	c.host.SetDefault(varDeactivationDomainsExcluded, defaultDeactivationDomainsExcluded)
 }
 
 // GetToolchainStatusName returns the configured name of the member status resource
@@ -290,4 +297,9 @@ func (c *Config) GetAllRegistrationServiceParameters() map[string]string {
 		}
 	}
 	return vars
+}
+
+// GetDeactivationDomainsExcludedList returns a string of space-separated domains that should be excluded from automatic user deactivation
+func (c *Config) GetDeactivationDomainsExcludedList() string {
+	return c.host.GetString(varDeactivationDomainsExcluded)
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -123,11 +123,9 @@ const (
 	// defaultToolchainStatusRefreshTime is the default refresh period for ToolchainStatus
 	defaultToolchainStatusRefreshTime = "5s"
 
-	// varDeactivationDomainsExcluded is a string of space-separated domains that should be excluded from automatic user deactivation
+	// varDeactivationDomainsExcluded is a string of comma-separated domains that should be excluded from automatic user deactivation
+	// For example: "@redhat.com,@ibm.com"
 	varDeactivationDomainsExcluded = "deactivation.domains.excluded"
-
-	// defaultDeactivationDomainsExcluded is the default set of domains that should be excluded from automatic user deactivation
-	defaultDeactivationDomainsExcluded = "@redhat.com"
 )
 
 // Config encapsulates the Viper configuration registry which stores the
@@ -200,7 +198,6 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varEnvironment, defaultEnvironment)
 	c.host.SetDefault(varMasterUserRecordUpdateFailureThreshold, 2) // allow 1 failure, try again and then give up if failed again
 	c.host.SetDefault(varToolchainStatusRefreshTime, defaultToolchainStatusRefreshTime)
-	c.host.SetDefault(varDeactivationDomainsExcluded, defaultDeactivationDomainsExcluded)
 }
 
 // GetToolchainStatusName returns the configured name of the member status resource
@@ -299,7 +296,9 @@ func (c *Config) GetAllRegistrationServiceParameters() map[string]string {
 	return vars
 }
 
-// GetDeactivationDomainsExcludedList returns a string of space-separated domains that should be excluded from automatic user deactivation
-func (c *Config) GetDeactivationDomainsExcludedList() string {
-	return c.host.GetString(varDeactivationDomainsExcluded)
+// GetDeactivationDomainsExcludedList returns a string of comma-separated user email domains that should be excluded from automatic user deactivation
+func (c *Config) GetDeactivationDomainsExcludedList() []string {
+	return strings.FieldsFunc(c.host.GetString(varDeactivationDomainsExcluded), func(c rune) bool {
+		return c == ','
+	})
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -297,17 +297,18 @@ func TestGetDeactivationDomainsExcludedList(t *testing.T) {
 		resetFunc := test.UnsetEnvVarAndRestore(t, key)
 		defer resetFunc()
 		config := getDefaultConfiguration(t)
-		assert.Equal(t, "@redhat.com", config.GetDeactivationDomainsExcludedList())
+		assert.Empty(t, config.GetDeactivationDomainsExcludedList())
 	})
 
 	t.Run("env overwrite", func(t *testing.T) {
-		testDomains := "@foo.com @bar.com"
+		testDomains := "@foo.com,@bar.com"
+		expected := []string{"@foo.com", "@bar.com"}
 		restore := test.SetEnvVarAndRestore(t, key, testDomains)
 		defer restore()
 
 		restore = test.SetEnvVarAndRestore(t, configuration.HostEnvPrefix+"_"+"ANY_CONFIG", "20s")
 		defer restore()
 		config := getDefaultConfiguration(t)
-		assert.Equal(t, testDomains, config.GetDeactivationDomainsExcludedList())
+		assert.Equal(t, expected, config.GetDeactivationDomainsExcludedList())
 	})
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -287,3 +287,27 @@ func TestGetToolchainStatusRefreshTime(t *testing.T) {
 		assert.Equal(t, cast.ToDuration("1s"), config.GetToolchainStatusRefreshTime())
 	})
 }
+
+func TestGetDeactivationDomainsExcludedList(t *testing.T) {
+	key := configuration.HostEnvPrefix + "_" + "DEACTIVATION_DOMAINS_EXCLUDED"
+	resetFunc := test.UnsetEnvVarAndRestore(t, key)
+	defer resetFunc()
+
+	t.Run("default", func(t *testing.T) {
+		resetFunc := test.UnsetEnvVarAndRestore(t, key)
+		defer resetFunc()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, "@redhat.com", config.GetDeactivationDomainsExcludedList())
+	})
+
+	t.Run("env overwrite", func(t *testing.T) {
+		testDomains := "@foo.com @bar.com"
+		restore := test.SetEnvVarAndRestore(t, key, testDomains)
+		defer restore()
+
+		restore = test.SetEnvVarAndRestore(t, configuration.HostEnvPrefix+"_"+"ANY_CONFIG", "20s")
+		defer restore()
+		config := getDefaultConfiguration(t)
+		assert.Equal(t, testDomains, config.GetDeactivationDomainsExcludedList())
+	})
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/host-operator/pkg/controller/changetierrequest"
+	"github.com/codeready-toolchain/host-operator/pkg/controller/deactivation"
 	"github.com/codeready-toolchain/host-operator/pkg/controller/masteruserrecord"
 	"github.com/codeready-toolchain/host-operator/pkg/controller/notification"
 	"github.com/codeready-toolchain/host-operator/pkg/controller/nstemplatetier"
@@ -28,6 +29,8 @@ func init() {
 	addToManagerFuncs = append(addToManagerFuncs, notification.Add)
 	addToManagerFuncs = append(addToManagerFuncs, toolchainstatus.Add)
 	addToManagerFuncs = append(addToManagerFuncs, templateupdaterequest.Add)
+	addToManagerFuncs = append(addToManagerFuncs, deactivation.Add)
+
 }
 
 // AddToManager adds all Controllers to the Manager

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -122,7 +122,7 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
-	// The tier a mur belongs to is defined as part of its user account, since murs can in theory have multiple user accounts we will only consider the first one
+	// The tier is defined as part of its user account, since murs can in theory have multiple user accounts we will only consider the first one
 	account := mur.Spec.UserAccounts[0]
 
 	// Get the tier associated with the user account, we'll observe the deactivation timeout period from the tier spec

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -110,7 +110,7 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 
 	// Check the domain exclusion list, if the user's email matches then they cannot be automatically deactivated
 	if emailLbl, exists := usersignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]; exists {
-		for _, domain := range strings.Split(r.config.GetDeactivationDomainsExcludedList(), " ") {
+		for _, domain := range r.config.GetDeactivationDomainsExcludedList() {
 			if strings.HasSuffix(emailLbl, domain) {
 				logger.Info("user cannot be automatically deactivated because they belong to the exclusion list", "domain", domain)
 				return reconcile.Result{}, nil

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -2,6 +2,7 @@ package deactivation
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -118,7 +119,8 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	if len(mur.Spec.UserAccounts) == 0 {
-		logger.Error(err, "cannot determine deactivation timeout period because the mur has no associated user accounts")
+		err = fmt.Errorf("cannot determine deactivation timeout period because the mur has no associated user accounts")
+		logger.Error(err, "failed to process deactivation")
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -1,0 +1,166 @@
+package deactivation
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	coputil "github.com/redhat-cop/operator-utils/pkg/util"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_deactivation")
+
+// Add creates a new Deactivation Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, config *configuration.Config) error {
+	return add(mgr, newReconciler(mgr, config))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, cfg *configuration.Config) reconcile.Reconciler {
+	return &ReconcileDeactivation{client: mgr.GetClient(), scheme: mgr.GetScheme(), config: cfg}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("deactivation-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource MasterUserRecord
+	err = c.Watch(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileDeactivation{}
+
+// ReconcileDeactivation reconciles a Deactivation object
+type ReconcileDeactivation struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+	config *configuration.Config
+}
+
+// Reconcile reads the state of the cluster for a MUR object and determines whether to trigger deactivation or requeue based on its current status
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	logger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	logger.Info("Reconciling Deactivation")
+
+	// Fetch the MasterUserRecord instance
+	mur := &toolchainv1alpha1.MasterUserRecord{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, mur)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		logger.Error(err, "unable to get MasterUserRecord")
+		return reconcile.Result{}, err
+	}
+
+	// If the MasterUserRecord is being deleted, no need to do anything else
+	if coputil.IsBeingDeleted(mur) {
+		return reconcile.Result{}, nil
+	}
+
+	// Deactivation only applies to users that have been provisioned
+	if mur.Status.ProvisionedTime == nil {
+		return reconcile.Result{}, nil
+	}
+	provisionedTimestamp := *mur.Status.ProvisionedTime
+
+	// Get the associated usersignup
+	usersignup := &toolchainv1alpha1.UserSignup{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{
+		Namespace: mur.Namespace,
+		Name:      mur.Spec.UserID,
+	}, usersignup); err != nil {
+		// Error getting usersignup - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Check the domain exclusion list, if the user's email matches then they cannot be automatically deactivated
+	if emailLbl, exists := usersignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]; exists {
+		for _, domain := range strings.Split(r.config.GetDeactivationDomainsExcludedList(), " ") {
+			if strings.HasSuffix(emailLbl, domain) {
+				logger.Info("user cannot be automatically deactivated because they belong to the exclusion list", "domain", domain)
+				return reconcile.Result{}, nil
+			}
+		}
+	}
+
+	if len(mur.Spec.UserAccounts) == 0 {
+		logger.Error(err, "cannot determine deactivation timeout period because the mur has no associated user accounts")
+		return reconcile.Result{}, err
+	}
+
+	// The tier a mur belongs to is defined as part of its user account, since murs can in theory have multiple user accounts we will only consider the first one
+	account := mur.Spec.UserAccounts[0]
+
+	// Get the tier associated with the user account, we'll observe the deactivation timeout period from the tier spec
+	nsTemplateTier := &toolchainv1alpha1.NSTemplateTier{}
+	tierName := types.NamespacedName{Namespace: request.Namespace, Name: account.Spec.NSTemplateSet.TierName}
+	if err := r.client.Get(context.TODO(), tierName, nsTemplateTier); err != nil {
+		logger.Error(err, "unable to get NSTemplateTier", "name", account.Spec.NSTemplateSet.TierName)
+		return reconcile.Result{}, err
+	}
+
+	// If the deactivation timeout is 0 then users that belong to this tier should not be automatically deactivated
+	deactivationTimeoutDays := nsTemplateTier.Spec.DeactivationTimeoutDays
+	if deactivationTimeoutDays == 0 {
+		logger.Info("User belongs to a tier that does not have a deactivation timeout. The user will not be automatically deactivated")
+		// Users belonging to this tier will not be auto deactivated, no need to requeue.
+		return reconcile.Result{}, nil
+	}
+
+	deactivationTimeout := time.Duration(deactivationTimeoutDays*24) * time.Hour
+
+	logger.Info("user account time values", "deactivation timeout duration", deactivationTimeout, "provisionedTimestamp", provisionedTimestamp)
+
+	timeSinceProvisioned := time.Since(provisionedTimestamp.Time)
+	if timeSinceProvisioned < deactivationTimeout {
+		// It is not yet time to deactivate so requeue when it will be
+		requeueAfterExpired := deactivationTimeout - timeSinceProvisioned
+		logger.Info("requeueing request", "RequeueAfter", requeueAfterExpired, "Expected deactivation date/time", time.Now().Add(requeueAfterExpired).String())
+		return reconcile.Result{RequeueAfter: requeueAfterExpired}, nil
+	}
+
+	// Deactivate the user
+	usersignup.Spec.Deactivated = true
+
+	logger.Info("deactivating the user")
+	if err := r.client.Update(context.TODO(), usersignup); err != nil {
+		logger.Error(err, "failed to update usersignup")
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -10,6 +10,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+	"github.com/codeready-toolchain/toolchain-common/pkg/predicate"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,7 +46,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource MasterUserRecord
-	err = c.Watch(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}}, &handler.EnqueueRequestForObject{}, predicate.OnlyUpdateWhenGenerationNotChanged{})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -116,6 +116,8 @@ func TestReconcile(t *testing.T) {
 		// a user that belongs to the deactivation domain excluded list
 		t.Run("user deactivation excluded", func(t *testing.T) {
 			// given
+			restore := test.SetEnvVarAndRestore(t, "HOST_OPERATOR_DEACTIVATION_DOMAINS_EXCLUDED", "@redhat.com")
+			defer restore()
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutBasicTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupRedhat))
 			r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupRedhat)

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -1,0 +1,421 @@
+package deactivation
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/apis"
+	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+	tiertest "github.com/codeready-toolchain/host-operator/test/nstemplatetier"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+const (
+	operatorNamespace = "toolchain-host-operator"
+)
+
+func TestReconcile(t *testing.T) {
+
+	// given
+	logf.SetLogger(logf.ZapLogger(true))
+	username := "test-user"
+
+	t.Run("controller should not deactivate user", func(t *testing.T) {
+
+		// the time since the mur was provisioned is within the deactivation timeout period for the 'basic' tier
+		t.Run("usersignup should not be deactivated - basic tier (30 days)", func(t *testing.T) {
+			// given
+			expectedDeactivationTimeout := 30
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
+			murProvisionedTime := &metav1.Time{Time: time.Now()}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{basicTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			timeSinceProvisioned := time.Since(murProvisionedTime.Time)
+			res, err := r.Reconcile(req)
+			// then
+			require.NoError(t, err)
+			expectedTime := (time.Duration(expectedDeactivationTimeout*24) * time.Hour) - timeSinceProvisioned
+			actualTime := res.RequeueAfter
+			diff := expectedTime - actualTime
+			require.Truef(t, diff > 0 && diff < time.Second, "expectedTime: '%v' is not within 1 second of actualTime: '%v' diff: '%v'", expectedTime, actualTime, diff)
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.False(t, deactivated)
+		})
+
+		// the time since the mur was provisioned is within the deactivation timeout period for the 'other' tier
+		t.Run("usersignup should not be deactivated - other tier (60 days)", func(t *testing.T) {
+			// given
+			expectedDeactivationTimeout := 60
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			otherTier := tiertest.OtherTier()
+			murProvisionedTime := &metav1.Time{Time: time.Now()}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *otherTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{otherTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			timeSinceProvisioned := time.Since(murProvisionedTime.Time)
+			res, err := r.Reconcile(req)
+			// then
+			require.NoError(t, err)
+			expectedTime := (time.Duration(expectedDeactivationTimeout*24) * time.Hour) - timeSinceProvisioned
+			actualTime := res.RequeueAfter
+			diff := expectedTime - actualTime
+			require.Truef(t, diff > 0 && diff < time.Second, "expectedTime: '%v' is not within 1 second of actualTime: '%v' diff: '%v'", expectedTime, actualTime, diff)
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.False(t, deactivated)
+		})
+
+		// the tier does not have a deactivationTimeoutDays set so the time since the mur was provisioned is irrelevant, the user should not be deactivated
+		t.Run("usersignup should not be deactivated - no deactivation tier", func(t *testing.T) {
+			// given
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			noDeactivationTier := tiertest.TierWithoutDeactivationTimeout()
+			murProvisionedTime := &metav1.Time{Time: time.Now()}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *noDeactivationTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{noDeactivationTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			res, err := r.Reconcile(req)
+			// then
+			require.NoError(t, err)
+			require.False(t, res.Requeue, "requeue should not be set")
+			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.False(t, deactivated)
+		})
+
+		// a mur that has not been provisioned yet
+		t.Run("mur without provisioned time", func(t *testing.T) {
+			// given
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{basicTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			res, err := r.Reconcile(req)
+			// then
+			require.NoError(t, err)
+			require.False(t, res.Requeue, "requeue should not be set")
+			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.False(t, deactivated)
+		})
+
+		// a user that belongs to the deactivation domain excluded list
+		t.Run("user deactivation excluded", func(t *testing.T) {
+			// given
+			expectedDeactivationTimeout := 30
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@redhat.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@redhat.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates)
+			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeout*24) * time.Hour)}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{basicTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			res, err := r.Reconcile(req)
+			// then
+			require.NoError(t, err)
+			require.False(t, res.Requeue, "requeue should not be set")
+			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.False(t, deactivated)
+		})
+	})
+
+	// in these tests, the controller should deactivate the user
+	t.Run("controller should deactivate user", func(t *testing.T) {
+		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'basic' tier
+		t.Run("usersignup should be deactivated - basic tier (30 days)", func(t *testing.T) {
+			// given
+			expectedDeactivationTimeout := 30
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates)
+			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeout*24) * time.Hour)}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{basicTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			res, err := r.Reconcile(req)
+			// then
+			require.NoError(t, err)
+			require.False(t, res.Requeue, "requeue should not be set")
+			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.True(t, deactivated)
+		})
+
+		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'other' tier
+		t.Run("usersignup should be deactivated - other tier (60 days)", func(t *testing.T) {
+			// given
+			expectedDeactivationTimeout := 60
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			otherTier := tiertest.OtherTier()
+			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeout*24) * time.Hour)}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *otherTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{otherTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			res, err := r.Reconcile(req)
+			// then
+			require.NoError(t, err)
+			require.False(t, res.Requeue, "requeue should not be set")
+			require.True(t, res.RequeueAfter == 0, "requeue should not be set")
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.True(t, deactivated)
+		})
+
+	})
+
+	t.Run("failures", func(t *testing.T) {
+
+		// cannot find NSTemplateTier
+		t.Run("unable to get NSTemplateTier", func(t *testing.T) {
+			// given
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
+			murProvisionedTime := &metav1.Time{Time: time.Now()}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			_, err := r.Reconcile(req)
+			// then
+			require.Error(t, err)
+			require.Contains(t, err.Error(), `nstemplatetiers.toolchain.dev.openshift.com "basic" not found`)
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.False(t, deactivated)
+		})
+
+		// cannot find NSTemplateTier
+		t.Run("NSTemplateTier without deactivation timeout", func(t *testing.T) {
+			// given
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			noDeactivationTier := tiertest.TierWithoutDeactivationTimeout()
+			murProvisionedTime := &metav1.Time{Time: time.Now()}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *noDeactivationTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{noDeactivationTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			// when
+			res, err := r.Reconcile(req)
+			// then
+			require.NoError(t, err)
+			require.False(t, res.Requeue, "requeue should not be set")
+			require.True(t, res.RequeueAfter == 0, "requeue should not be set")
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.False(t, deactivated)
+		})
+
+		// cannot get UserSignup
+		t.Run("UserSignup get failure", func(t *testing.T) {
+			// given
+			expectedDeactivationTimeout := 30
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates)
+			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeout*24) * time.Hour)}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{basicTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				_, ok := obj.(*toolchainv1alpha1.UserSignup)
+				if ok {
+					return fmt.Errorf("usersignup get error")
+				}
+				rmur, ok := obj.(*toolchainv1alpha1.MasterUserRecord)
+				if ok {
+					mur.DeepCopyInto(rmur)
+					return nil
+				}
+				return nil
+			}
+			// when
+			res, err := r.Reconcile(req)
+			// then
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "usersignup get error")
+			require.False(t, res.Requeue, "requeue should not be set")
+			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
+		})
+
+		// cannot update UserSignup
+		t.Run("UserSignup update failure", func(t *testing.T) {
+			// given
+			expectedDeactivationTimeout := 30
+			userSignup := &toolchainv1alpha1.UserSignup{
+				ObjectMeta: newObjectMeta(username, "foo@bar.com"),
+				Spec: toolchainv1alpha1.UserSignupSpec{
+					Username:      "foo@bar.com",
+					Approved:      true,
+					TargetCluster: "east",
+				},
+			}
+			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates)
+			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeout*24) * time.Hour)}
+			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignup))
+			initObjs := []runtime.Object{basicTier, mur, userSignup}
+			r, req, cl := prepareReconcile(t, mur.Name, initObjs...)
+			cl.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+				_, ok := obj.(*toolchainv1alpha1.UserSignup)
+				if ok {
+					return fmt.Errorf("usersignup update error")
+				}
+				return nil
+			}
+			// when
+			res, err := r.Reconcile(req)
+			// then
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "usersignup update error")
+			require.False(t, res.Requeue, "requeue should not be set")
+			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
+			deactivated, err := isUserSignupDeactivated(cl, username)
+			require.NoError(t, err)
+			require.False(t, deactivated)
+		})
+	})
+
+}
+
+func prepareReconcile(t *testing.T, name string, initObjs ...runtime.Object) (reconcile.Reconciler, reconcile.Request, *test.FakeClient) {
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+	cl := test.NewFakeClient(t, initObjs...)
+	cfg, err := configuration.LoadConfig(cl)
+	r := &ReconcileDeactivation{client: cl, scheme: s, config: cfg}
+	return r, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: operatorNamespace,
+		},
+	}, cl
+}
+
+func newObjectMeta(name, email string) metav1.ObjectMeta {
+	if name == "" {
+		name = uuid.NewV4().String()
+	}
+
+	md5hash := md5.New()
+	// Ignore the error, as this implementation cannot return one
+	_, _ = md5hash.Write([]byte(email))
+	emailHash := hex.EncodeToString(md5hash.Sum(nil))
+
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: operatorNamespace,
+		Annotations: map[string]string{
+			toolchainv1alpha1.UserSignupUserEmailAnnotationKey: email,
+		},
+		Labels: map[string]string{
+			toolchainv1alpha1.UserSignupUserEmailHashLabelKey: emailHash,
+		},
+	}
+}
+
+func isUserSignupDeactivated(cl *test.FakeClient, name string) (bool, error) {
+	userSignup := &toolchainv1alpha1.UserSignup{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: operatorNamespace}, userSignup)
+	if err != nil {
+		return false, err
+	}
+	return userSignup.Spec.Deactivated, nil
+}

--- a/test/nstemplatetier/nstemplatetier.go
+++ b/test/nstemplatetier/nstemplatetier.go
@@ -12,6 +12,7 @@ import (
 
 // PreviousBasicTemplates previous templates for the "basic" tier
 var PreviousBasicTemplates = toolchainv1alpha1.NSTemplateTierSpec{
+	DeactivationTimeoutDays: 30,
 	Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
 		{
 			TemplateRef: "basic-code-123456old",
@@ -30,6 +31,7 @@ var PreviousBasicTemplates = toolchainv1alpha1.NSTemplateTierSpec{
 
 // CurrentBasicTemplates current templates for the "basic" tier
 var CurrentBasicTemplates = toolchainv1alpha1.NSTemplateTierSpec{
+	DeactivationTimeoutDays: 30,
 	Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
 		{
 			TemplateRef: "basic-code-123456new",
@@ -120,6 +122,7 @@ func OtherTier() *toolchainv1alpha1.NSTemplateTier {
 			Name:      "other",
 		},
 		Spec: toolchainv1alpha1.NSTemplateTierSpec{
+			DeactivationTimeoutDays: 60,
 			Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
 				{
 					TemplateRef: "other-code-123456a",
@@ -133,6 +136,32 @@ func OtherTier() *toolchainv1alpha1.NSTemplateTier {
 			},
 			ClusterResources: &toolchainv1alpha1.NSTemplateTierClusterResources{
 				TemplateRef: "other-clusterresources-123456a",
+			},
+		},
+	}
+}
+
+// TierWithoutDeactivationTimeout returns a NSTemplateTier with no deactivation timeout set
+func TierWithoutDeactivationTimeout() *toolchainv1alpha1.NSTemplateTier {
+	return &toolchainv1alpha1.NSTemplateTier{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "toolchain-host-operator",
+			Name:      "no-deactivation",
+		},
+		Spec: toolchainv1alpha1.NSTemplateTierSpec{
+			Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
+				{
+					TemplateRef: "no-deactivation-code-123456a",
+				},
+				{
+					TemplateRef: "no-deactivation-dev-123456a",
+				},
+				{
+					TemplateRef: "no-deactivation-stage-123456a",
+				},
+			},
+			ClusterResources: &toolchainv1alpha1.NSTemplateTierClusterResources{
+				TemplateRef: "no-deactivation-clusterresources-123456a",
 			},
 		},
 	}


### PR DESCRIPTION
Adds a new deactivation controller that watches MUR resources and triggers deactivation of users after the deactivation period expires. The deactivation period is determined by their associated tier.

Adds a configurable domain exclusion list that allows user accounts that match any of the domains in the list to be excluded from automatic deactivation

- The deactivation controller checks the NSTemplateTier associated with the MUR to discover the deactivation timeout value
- If the time since the MUR was provisioned exceeds the Deactivation Period then deactivate the user
- Otherwise, it will requeue the reconcile to a time when the user should be deactivated
- Added unit tests

Note: We cannot activate auto deactivation until we have an API to delete users from Che so this PR introduces the controller but it will not deactivate any users because none of the tiers have `DeactivationTimeoutDays` set. Once the Che changes are in we can put up a separate PR to update the tiers.

Related issue:
https://issues.redhat.com/browse/CRT-755