### PR TITLE
Refactor user signup

### DIFF
--- a/pkg/controller/usersignup/mapper.go
+++ b/pkg/controller/usersignup/mapper.go
@@ -1,0 +1,52 @@
+package usersignup
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type BannedUserToUserSignupMapper struct {
+	client client.Client
+}
+
+var _ handler.Mapper = BannedUserToUserSignupMapper{}
+
+func (b BannedUserToUserSignupMapper) Map(obj handler.MapObject) []reconcile.Request {
+	if bu, ok := obj.Object.(*toolchainv1alpha1.BannedUser); ok {
+		// look-up any associated UserSignup using the BannedUser's "toolchain.dev.openshift.com/email-hash" label
+		if emailHashLbl, exists := bu.Labels[toolchainv1alpha1.BannedUserEmailHashLabelKey]; exists {
+
+			labels := map[string]string{toolchainv1alpha1.UserSignupUserEmailHashLabelKey: emailHashLbl}
+			opts := client.MatchingLabels(labels)
+			userSignupList := &toolchainv1alpha1.UserSignupList{}
+			if err := b.client.List(context.TODO(), userSignupList, opts); err != nil {
+				log.Error(err, "Could not list UserSignup resources with label value", toolchainv1alpha1.UserSignupUserEmailHashLabelKey, emailHashLbl)
+				return nil
+			}
+
+			req := []reconcile.Request{}
+
+			ns, err := k8sutil.GetWatchNamespace()
+			if err != nil {
+				log.Error(err, "Could not determine watched namespace")
+				return nil
+			}
+
+			for _, userSignup := range userSignupList.Items {
+				req = append(req, reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: ns, Name: userSignup.Name},
+				})
+			}
+
+			return req
+		}
+	}
+	// the obj was not a BannedUser or it did not have the required label.
+	return []reconcile.Request{}
+}

--- a/pkg/controller/usersignup/mapper_test.go
+++ b/pkg/controller/usersignup/mapper_test.go
@@ -1,0 +1,100 @@
+package usersignup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestBannedUserToUserSignupMapper(t *testing.T) {
+	// when
+	bannedUser := &toolchainv1alpha1.BannedUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				toolchainv1alpha1.BannedUserEmailHashLabelKey: "fd2addbd8d82f0d2dc088fa122377eaa",
+			},
+		},
+		Spec: toolchainv1alpha1.BannedUserSpec{
+			Email: "foo@redhat.com",
+		},
+	}
+
+	t.Run("test BannedUserToUserSignupMapper maps correctly", func(t *testing.T) {
+		userSignup := &v1alpha1.UserSignup{
+			ObjectMeta: newObjectMeta("", "foo@redhat.com"),
+			Spec: v1alpha1.UserSignupSpec{
+				Username: "foo@redhat.com",
+			},
+		}
+
+		userSignup2 := &v1alpha1.UserSignup{
+			ObjectMeta: newObjectMeta("", "alice.mayweather.doe@redhat.com"),
+			Spec: v1alpha1.UserSignupSpec{
+				Username: "alice.mayweather.doe@redhat.com",
+			},
+		}
+
+		c := test.NewFakeClient(t, userSignup, userSignup2)
+
+		mapper := &BannedUserToUserSignupMapper{
+			client: c,
+		}
+
+		// This is required for the mapper to function
+		os.Setenv(k8sutil.WatchNamespaceEnvVar, operatorNamespace)
+		defer os.Unsetenv(k8sutil.WatchNamespaceEnvVar)
+
+		req := mapper.Map(handler.MapObject{
+			Object: bannedUser,
+		})
+
+		require.Len(t, req, 1)
+		require.Equal(t, types.NamespacedName{
+			Namespace: userSignup.Namespace,
+			Name:      userSignup.Name,
+		}, req[0].NamespacedName)
+	})
+
+	t.Run("test BannedUserToUserSignupMapper returns nil when client list fails", func(t *testing.T) {
+		c := test.NewFakeClient(t)
+		c.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			return errors.New("err happened")
+		}
+
+		mapper := &BannedUserToUserSignupMapper{
+			client: c,
+		}
+		req := mapper.Map(handler.MapObject{
+			Object: bannedUser,
+		})
+
+		require.Nil(t, req)
+	})
+
+	t.Run("test BannedUserToUserSignupMapper returns nil when watch namespace not set ", func(t *testing.T) {
+		c := test.NewFakeClient(t)
+
+		mapper := &BannedUserToUserSignupMapper{
+			client: c,
+		}
+		req := mapper.Map(handler.MapObject{
+			Object: bannedUser,
+		})
+
+		require.Nil(t, req)
+	})
+}

--- a/pkg/controller/usersignup/predicate.go
+++ b/pkg/controller/usersignup/predicate.go
@@ -1,0 +1,46 @@
+package usersignup
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	controllerPredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type UserSignupChangedPredicate struct {
+	controllerPredicate.Funcs
+}
+
+// Update implements default UpdateEvent filter for validating generation change
+func (p UserSignupChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.MetaOld == nil {
+		log.Error(nil, "Update event has no old metadata", "event", e)
+		return false
+	}
+	if e.ObjectOld == nil {
+		log.Error(nil, "Update event has no old runtime object to update", "event", e)
+		return false
+	}
+	if e.ObjectNew == nil {
+		log.Error(nil, "Update event has no new runtime object for update", "event", e)
+		return false
+	}
+	if e.MetaNew == nil {
+		log.Error(nil, "Update event has no new metadata", "event", e)
+		return false
+	}
+	if e.MetaNew.GetGeneration() == e.MetaOld.GetGeneration() &&
+		!p.AnnotationChanged(e, toolchainv1alpha1.UserSignupUserEmailAnnotationKey) &&
+		!p.LabelChanged(e, toolchainv1alpha1.UserSignupUserEmailHashLabelKey) {
+		return false
+	}
+	return true
+}
+
+func (p UserSignupChangedPredicate) AnnotationChanged(e event.UpdateEvent, annotationName string) bool {
+	return e.MetaOld.GetAnnotations()[annotationName] != e.MetaNew.GetAnnotations()[annotationName]
+}
+
+func (p UserSignupChangedPredicate) LabelChanged(e event.UpdateEvent, labelName string) bool {
+	return e.MetaOld.GetLabels()[labelName] != e.MetaNew.GetLabels()[labelName]
+}

--- a/pkg/controller/usersignup/predicate_test.go
+++ b/pkg/controller/usersignup/predicate_test.go
@@ -1,0 +1,124 @@
+package usersignup
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestUserSignupChangedPredicate(t *testing.T) {
+	// when
+	pred := &UserSignupChangedPredicate{}
+	userSignupName := uuid.NewV4().String()
+
+	userSignupOld := &v1alpha1.UserSignup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userSignupName,
+			Namespace: operatorNamespace,
+			Annotations: map[string]string{
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "foo@redhat.com",
+			},
+			Labels: map[string]string{
+				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: "fd2addbd8d82f0d2dc088fa122377eaa",
+			},
+			Generation: 1,
+		},
+		Spec: v1alpha1.UserSignupSpec{
+			Username: "foo@redhat.com",
+		},
+	}
+
+	userSignupNewNotChanged := &v1alpha1.UserSignup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userSignupName,
+			Namespace: operatorNamespace,
+			Annotations: map[string]string{
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "foo@redhat.com",
+			},
+			Labels: map[string]string{
+				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: "fd2addbd8d82f0d2dc088fa122377eaa",
+			},
+			Generation: 1,
+		},
+		Spec: v1alpha1.UserSignupSpec{
+			Username: "alice.mayweather.doe@redhat.com",
+		},
+	}
+
+	userSignupNewChanged := &v1alpha1.UserSignup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      userSignupName,
+			Namespace: operatorNamespace,
+			Annotations: map[string]string{
+				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "alice.mayweather.doe@redhat.com",
+			},
+			Labels: map[string]string{
+				toolchainv1alpha1.UserSignupUserEmailHashLabelKey: "747a250430df0c7976bf2363ebb4014a",
+			},
+			Generation: 2,
+		},
+		Spec: v1alpha1.UserSignupSpec{
+			Username: "alice.mayweather.doe@redhat.com",
+		},
+	}
+
+	t.Run("test UserSignupChangedPredicate returns false when MetaOld not set", func(t *testing.T) {
+		e := event.UpdateEvent{
+			MetaOld:   nil,
+			ObjectOld: userSignupOld,
+			MetaNew:   userSignupNewNotChanged.ObjectMeta.GetObjectMeta(),
+			ObjectNew: userSignupNewNotChanged,
+		}
+		require.False(t, pred.Update(e))
+	})
+	t.Run("test UserSignupChangedPredicate returns false when ObjectOld not set", func(t *testing.T) {
+		e := event.UpdateEvent{
+			MetaOld:   userSignupOld.ObjectMeta.GetObjectMeta(),
+			ObjectOld: nil,
+			MetaNew:   userSignupNewNotChanged.ObjectMeta.GetObjectMeta(),
+			ObjectNew: userSignupNewNotChanged,
+		}
+		require.False(t, pred.Update(e))
+	})
+	t.Run("test UserSignupChangedPredicate returns false when ObjectNew not set", func(t *testing.T) {
+		e := event.UpdateEvent{
+			MetaOld:   userSignupOld.ObjectMeta.GetObjectMeta(),
+			ObjectOld: userSignupOld,
+			MetaNew:   userSignupNewNotChanged.ObjectMeta.GetObjectMeta(),
+			ObjectNew: nil,
+		}
+		require.False(t, pred.Update(e))
+	})
+	t.Run("test UserSignupChangedPredicate returns false when MetaNew not set", func(t *testing.T) {
+		e := event.UpdateEvent{
+			MetaOld:   userSignupOld.ObjectMeta.GetObjectMeta(),
+			ObjectOld: userSignupOld,
+			MetaNew:   nil,
+			ObjectNew: userSignupNewNotChanged,
+		}
+		require.False(t, pred.Update(e))
+	})
+	t.Run("test UserSignupChangedPredicate returns false when generation unchanged and annoations unchanged", func(t *testing.T) {
+		e := event.UpdateEvent{
+			MetaOld:   userSignupOld.ObjectMeta.GetObjectMeta(),
+			ObjectOld: userSignupOld,
+			MetaNew:   userSignupNewNotChanged.ObjectMeta.GetObjectMeta(),
+			ObjectNew: userSignupNewNotChanged,
+		}
+		require.False(t, pred.Update(e))
+	})
+	t.Run("test UserSignupChangedPredicate returns true when generation changed", func(t *testing.T) {
+		e := event.UpdateEvent{
+			MetaOld:   userSignupOld.ObjectMeta.GetObjectMeta(),
+			ObjectOld: userSignupOld,
+			MetaNew:   userSignupNewChanged.ObjectMeta.GetObjectMeta(),
+			ObjectNew: userSignupNewChanged,
+		}
+		require.True(t, pred.Update(e))
+	})
+}

--- a/pkg/controller/usersignup/status.go
+++ b/pkg/controller/usersignup/status.go
@@ -1,0 +1,279 @@
+package usersignup
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	commonCondition "github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/go-logr/logr"
+	errs "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type statusUpdater struct {
+	client client.Client
+}
+
+func (u *statusUpdater) setStatusApprovedAutomatically(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupApproved,
+			Status:  corev1.ConditionTrue,
+			Reason:  toolchainv1alpha1.UserSignupApprovedAutomaticallyReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusApprovedByAdmin(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupApproved,
+			Status:  corev1.ConditionTrue,
+			Reason:  toolchainv1alpha1.UserSignupApprovedByAdminReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusPendingApproval(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupApproved,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupPendingApprovalReason,
+			Message: message,
+		},
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupPendingApprovalReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusFailedToReadUserApprovalPolicy(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupFailedToReadUserApprovalPolicyReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusInvalidMURState(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupInvalidMURStateReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusFailedToCreateMUR(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupUnableToCreateMURReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusFailedToDeleteMUR(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupUnableToDeleteMURReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusNoClustersAvailable(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupNoClusterAvailableReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusNoTemplateTierAvailable(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupNoTemplateTierAvailableReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusBanning(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupUserBanningReason,
+			Message: message,
+		})
+}
+
+// setStatusBanned sets the Complete status to True, as the banning operation has been successful (with a reason of "Banned")
+func (u *statusUpdater) setStatusBanned(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionTrue,
+			Reason:  toolchainv1alpha1.UserSignupUserBannedReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusDeactivating(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupUserDeactivatingReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusDeactivated(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionTrue,
+			Reason:  toolchainv1alpha1.UserSignupUserDeactivatedReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusFailedToReadBannedUsers(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupFailedToReadBannedUsersReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusInvalidMissingUserEmailAnnotation(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupMissingUserEmailAnnotationReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusMissingEmailHash(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupMissingEmailHashLabelReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusInvalidEmailHash(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupInvalidEmailHashLabelReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) setStatusVerificationRequired(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return u.updateStatusConditions(
+		userSignup,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.UserSignupVerificationRequiredReason,
+			Message: message,
+		})
+}
+
+func (u *statusUpdater) updateStatus(logger logr.Logger, userSignup *toolchainv1alpha1.UserSignup,
+	statusUpdater func(userAcc *toolchainv1alpha1.UserSignup, message string) error) error {
+
+	if err := statusUpdater(userSignup, ""); err != nil {
+		logger.Error(err, "status update failed")
+		return err
+	}
+
+	return nil
+}
+
+// updateCompleteStatus updates the `CompliantUsername` and `Conditions` in the status, should only be invoked on completion because
+// both completion and the compliant username require the master user record to be created.
+func (u *statusUpdater) updateCompleteStatus(compliantUsername string) func(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+	return func(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+
+		usernameUpdated := userSignup.Status.CompliantUsername != compliantUsername
+		userSignup.Status.CompliantUsername = compliantUsername
+
+		var conditionUpdated bool
+		userSignup.Status.Conditions, conditionUpdated = commonCondition.AddOrUpdateStatusConditions(userSignup.Status.Conditions,
+			toolchainv1alpha1.Condition{
+				Type:    toolchainv1alpha1.UserSignupComplete,
+				Status:  corev1.ConditionTrue,
+				Reason:  "",
+				Message: message,
+			})
+
+		if !usernameUpdated && !conditionUpdated {
+			// Nothing changed
+			return nil
+		}
+		return u.client.Status().Update(context.TODO(), userSignup)
+	}
+}
+
+// wrapErrorWithStatusUpdate wraps the error and update the UserSignup status. If the update fails then the error is logged.
+func (u *statusUpdater) wrapErrorWithStatusUpdate(logger logr.Logger, userSignup *toolchainv1alpha1.UserSignup,
+	statusUpdater StatusUpdater, err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	if err := statusUpdater(userSignup, err.Error()); err != nil {
+		logger.Error(err, "Error updating UserSignup status")
+	}
+	return errs.Wrapf(err, format, args...)
+}
+
+func (u *statusUpdater) updateStatusConditions(userSignup *toolchainv1alpha1.UserSignup, newConditions ...toolchainv1alpha1.Condition) error {
+	var updated bool
+	userSignup.Status.Conditions, updated = commonCondition.AddOrUpdateStatusConditions(userSignup.Status.Conditions, newConditions...)
+	if !updated {
+		// Nothing changed
+		return nil
+	}
+	return u.client.Status().Update(context.TODO(), userSignup)
+}

--- a/pkg/controller/usersignup/status_test.go
+++ b/pkg/controller/usersignup/status_test.go
@@ -1,0 +1,45 @@
+package usersignup
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func TestUpdateStatus(t *testing.T) {
+	// given
+	userSignup := &v1alpha1.UserSignup{}
+
+	statusUpdater := statusUpdater{client: test.NewFakeClient(t)}
+
+	t.Run("status updated", func(t *testing.T) {
+		updateStatus := func(changeTierRequest *v1alpha1.UserSignup, message string) error {
+			assert.Equal(t, "oopsy woopsy", message)
+			return nil
+		}
+
+		// test
+		err := statusUpdater.wrapErrorWithStatusUpdate(log, userSignup, updateStatus, apierrors.NewBadRequest("oopsy woopsy"), "failed to create namespace")
+
+		require.Error(t, err)
+		assert.Equal(t, "failed to create namespace: oopsy woopsy", err.Error())
+	})
+
+	t.Run("status update failed", func(t *testing.T) {
+		updateStatus := func(changeTierRequest *v1alpha1.UserSignup, message string) error {
+			return fmt.Errorf("unable to update status")
+		}
+
+		// when
+		err := statusUpdater.wrapErrorWithStatusUpdate(log, userSignup, updateStatus, apierrors.NewBadRequest("oopsy woopsy"), "failed to create namespace")
+
+		// then
+		require.Error(t, err)
+		assert.Equal(t, "failed to create namespace: oopsy woopsy", err.Error())
+	})
+}

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -193,6 +193,10 @@ func (r *ReconcileUserSignup) isUserBanned(reqLogger logr.Logger, userSignup *to
 	return banned, nil
 }
 
+// ensureMurIfAlreadyExists checks if there is already a MUR for the given UserSignup.
+// If there is already one then it returns 'true' as the first returned value, but before doing that it checks if the MUR should be deleted or not
+// or if the MUR requires some migration changes or additional fixes.
+// If no MUR for the given UserSignup is found, then it returns 'false' as the first returned value.
 func (r *ReconcileUserSignup) ensureMurIfAlreadyExists(reqLogger logr.Logger, userSignup *toolchainv1alpha1.UserSignup, banned bool) (bool, error) {
 	// List all MasterUserRecord resources that have a UserID label equal to the UserSignup.Name
 	labels := map[string]string{toolchainv1alpha1.MasterUserRecordUserIDLabelKey: userSignup.Name}

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -8,17 +8,11 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/codeready-toolchain/host-operator/pkg/counter"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+	"github.com/codeready-toolchain/host-operator/pkg/counter"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-	commonCondition "github.com/codeready-toolchain/toolchain-common/pkg/condition"
-
 	"github.com/go-logr/logr"
-	errs "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	controllerPredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -42,87 +35,9 @@ var (
 	onlyNumbers       = regexp.MustCompile("^[0-9]*$")
 )
 
-type BannedUserToUserSignupMapper struct {
-	client client.Client
-}
-
 type StatusUpdater func(userAcc *toolchainv1alpha1.UserSignup, message string) error
 
 const defaultTierName = "basic"
-
-func (b BannedUserToUserSignupMapper) Map(obj handler.MapObject) []reconcile.Request {
-	if bu, ok := obj.Object.(*toolchainv1alpha1.BannedUser); ok {
-		// look-up any associated UserSignup using the BannedUser's "toolchain.dev.openshift.com/email-hash" label
-		if emailHashLbl, exists := bu.Labels[toolchainv1alpha1.BannedUserEmailHashLabelKey]; exists {
-
-			labels := map[string]string{toolchainv1alpha1.UserSignupUserEmailHashLabelKey: emailHashLbl}
-			opts := client.MatchingLabels(labels)
-			userSignupList := &toolchainv1alpha1.UserSignupList{}
-			if err := b.client.List(context.TODO(), userSignupList, opts); err != nil {
-				log.Error(err, "Could not list UserSignup resources with label value", toolchainv1alpha1.UserSignupUserEmailHashLabelKey, emailHashLbl)
-				return nil
-			}
-
-			req := []reconcile.Request{}
-
-			ns, err := k8sutil.GetWatchNamespace()
-			if err != nil {
-				log.Error(err, "Could not determine watched namespace")
-				return nil
-			}
-
-			for _, userSignup := range userSignupList.Items {
-				req = append(req, reconcile.Request{
-					NamespacedName: types.NamespacedName{Namespace: ns, Name: userSignup.Name},
-				})
-			}
-
-			return req
-		}
-	}
-	// the obj was not a BannedUser or it did not have the required label.
-	return []reconcile.Request{}
-}
-
-var _ handler.Mapper = BannedUserToUserSignupMapper{}
-
-type UserSignupChangedPredicate struct {
-	controllerPredicate.Funcs
-}
-
-// Update implements default UpdateEvent filter for validating generation change
-func (p UserSignupChangedPredicate) Update(e event.UpdateEvent) bool {
-	if e.MetaOld == nil {
-		log.Error(nil, "Update event has no old metadata", "event", e)
-		return false
-	}
-	if e.ObjectOld == nil {
-		log.Error(nil, "Update event has no old runtime object to update", "event", e)
-		return false
-	}
-	if e.ObjectNew == nil {
-		log.Error(nil, "Update event has no new runtime object for update", "event", e)
-		return false
-	}
-	if e.MetaNew == nil {
-		log.Error(nil, "Update event has no new metadata", "event", e)
-		return false
-	}
-	if e.MetaNew.GetGeneration() == e.MetaOld.GetGeneration() &&
-		!p.AnnotationChanged(e, toolchainv1alpha1.UserSignupUserEmailAnnotationKey) &&
-		!p.LabelChanged(e, toolchainv1alpha1.UserSignupUserEmailHashLabelKey) {
-		return false
-	}
-	return true
-}
-
-func (p UserSignupChangedPredicate) AnnotationChanged(e event.UpdateEvent, annotationName string) bool {
-	return e.MetaOld.GetAnnotations()[annotationName] != e.MetaNew.GetAnnotations()[annotationName]
-}
-
-func (p UserSignupChangedPredicate) LabelChanged(e event.UpdateEvent, labelName string) bool {
-	return e.MetaOld.GetLabels()[labelName] != e.MetaNew.GetLabels()[labelName]
-}
 
 // Add creates a new UserSignup Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -132,7 +47,12 @@ func Add(mgr manager.Manager, _ *configuration.Config) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileUserSignup{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileUserSignup{
+		statusUpdater: &statusUpdater{
+			client: mgr.GetClient(),
+		},
+		scheme: mgr.GetScheme(),
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -188,9 +108,7 @@ func (err SignupError) Error() string {
 
 // ReconcileUserSignup reconciles a UserSignup object
 type ReconcileUserSignup struct {
-	// This client, initialized using mgr.Client() above, is a split client
-	// that reads objects from the cache and writes to the apiserver
-	client client.Client
+	*statusUpdater
 	scheme *runtime.Scheme
 }
 
@@ -217,97 +135,14 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 	reqLogger = reqLogger.WithValues("username", instance.Spec.Username)
-	// Is the user banned? To determine this we query the BannedUser resource for any matching entries.  The query
-	// is based on the user's emailHash value - if there is a match, and the e-mail addresses are equal, then the
-	// user is banned.
-	banned := false
 
-	// Lookup the user email annotation
-	if emailLbl, exists := instance.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]; exists {
-
-		// Lookup the email hash label
-		if emailHashLbl, exists := instance.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey]; exists {
-
-			labels := map[string]string{toolchainv1alpha1.BannedUserEmailHashLabelKey: emailHashLbl}
-			opts := client.MatchingLabels(labels)
-			bannedUserList := &toolchainv1alpha1.BannedUserList{}
-
-			// Query BannedUser for resources that match the same email hash
-			if err = r.client.List(context.TODO(), bannedUserList, opts); err != nil {
-				return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, instance, r.setStatusFailedToReadBannedUsers, err, "Failed to query BannedUsers")
-			}
-
-			// One last check to confirm that the e-mail addresses match also (in case of the infinitesimal chance of a hash collision)
-			for _, bannedUser := range bannedUserList.Items {
-				if bannedUser.Spec.Email == emailLbl {
-					banned = true
-					break
-				}
-			}
-
-			hashIsValid := validateEmailHash(emailLbl, emailHashLbl)
-			if !hashIsValid {
-				return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusInvalidEmailHash)
-			}
-		} else {
-			// If there isn't an email-hash label, then the state is invalid
-			reqLogger.Info("missing label on usersignup", "label", toolchainv1alpha1.UserSignupUserEmailHashLabelKey)
-			return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusMissingEmailHash)
-		}
-	} else {
-		reqLogger.Info("missing annotation on usersignup", "annotation", toolchainv1alpha1.UserSignupUserEmailAnnotationKey)
-		return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusInvalidMissingUserEmailAnnotation)
-	}
-
-	// List all MasterUserRecord resources that have a UserID label equal to the UserSignup.Name
-	labels := map[string]string{toolchainv1alpha1.MasterUserRecordUserIDLabelKey: instance.Name}
-	opts := client.MatchingLabels(labels)
-	murList := &toolchainv1alpha1.MasterUserRecordList{}
-	if err = r.client.List(context.TODO(), murList, opts); err != nil {
-		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, instance, r.setStatusInvalidMURState, err, "Failed to list MasterUserRecords")
-	}
-
-	// look-up the `basic` NSTemplateTier to get the NS templates
-	nstemplateTier, err := getNsTemplateTier(r.client, defaultTierName, request.Namespace)
+	banned, err := r.isUserBanned(reqLogger, instance)
 	if err != nil {
-		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, instance, r.setStatusNoTemplateTierAvailable, err, "")
+		return reconcile.Result{}, err
 	}
 
-	murs := murList.Items
-	// If we found more than one MasterUserRecord, then die
-	if len(murs) > 1 {
-		err = NewSignupError("multiple matching MasterUserRecord resources found")
-		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, instance, r.setStatusInvalidMURState, err, "Multiple MasterUserRecords found")
-	} else if len(murs) == 1 {
-		mur := murs[0]
-
-		// If the user has been banned, then we need to delete the MUR
-		if banned {
-			return r.DeleteMasterUserRecord(&mur, instance, reqLogger, r.setStatusBanning, r.setStatusFailedToDeleteMUR)
-		}
-
-		// If the user has been deactivated, then we need to delete the MUR
-		if instance.Spec.Deactivated {
-			return r.DeleteMasterUserRecord(&mur, instance, reqLogger, r.setStatusDeactivating, r.setStatusFailedToDeleteMUR)
-		}
-
-		// check if anything in the MUR chould be migrated/fixed
-		if changed, err := migrateOrFixMurIfNecessary(&mur, nstemplateTier); err != nil {
-			return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, instance, r.setStatusInvalidMURState, err, "unable to migrate or fix existing MasterUserRecord")
-
-		} else if changed {
-			if err := r.client.Update(context.TODO(), &mur); err != nil {
-				return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, instance, r.setStatusInvalidMURState, err, "unable to migrate or fix existing MasterUserRecord")
-			}
-			return reconcile.Result{}, nil
-		}
-
-		// If we successfully found an existing MasterUserRecord then our work here is done, set the status
-		// conditions to complete and set the compliant username and return
-		reqLogger.Info("MasterUserRecord exists, setting UserSignup status to 'Complete'")
-		// Use compliantUsernameUpdater to properly handle when the master user record is created or updated
-		c := completeStatusUpdater{CompliantUsername: mur.Name, R: r}
-		return reconcile.Result{}, r.updateStatus(reqLogger, instance, c.updateCompleteStatus)
+	if exists, err := r.ensureMurIfAlreadyExists(reqLogger, instance, banned); exists || err != nil {
+		return reconcile.Result{}, err
 	}
 
 	// If there is no MasterUserRecord created, yet the UserSignup is Banned, simply set the status
@@ -322,35 +157,138 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusDeactivated)
 	}
 
+	return reconcile.Result{}, r.ensureNewMurIfApproved(reqLogger, instance)
+}
+
+// Is the user banned? To determine this we query the BannedUser resource for any matching entries.  The query
+// is based on the user's emailHash value - if there is a match, and the e-mail addresses are equal, then the
+// user is banned.
+func (r *ReconcileUserSignup) isUserBanned(reqLogger logr.Logger, userSignup *toolchainv1alpha1.UserSignup) (bool, error) {
+	banned := false
+	// Lookup the user email annotation
+	if emailLbl, exists := userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]; exists {
+
+		// Lookup the email hash label
+		if emailHashLbl, exists := userSignup.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey]; exists {
+
+			labels := map[string]string{toolchainv1alpha1.BannedUserEmailHashLabelKey: emailHashLbl}
+			opts := client.MatchingLabels(labels)
+			bannedUserList := &toolchainv1alpha1.BannedUserList{}
+
+			// Query BannedUser for resources that match the same email hash
+			if err := r.client.List(context.TODO(), bannedUserList, opts); err != nil {
+				return false, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusFailedToReadBannedUsers, err, "Failed to query BannedUsers")
+			}
+
+			// One last check to confirm that the e-mail addresses match also (in case of the infinitesimal chance of a hash collision)
+			for _, bannedUser := range bannedUserList.Items {
+				if bannedUser.Spec.Email == emailLbl {
+					banned = true
+					break
+				}
+			}
+
+			hashIsValid := validateEmailHash(emailLbl, emailHashLbl)
+			if !hashIsValid {
+				err := fmt.Errorf("hash is invalid")
+				return banned, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusInvalidEmailHash, err, "the email hash '%s' is invalid ", emailHashLbl)
+			}
+		} else {
+			// If there isn't an email-hash label, then the state is invalid
+			err := fmt.Errorf("missing label at usersignup")
+			return banned, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusMissingEmailHash, err,
+				"the required label '%s' is not present", toolchainv1alpha1.UserSignupUserEmailHashLabelKey)
+		}
+	} else {
+		err := fmt.Errorf("missing annotation at usersignup")
+		return banned, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusInvalidMissingUserEmailAnnotation, err,
+			"the required annotation '%s' is not present", toolchainv1alpha1.UserSignupUserEmailAnnotationKey)
+	}
+	return banned, nil
+}
+
+func (r *ReconcileUserSignup) ensureMurIfAlreadyExists(reqLogger logr.Logger, userSignup *toolchainv1alpha1.UserSignup, banned bool) (bool, error) {
+	// List all MasterUserRecord resources that have a UserID label equal to the UserSignup.Name
+	labels := map[string]string{toolchainv1alpha1.MasterUserRecordUserIDLabelKey: userSignup.Name}
+	opts := client.MatchingLabels(labels)
+	murList := &toolchainv1alpha1.MasterUserRecordList{}
+	if err := r.client.List(context.TODO(), murList, opts); err != nil {
+		return false, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusInvalidMURState, err, "Failed to list MasterUserRecords")
+	}
+
+	murs := murList.Items
+	// If we found more than one MasterUserRecord, then die
+	if len(murs) > 1 {
+		err := NewSignupError("multiple matching MasterUserRecord resources found")
+		return false, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusInvalidMURState, err, "Multiple MasterUserRecords found")
+	} else if len(murs) == 1 {
+		mur := &murs[0]
+		// If the user has been banned, then we need to delete the MUR
+		if banned {
+			return true, r.DeleteMasterUserRecord(mur, userSignup, reqLogger, r.setStatusBanning, r.setStatusFailedToDeleteMUR)
+		}
+
+		// If the user has been deactivated, then we need to delete the MUR
+		if userSignup.Spec.Deactivated {
+			return true, r.DeleteMasterUserRecord(mur, userSignup, reqLogger, r.setStatusDeactivating, r.setStatusFailedToDeleteMUR)
+		}
+
+		// look-up the `basic` NSTemplateTier to get the NS templates
+		nstemplateTier, err := getNsTemplateTier(r.client, defaultTierName, userSignup.Namespace)
+		if err != nil {
+			return true, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusNoTemplateTierAvailable, err, "")
+		}
+
+		// check if anything in the MUR chould be migrated/fixed
+		if changed, err := migrateOrFixMurIfNecessary(mur, nstemplateTier); err != nil {
+			return true, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusInvalidMURState, err, "unable to migrate or fix existing MasterUserRecord")
+
+		} else if changed {
+			if err := r.client.Update(context.TODO(), mur); err != nil {
+				return true, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusInvalidMURState, err, "unable to migrate or fix existing MasterUserRecord")
+			}
+			return true, nil
+		}
+
+		// If we successfully found an existing MasterUserRecord then our work here is done, set the status
+		// conditions to complete and set the compliant username and return
+		reqLogger.Info("MasterUserRecord exists, setting UserSignup status to 'Complete'")
+		// Use compliantUsernameUpdater to properly handle when the master user record is created or updated
+		return true, r.updateStatus(reqLogger, userSignup, r.updateCompleteStatus(mur.Name))
+	}
+	return false, nil
+}
+
+func (r *ReconcileUserSignup) ensureNewMurIfApproved(reqLogger logr.Logger, userSignup *toolchainv1alpha1.UserSignup) error {
 	// Check the user approval policy.
-	userApprovalPolicy, err := r.ReadUserApprovalPolicyConfig(request.Namespace)
+	userApprovalPolicy, err := r.ReadUserApprovalPolicyConfig(userSignup.Namespace)
 	if err != nil {
-		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, instance, r.setStatusFailedToReadUserApprovalPolicy, err, "")
+		return r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusFailedToReadUserApprovalPolicy, err, "")
 	}
 
 	// If the signup has been explicitly approved (by an admin), or the user approval policy is set to automatic,
 	// then proceed with the signup
-	if instance.Spec.Approved || userApprovalPolicy == configuration.UserApprovalPolicyAutomatic {
-		if instance.Spec.Approved {
-			if statusError := r.updateStatus(reqLogger, instance, r.setStatusApprovedByAdmin); statusError != nil {
-				return reconcile.Result{}, statusError
+	if userSignup.Spec.Approved || userApprovalPolicy == configuration.UserApprovalPolicyAutomatic {
+		if userSignup.Spec.Approved {
+			if statusError := r.updateStatus(reqLogger, userSignup, r.setStatusApprovedByAdmin); statusError != nil {
+				return statusError
 			}
 		} else {
-			if statusError := r.updateStatus(reqLogger, instance, r.setStatusApprovedAutomatically); statusError != nil {
-				return reconcile.Result{}, statusError
+			if statusError := r.updateStatus(reqLogger, userSignup, r.setStatusApprovedAutomatically); statusError != nil {
+				return statusError
 			}
 		}
 
 		// Check if the user requires phone verification, and do not proceed further if they do
-		if instance.Spec.VerificationRequired {
-			return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusVerificationRequired)
+		if userSignup.Spec.VerificationRequired {
+			return r.updateStatus(reqLogger, userSignup, r.setStatusVerificationRequired)
 		}
 
 		var targetCluster string
 
 		// If a target cluster hasn't been selected, select one from the members
-		if instance.Spec.TargetCluster != "" {
-			targetCluster = instance.Spec.TargetCluster
+		if userSignup.Spec.TargetCluster != "" {
+			targetCluster = userSignup.Spec.TargetCluster
 		} else {
 			// Automatic cluster selection based on cluster readiness
 			members := cluster.GetMemberClusters(cluster.Ready, cluster.CapacityNotExhausted)
@@ -358,25 +296,30 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 				targetCluster = members[0].Name
 			} else {
 				reqLogger.Error(err, "No member clusters found")
-				if statusError := r.updateStatus(reqLogger, instance, r.setStatusNoClustersAvailable); statusError != nil {
-					return reconcile.Result{}, statusError
+				if statusError := r.updateStatus(reqLogger, userSignup, r.setStatusNoClustersAvailable); statusError != nil {
+					return statusError
 				}
 
 				err = NewSignupError("no target clusters available")
-				return reconcile.Result{}, err
+				return err
 			}
 		}
 
-		// Provision the MasterUserRecord
-		err = r.provisionMasterUserRecord(instance, targetCluster, nstemplateTier, reqLogger)
+		// look-up the `basic` NSTemplateTier to get the NS templates
+		nstemplateTier, err := getNsTemplateTier(r.client, defaultTierName, userSignup.Namespace)
 		if err != nil {
-			return reconcile.Result{}, err
+			return r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusNoTemplateTierAvailable, err, "")
+		}
+
+		// Provision the MasterUserRecord
+		err = r.provisionMasterUserRecord(userSignup, targetCluster, nstemplateTier, reqLogger)
+		if err != nil {
+			return err
 		}
 	} else {
-		return reconcile.Result{}, r.updateStatus(reqLogger, instance, r.setStatusPendingApproval)
+		return r.updateStatus(reqLogger, userSignup, r.setStatusPendingApproval)
 	}
-
-	return reconcile.Result{}, nil
+	return nil
 }
 
 func getNsTemplateTier(cl client.Client, tierName, namespace string) (*toolchainv1alpha1.NSTemplateTier, error) {
@@ -479,20 +422,20 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 // DeleteMasterUserRecord deletes the specified MasterUserRecord
 func (r *ReconcileUserSignup) DeleteMasterUserRecord(mur *toolchainv1alpha1.MasterUserRecord,
 	userSignup *toolchainv1alpha1.UserSignup, logger logr.Logger,
-	inProgressStatusUpdater, failedStatusUpdater StatusUpdater) (reconcile.Result, error) {
+	inProgressStatusUpdater, failedStatusUpdater StatusUpdater) error {
 
 	err := r.updateStatus(logger, userSignup, inProgressStatusUpdater)
 	if err != nil {
-		return reconcile.Result{}, nil
+		return nil
 	}
 
 	err = r.client.Delete(context.TODO(), mur)
 	if err != nil {
-		return reconcile.Result{}, r.wrapErrorWithStatusUpdate(logger, userSignup, failedStatusUpdater, err,
+		return r.wrapErrorWithStatusUpdate(logger, userSignup, failedStatusUpdater, err,
 			"Error deleting MasterUserRecord")
 	}
 	logger.Info("Deleted MasterUserRecord", "Name", mur.Name)
-	return reconcile.Result{}, nil
+	return nil
 }
 
 // ReadUserApprovalPolicyConfig reads the ConfigMap for the toolchain configuration in the operator namespace, and returns
@@ -512,271 +455,6 @@ func (r *ReconcileUserSignup) ReadUserApprovalPolicyConfig(namespace string) (st
 		return "", nil
 	}
 	return val, nil
-}
-
-func (r *ReconcileUserSignup) setStatusApprovedAutomatically(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupApproved,
-			Status:  corev1.ConditionTrue,
-			Reason:  toolchainv1alpha1.UserSignupApprovedAutomaticallyReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusApprovedByAdmin(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupApproved,
-			Status:  corev1.ConditionTrue,
-			Reason:  toolchainv1alpha1.UserSignupApprovedByAdminReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusPendingApproval(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupApproved,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupPendingApprovalReason,
-			Message: message,
-		},
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupPendingApprovalReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusFailedToReadUserApprovalPolicy(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupFailedToReadUserApprovalPolicyReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusInvalidMURState(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupInvalidMURStateReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusFailedToCreateMUR(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUnableToCreateMURReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusFailedToDeleteMUR(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUnableToDeleteMURReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusNoClustersAvailable(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupNoClusterAvailableReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusNoTemplateTierAvailable(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupNoTemplateTierAvailableReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusBanning(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUserBanningReason,
-			Message: message,
-		})
-}
-
-// setStatusBanned sets the Complete status to True, as the banning operation has been successful (with a reason of "Banned")
-func (r *ReconcileUserSignup) setStatusBanned(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionTrue,
-			Reason:  toolchainv1alpha1.UserSignupUserBannedReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusDeactivating(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUserDeactivatingReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusDeactivated(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionTrue,
-			Reason:  toolchainv1alpha1.UserSignupUserDeactivatedReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusFailedToReadBannedUsers(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupFailedToReadBannedUsersReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusInvalidMissingUserEmailAnnotation(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupMissingUserEmailAnnotationReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusMissingEmailHash(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupMissingEmailHashLabelReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusInvalidEmailHash(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupInvalidEmailHashLabelReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) setStatusVerificationRequired(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return r.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupVerificationRequiredReason,
-			Message: message,
-		})
-}
-
-func (r *ReconcileUserSignup) updateStatus(logger logr.Logger, userSignup *toolchainv1alpha1.UserSignup,
-	statusUpdater func(userAcc *toolchainv1alpha1.UserSignup, message string) error) error {
-
-	if err := statusUpdater(userSignup, ""); err != nil {
-		logger.Error(err, "status update failed")
-		return err
-	}
-
-	return nil
-}
-
-type completeStatusUpdater struct {
-	CompliantUsername string
-	R                 *ReconcileUserSignup
-}
-
-// updateCompleteStatus updates the `CompliantUsername` and `Conditions` in the status, should only be invoked on completion because
-// both completion and the compliant username require the master user record to be created.
-func (u *completeStatusUpdater) updateCompleteStatus(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	usernameUpdated := userSignup.Status.CompliantUsername != u.CompliantUsername
-	userSignup.Status.CompliantUsername = u.CompliantUsername
-
-	var conditionUpdated bool
-	userSignup.Status.Conditions, conditionUpdated = commonCondition.AddOrUpdateStatusConditions(userSignup.Status.Conditions,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionTrue,
-			Reason:  "",
-			Message: message,
-		})
-
-	if !usernameUpdated && !conditionUpdated {
-		// Nothing changed
-		return nil
-	}
-	return u.R.client.Status().Update(context.TODO(), userSignup)
-}
-
-// wrapErrorWithStatusUpdate wraps the error and update the UserSignup status. If the update fails then the error is logged.
-func (r *ReconcileUserSignup) wrapErrorWithStatusUpdate(logger logr.Logger, userSignup *toolchainv1alpha1.UserSignup,
-	statusUpdater StatusUpdater, err error, format string, args ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-	if err := statusUpdater(userSignup, err.Error()); err != nil {
-		logger.Error(err, "Error updating UserSignup status")
-	}
-	return errs.Wrapf(err, format, args...)
-}
-
-func (r *ReconcileUserSignup) updateStatusConditions(userSignup *toolchainv1alpha1.UserSignup, newConditions ...toolchainv1alpha1.Condition) error {
-	var updated bool
-	userSignup.Status.Conditions, updated = commonCondition.AddOrUpdateStatusConditions(userSignup.Status.Conditions, newConditions...)
-	if !updated {
-		// Nothing changed
-		return nil
-	}
-	return r.client.Status().Update(context.TODO(), userSignup)
 }
 
 // validateEmailHash calculates an md5 hash value for the provided userEmail string, and compares it to the provided

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -1714,8 +1714,7 @@ func TestUserSignupNoMembersAvailableFails(t *testing.T) {
 	_, err := r.Reconcile(req)
 
 	// then
-	require.Error(t, err)
-	require.IsType(t, SignupError{}, err)
+	assert.EqualError(t, err, "no target clusters available")
 	AssertThatCounterHas(t, 1)
 }
 


### PR DESCRIPTION
This PR slightly refactors the UserSignup controller - the code was long with long methods and hard to maintain and read.
I moved:
* predicate related code into `predicate.go` (the related tests were moved into `predicate_test.go`)
* mapper related code into `mapper.go` (the related tests were moved into `mapper_test.go`)
* functions taking care of status update into `status.go`. There was no test that would verify the status update functionality, but I added a new one that verifies the method `wrapErrorWithStatusUpdate` into `status_test.go`

All above is just copy-paste operations

Then I split the `Reconcile` method into separated methods. Newly, none one of the new methods returns the `reconcile.Result{}` - they return only values related to their functionality.

Newly, when the UserSignup is invalid (eg. missing label or annotation) then the controller returns an error. Previously, the information was only set in status but no error was returned.

I also removed the `SignupError` type and replaced the usage with a string error because there was no real usage of the type.