### PR TITLE
chore: refactor test helper functions to make them reusable&extendable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20200923090207-76fb069067fa
+
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20200914140452-d2c86086863e
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20200916194155-0cfe3ba580d9
+	github.com/codeready-toolchain/api v0.0.0-20200925000842-d2e82e080a5a
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20200925155619-fa1a922a4e44
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.3.0+incompatible
@@ -29,8 +29,6 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.6.0
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20200923090207-76fb069067fa
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,6 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20200914140452-d2c86086863e h1:XVp2vhAUGhh3SymWiLwaqqehfjs120p5wo/64yvgvWQ=
 github.com/codeready-toolchain/api v0.0.0-20200914140452-d2c86086863e/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200916194155-0cfe3ba580d9 h1:8rz+YtJXLxZoMeRLdng6j2Ja9BaOqPG4AK9VLIaa4dk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20200916194155-0cfe3ba580d9/go.mod h1:VhMZjATgVT/YrbXuEj+erSsxKCXoyF9uCHLs6hOt2VA=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -385,7 +383,6 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -407,7 +404,6 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -509,7 +505,6 @@ github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -585,6 +580,8 @@ github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/matousjobanek/toolchain-common v0.0.0-20200923090207-76fb069067fa h1:akcW6r81ldVCaN9H0qun1CnCJSFDQ8cFlx5leqVsKh8=
+github.com/matousjobanek/toolchain-common v0.0.0-20200923090207-76fb069067fa/go.mod h1:VhMZjATgVT/YrbXuEj+erSsxKCXoyF9uCHLs6hOt2VA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -820,7 +817,6 @@ github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
-github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -942,7 +938,6 @@ golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
@@ -962,7 +957,6 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
@@ -1083,7 +1077,6 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180805044716-cb6730876b98/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,10 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20200914140452-d2c86086863e h1:XVp2vhAUGhh3SymWiLwaqqehfjs120p5wo/64yvgvWQ=
 github.com/codeready-toolchain/api v0.0.0-20200914140452-d2c86086863e/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
+github.com/codeready-toolchain/api v0.0.0-20200925000842-d2e82e080a5a h1:zdLP2nVrHV+pzx39GIdz9iAunjaFQzS7G1XfjeUDk14=
+github.com/codeready-toolchain/api v0.0.0-20200925000842-d2e82e080a5a/go.mod h1:K0M7N66c37ebaXi/uFEGY/H9oieYR8PYYnhjfueTdYs=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200925155619-fa1a922a4e44 h1:a8q69+u/ZZck+WMC+aJGbe5zhZf6trVig6j4fz6d5rE=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20200925155619-fa1a922a4e44/go.mod h1:VhMZjATgVT/YrbXuEj+erSsxKCXoyF9uCHLs6hOt2VA=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -580,8 +584,6 @@ github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/matousjobanek/toolchain-common v0.0.0-20200923090207-76fb069067fa h1:akcW6r81ldVCaN9H0qun1CnCJSFDQ8cFlx5leqVsKh8=
-github.com/matousjobanek/toolchain-common v0.0.0-20200923090207-76fb069067fa/go.mod h1:VhMZjATgVT/YrbXuEj+erSsxKCXoyF9uCHLs6hOt2VA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/host-operator/pkg/counter"
 	. "github.com/codeready-toolchain/host-operator/test"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	uatest "github.com/codeready-toolchain/toolchain-common/pkg/test/useraccount"
@@ -43,8 +42,8 @@ func TestAddFinalizer(t *testing.T) {
 		memberClient := test.NewFakeClient(t)
 		hostClient := test.NewFakeClient(t, mur)
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		result, err := cntrl.Reconcile(newMurRequest(mur))
@@ -70,8 +69,8 @@ func TestAddFinalizer(t *testing.T) {
 			return fmt.Errorf("unable to add finalizer to MUR %s", mur.Name)
 		}
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -99,8 +98,8 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 	memberClient := test.NewFakeClient(t)
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-		clusterClient(test.MemberClusterName, memberClient))
+	cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+		ClusterClient(test.MemberClusterName, memberClient))
 
 	// when
 	_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -127,8 +126,8 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 	memberClient2 := test.NewFakeClient(t, consoleRoute())
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
+	cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+		ClusterClient(test.MemberClusterName, memberClient), ClusterClient("member2-cluster", memberClient2))
 
 	// when reconciling
 	result, err := cntrl.Reconcile(newMurRequest(mur))
@@ -164,10 +163,10 @@ func TestRequeueWhenUserAccountDeleted(t *testing.T) {
 		InitializeCounter(t, 1, UserAccountsForCluster(test.MemberClusterName, 2), UserAccountsForCluster("member2-cluster", 2))
 		userAccount2 := uatest.NewUserAccountFromMur(mur, uatest.DeletedUa())
 		memberClient2 := test.NewFakeClient(t, userAccount2, consoleRoute())
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient1),
-			clusterClient("member2-cluster", memberClient2),
-			clusterClient("member3-cluster", memberClient3))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient1),
+			ClusterClient("member2-cluster", memberClient2),
+			ClusterClient("member3-cluster", memberClient3))
 
 		// when
 		result, err := cntrl.Reconcile(newMurRequest(mur))
@@ -186,10 +185,10 @@ func TestRequeueWhenUserAccountDeleted(t *testing.T) {
 		userAccount2 := uatest.NewUserAccountFromMur(mur, uatest.DeletedUa())
 		userAccount2.DeletionTimestamp = &metav1.Time{Time: time.Now().Add(-3 * time.Second)}
 		memberClient2 := test.NewFakeClient(t, userAccount2, consoleRoute())
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient1),
-			clusterClient("member2-cluster", memberClient2),
-			clusterClient("member3-cluster", memberClient3))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient1),
+			ClusterClient("member2-cluster", memberClient2),
+			ClusterClient("member3-cluster", memberClient3))
 
 		// when
 		result, err := cntrl.Reconcile(newMurRequest(mur))
@@ -208,10 +207,10 @@ func TestRequeueWhenUserAccountDeleted(t *testing.T) {
 		userAccount2 := uatest.NewUserAccountFromMur(mur, uatest.DeletedUa())
 		userAccount2.DeletionTimestamp = &metav1.Time{Time: time.Now().Add(2 * time.Second)}
 		memberClient2 := test.NewFakeClient(t, userAccount2, consoleRoute())
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient1),
-			clusterClient("member2-cluster", memberClient2),
-			clusterClient("member3-cluster", memberClient3))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient1),
+			ClusterClient("member2-cluster", memberClient2),
+			ClusterClient("member3-cluster", memberClient3))
 
 		// when
 		result, err := cntrl.Reconcile(newMurRequest(mur))
@@ -237,8 +236,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		InitializeCounter(t, 1, UserAccountsForCluster(test.MemberClusterName, 1))
 		memberClient := test.NewFakeClient(t)
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(false, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -261,8 +260,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		InitializeCounter(t, 1, UserAccountsForCluster(test.MemberClusterName, 1))
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(false, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(false, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -283,8 +282,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		InitializeCounter(t, 1, UserAccountsForCluster(test.MemberClusterName, 1))
 		memberClient := test.NewFakeClient(t)
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionFalse),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -307,8 +306,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		InitializeCounter(t, 1, UserAccountsForCluster(test.MemberClusterName, 1))
 		memberClient := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionFalse),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionFalse),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -330,8 +329,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		InitializeCounter(t, 1, UserAccountsForCluster(test.MemberClusterName, 1))
 		memberClient := test.NewFakeClient(t)
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 		statusUpdater := func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error {
 			return fmt.Errorf("unable to update status")
 		}
@@ -355,8 +354,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			return fmt.Errorf("unable to create user account %s", mur.Name)
 		}
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -385,8 +384,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		murtest.ModifyUaInMur(modifiedMur, test.MemberClusterName, murtest.TierName("admin"))
 		hostClient := test.NewFakeClient(t, modifiedMur)
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(modifiedMur))
@@ -422,8 +421,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			return fmt.Errorf("unable to update MUR %s", provisionedMur.Name)
 		}
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(provisionedMur))
@@ -455,8 +454,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			return fmt.Errorf("unable to remove finalizer from MUR %s", mur.Name)
 		}
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -486,8 +485,8 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			return fmt.Errorf("unable to delete user account %s", mur.Name)
 		}
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -531,9 +530,9 @@ func TestModifyUserAccounts(t *testing.T) {
 	memberClient3 := test.NewFakeClient(t, userAccount3, consoleRoute())
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
-		clusterClient("member3-cluster", memberClient3))
+	cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+		ClusterClient(test.MemberClusterName, memberClient), ClusterClient("member2-cluster", memberClient2),
+		ClusterClient("member3-cluster", memberClient3))
 
 	// when ensuring 1st account
 	_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -611,9 +610,9 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 		hostClient := test.NewFakeClient(t, mur)
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2),
-			clusterClient("member3-cluster", memberClient3))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient), ClusterClient("member2-cluster", memberClient2),
+			ClusterClient("member3-cluster", memberClient3))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -672,9 +671,9 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 		memberClient := test.NewFakeClient(t, userAccount, consoleRoute())
 		memberClient2 := test.NewFakeClient(t, uatest.NewUserAccountFromMur(mur), consoleRoute())
 
-		cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-			clusterClient(test.MemberClusterName, memberClient),
-			clusterClient("member2-cluster", memberClient2))
+		cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+			ClusterClient(test.MemberClusterName, memberClient),
+			ClusterClient("member2-cluster", memberClient2))
 
 		// when
 		_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -717,8 +716,8 @@ func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
 	memberClient := test.NewFakeClient(t, userAcc)
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-		clusterClient(test.MemberClusterName, memberClient))
+	cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+		ClusterClient(test.MemberClusterName, memberClient))
 
 	// when
 	_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -751,8 +750,8 @@ func TestDeleteMultipleUserAccountsViaMasterUserRecordBeingDeleted(t *testing.T)
 	memberClient2 := test.NewFakeClient(t, userAcc)
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-		clusterClient(test.MemberClusterName, memberClient), clusterClient("member2-cluster", memberClient2))
+	cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+		ClusterClient(test.MemberClusterName, memberClient), ClusterClient("member2-cluster", memberClient2))
 
 	// when
 	_, err := cntrl.Reconcile(newMurRequest(mur))
@@ -785,8 +784,8 @@ func TestDisablingMasterUserRecord(t *testing.T) {
 	memberClient := test.NewFakeClient(t, userAccount, consoleRoute(), cheRoute(false))
 	hostClient := test.NewFakeClient(t, mur)
 
-	cntrl := newController(t, hostClient, s, newGetMemberCluster(true, v1.ConditionTrue),
-		clusterClient(test.MemberClusterName, memberClient))
+	cntrl := newController(t, hostClient, s, NewGetMemberCluster(true, v1.ConditionTrue),
+		ClusterClient(test.MemberClusterName, memberClient))
 
 	// when
 	res, err := cntrl.Reconcile(newMurRequest(mur))
@@ -812,9 +811,7 @@ func apiScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-type getMemberClusterFunc func(clusters ...clientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool)
-
-func newController(t *testing.T, hostCl client.Client, s *runtime.Scheme, getMemberCluster getMemberClusterFunc, memberCl ...clientForCluster) ReconcileMasterUserRecord {
+func newController(t *testing.T, hostCl client.Client, s *runtime.Scheme, getMemberCluster GetMemberClusterFunc, memberCl ...ClientForCluster) ReconcileMasterUserRecord {
 	config, err := configuration.LoadConfig(hostCl)
 	require.NoError(t, err)
 	return ReconcileMasterUserRecord{
@@ -822,48 +819,5 @@ func newController(t *testing.T, hostCl client.Client, s *runtime.Scheme, getMem
 		scheme:                s,
 		retrieveMemberCluster: getMemberCluster(memberCl...),
 		config:                config,
-	}
-}
-
-func newGetMemberCluster(ok bool, status v1.ConditionStatus) getMemberClusterFunc {
-	if !ok {
-		return func(clusters ...clientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool) {
-			return func(name string) (*cluster.CachedToolchainCluster, bool) {
-				return nil, false
-			}
-		}
-	}
-	return func(clusters ...clientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool) {
-		mapping := map[string]client.Client{}
-		for _, cluster := range clusters {
-			n, cl := cluster()
-			mapping[n] = cl
-		}
-		return func(name string) (*cluster.CachedToolchainCluster, bool) {
-			cl, ok := mapping[name]
-			if !ok {
-				return nil, false
-			}
-			return &cluster.CachedToolchainCluster{
-				Client:            cl,
-				Type:              cluster.Host,
-				OperatorNamespace: test.MemberOperatorNs,
-				OwnerClusterName:  test.HostClusterName,
-				ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
-					Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
-						Type:   toolchainv1alpha1.ToolchainClusterReady,
-						Status: status,
-					}},
-				},
-			}, true
-		}
-	}
-}
-
-type clientForCluster func() (string, client.Client)
-
-func clusterClient(name string, cl client.Client) clientForCluster {
-	return func() (string, client.Client) {
-		return name, cl
 	}
 }

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -38,7 +38,6 @@ var requeueResult = reconcile.Result{RequeueAfter: 5 * time.Second}
 const (
 	defaultHostOperatorName        = "host-operator"
 	defaultRegistrationServiceName = "registration-service"
-	defaultToolchainStatusName     = configuration.DefaultToolchainStatusName
 )
 
 type fakeHTTPClient struct {
@@ -89,7 +88,7 @@ func TestNoToolchainStatusFound(t *testing.T) {
 	t.Run("No toolchainstatus resource found - right name but not found", func(t *testing.T) {
 		// given
 		expectedErrMsg := "get failed"
-		requestName := defaultToolchainStatusName
+		requestName := configuration.DefaultToolchainStatusName
 		reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), newGetMemberClustersFuncReady)
 		fakeClient.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
 			return fmt.Errorf(expectedErrMsg)
@@ -109,7 +108,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 	// set the operator name environment variable for all the tests which is used to get the host operator deployment name
 	restore := test.SetEnvVarsAndRestore(t, test.Env(k8sutil.OperatorNameEnvVar, defaultHostOperatorName))
 	defer restore()
-	requestName := defaultToolchainStatusName
+	requestName := configuration.DefaultToolchainStatusName
 
 	t.Run("All components ready", func(t *testing.T) {
 		// given
@@ -117,7 +116,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 		hostOperatorDeployment := newDeploymentWithConditions(t, defaultHostOperatorName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 		registrationServiceDeployment := newDeploymentWithConditions(t, registrationservice.ResourceName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 		memberStatus := newMemberStatusReady()
-		toolchainStatus := newToolchainStatus()
+		toolchainStatus := NewToolchainStatus()
 		reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), newGetMemberClustersFuncReady, hostOperatorDeployment, memberStatus, registrationServiceDeployment, registrationService, toolchainStatus)
 
 		// when
@@ -135,7 +134,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 
 	t.Run("HostOperator tests", func(t *testing.T) {
 		registrationService := newRegistrationServiceReady()
-		toolchainStatus := newToolchainStatus()
+		toolchainStatus := NewToolchainStatus()
 		registrationServiceDeployment := newDeploymentWithConditions(t, registrationservice.ResourceName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 		memberStatus := newMemberStatusReady()
 
@@ -214,7 +213,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 
 	t.Run("RegistrationService deployment tests", func(t *testing.T) {
 		registrationService := newRegistrationServiceReady()
-		toolchainStatus := newToolchainStatus()
+		toolchainStatus := NewToolchainStatus()
 		memberStatus := newMemberStatusReady()
 		hostOperatorDeployment := newDeploymentWithConditions(t, defaultHostOperatorName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 
@@ -273,7 +272,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 	})
 
 	t.Run("RegistrationService resource tests", func(t *testing.T) {
-		toolchainStatus := newToolchainStatus()
+		toolchainStatus := NewToolchainStatus()
 		memberStatus := newMemberStatusReady()
 		hostOperatorDeployment := newDeploymentWithConditions(t, defaultHostOperatorName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 		registrationServiceDeployment := newDeploymentWithConditions(t, registrationservice.ResourceName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
@@ -319,7 +318,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 		hostOperatorDeployment := newDeploymentWithConditions(t, defaultHostOperatorName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 		registrationServiceDeployment := newDeploymentWithConditions(t, registrationservice.ResourceName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 		memberStatus := newMemberStatusReady()
-		toolchainStatus := newToolchainStatus()
+		toolchainStatus := NewToolchainStatus()
 
 		t.Run("Registration health endpoint - http client error", func(t *testing.T) {
 			// given
@@ -391,7 +390,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 	})
 
 	t.Run("MemberStatus tests", func(t *testing.T) {
-		toolchainStatus := newToolchainStatus()
+		toolchainStatus := NewToolchainStatus()
 		registrationService := newRegistrationServiceReady()
 		hostOperatorDeployment := newDeploymentWithConditions(t, defaultHostOperatorName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 		registrationServiceDeployment := newDeploymentWithConditions(t, registrationservice.ResourceName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
@@ -423,7 +422,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 			// given
 			defer counter.Reset()
 			memberStatus := newMemberStatusReady()
-			toolchainStatus := newToolchainStatus()
+			toolchainStatus := NewToolchainStatus()
 			toolchainStatus.Status.Members = []toolchainv1alpha1.Member{
 				memberClusterSingleNotReady("", "NoMemberClustersFound", "no member clusters found", nil),
 			}
@@ -505,7 +504,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 			// given
 			defer counter.Reset()
 			memberStatus := newMemberStatusReady()
-			toolchainStatus := newToolchainStatus()
+			toolchainStatus := NewToolchainStatus()
 			toolchainStatus.Status.Members = []toolchainv1alpha1.Member{
 				memberClusterSingleNotReady("member-cluster", "ComponentsNotReady", "some cool error", resourceUsage),
 			}
@@ -530,7 +529,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 			hostOperatorDeployment := newDeploymentWithConditions(t, defaultHostOperatorName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 			registrationServiceDeployment := newDeploymentWithConditions(t, registrationservice.ResourceName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 			memberStatus := newMemberStatusReady()
-			toolchainStatus := newToolchainStatus()
+			toolchainStatus := NewToolchainStatus()
 
 			t.Run("with non-zero counter", func(t *testing.T) {
 				// given
@@ -586,11 +585,11 @@ func TestSynchronizationWithCounter(t *testing.T) {
 	// given
 	restore := test.SetEnvVarsAndRestore(t, test.Env(k8sutil.OperatorNameEnvVar, defaultHostOperatorName))
 	defer restore()
-	requestName := defaultToolchainStatusName
+	requestName := configuration.DefaultToolchainStatusName
 	registrationService := newRegistrationServiceReady()
 	hostOperatorDeployment := newDeploymentWithConditions(t, defaultHostOperatorName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
 	registrationServiceDeployment := newDeploymentWithConditions(t, registrationservice.ResourceName, status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
-	toolchainStatus := newToolchainStatus()
+	toolchainStatus := NewToolchainStatus()
 	memberStatus := newMemberStatusReady()
 
 	t.Run("Load all current MURs & UAs", func(t *testing.T) {
@@ -619,7 +618,7 @@ func TestSynchronizationWithCounter(t *testing.T) {
 			counter.IncrementMasterUserRecordCount()
 			counter.IncrementMasterUserRecordCount()
 			counter.IncrementUserAccountCount("member-cluster")
-			toolchainStatus := newToolchainStatus()
+			toolchainStatus := NewToolchainStatus()
 			toolchainStatus.Status.HostOperator = &toolchainv1alpha1.HostOperatorStatus{
 				MasterUserRecordCount: 1,
 			}
@@ -647,7 +646,7 @@ func TestSynchronizationWithCounter(t *testing.T) {
 		defer counter.Reset()
 		counter.IncrementMasterUserRecordCount()
 		counter.IncrementUserAccountCount("member-cluster")
-		toolchainStatus := newToolchainStatus()
+		toolchainStatus := NewToolchainStatus()
 		toolchainStatus.Status.HostOperator = &toolchainv1alpha1.HostOperatorStatus{
 			MasterUserRecordCount: 8,
 		}
@@ -693,15 +692,6 @@ func newDeploymentWithConditions(t *testing.T, deploymentName string, deployment
 		},
 		Status: appsv1.DeploymentStatus{
 			Conditions: deploymentConditions,
-		},
-	}
-}
-
-func newToolchainStatus() *toolchainv1alpha1.ToolchainStatus {
-	return &toolchainv1alpha1.ToolchainStatus{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultToolchainStatusName,
-			Namespace: test.HostOperatorNs,
 		},
 	}
 }

--- a/pkg/controller/usersignup/mapper_test.go
+++ b/pkg/controller/usersignup/mapper_test.go
@@ -3,9 +3,9 @@ package usersignup
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
+	. "github.com/codeready-toolchain/host-operator/test"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
@@ -35,14 +35,14 @@ func TestBannedUserToUserSignupMapper(t *testing.T) {
 
 	t.Run("test BannedUserToUserSignupMapper maps correctly", func(t *testing.T) {
 		userSignup := &v1alpha1.UserSignup{
-			ObjectMeta: newObjectMeta("", "foo@redhat.com"),
+			ObjectMeta: NewUserSignupObjectMeta("", "foo@redhat.com"),
 			Spec: v1alpha1.UserSignupSpec{
 				Username: "foo@redhat.com",
 			},
 		}
 
 		userSignup2 := &v1alpha1.UserSignup{
-			ObjectMeta: newObjectMeta("", "alice.mayweather.doe@redhat.com"),
+			ObjectMeta: NewUserSignupObjectMeta("", "alice.mayweather.doe@redhat.com"),
 			Spec: v1alpha1.UserSignupSpec{
 				Username: "alice.mayweather.doe@redhat.com",
 			},
@@ -55,8 +55,8 @@ func TestBannedUserToUserSignupMapper(t *testing.T) {
 		}
 
 		// This is required for the mapper to function
-		os.Setenv(k8sutil.WatchNamespaceEnvVar, operatorNamespace)
-		defer os.Unsetenv(k8sutil.WatchNamespaceEnvVar)
+		restore := test.SetEnvVarAndRestore(t, k8sutil.WatchNamespaceEnvVar, test.HostOperatorNs)
+		defer restore()
 
 		req := mapper.Map(handler.MapObject{
 			Object: bannedUser,

--- a/pkg/controller/usersignup/masteruserrecord_test.go
+++ b/pkg/controller/usersignup/masteruserrecord_test.go
@@ -18,7 +18,7 @@ func TestNewMasterUserRecord(t *testing.T) {
 		nsTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
 
 		// when
-		mur, err := newMasterUserRecord(nsTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+		mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
 
 		// then
 		require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestNewMasterUserRecord(t *testing.T) {
 		nsTemplateTier.Spec.ClusterResources = nil
 
 		// when
-		mur, err := newMasterUserRecord(nsTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+		mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
 
 		// then
 		require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when mur is the same", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
 			require.NoError(t, err)
 
 			// when
@@ -90,7 +90,7 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when one namespace is missing and one is extra, but rest is fine, then doesn't change", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
 			require.NoError(t, err)
 			mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces[0].TemplateRef = "advanced-cicd-123abc1"
 			providedMur := mur.DeepCopy()
@@ -110,7 +110,7 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when mur is missing NsLimit", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
 			require.NoError(t, err)
 			mur.Spec.UserAccounts[0].Spec.NSLimit = ""
 
@@ -126,7 +126,7 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when whole NSTemplateSet is missing", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
 			require.NoError(t, err)
 			mur.Spec.UserAccounts[0].Spec.NSTemplateSet = v1alpha1.NSTemplateSetSpec{}
 
@@ -142,7 +142,7 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when tier labels are missing", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "654321b", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", operatorNamespace, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
 			delete(mur.Labels, "toolchain.dev.openshift.com/advanced-tier-hash") // removed for the purpose of this test
 			require.NoError(t, err)
 
@@ -183,7 +183,7 @@ func newExpectedMur(tier v1alpha1.NSTemplateTier) v1alpha1.MasterUserRecord {
 	return v1alpha1.MasterUserRecord{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "johny",
-			Namespace: operatorNamespace,
+			Namespace: test.HostOperatorNs,
 			Labels: map[string]string{
 				"toolchain.dev.openshift.com/user-id":              "123456789",
 				nstemplatetier.TemplateTierHashLabelKey(tier.Name): hash,

--- a/pkg/controller/usersignup/predicate_test.go
+++ b/pkg/controller/usersignup/predicate_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,7 @@ func TestUserSignupChangedPredicate(t *testing.T) {
 	userSignupOld := &v1alpha1.UserSignup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      userSignupName,
-			Namespace: operatorNamespace,
+			Namespace: test.HostOperatorNs,
 			Annotations: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "foo@redhat.com",
 			},
@@ -36,7 +37,7 @@ func TestUserSignupChangedPredicate(t *testing.T) {
 	userSignupNewNotChanged := &v1alpha1.UserSignup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      userSignupName,
-			Namespace: operatorNamespace,
+			Namespace: test.HostOperatorNs,
 			Annotations: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "foo@redhat.com",
 			},
@@ -53,7 +54,7 @@ func TestUserSignupChangedPredicate(t *testing.T) {
 	userSignupNewChanged := &v1alpha1.UserSignup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      userSignupName,
-			Namespace: operatorNamespace,
+			Namespace: test.HostOperatorNs,
 			Annotations: map[string]string{
 				toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "alice.mayweather.doe@redhat.com",
 			},

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -51,7 +51,8 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 		statusUpdater: &statusUpdater{
 			client: mgr.GetClient(),
 		},
-		scheme: mgr.GetScheme(),
+		scheme:            mgr.GetScheme(),
+		getMemberClusters: cluster.GetMemberClusters,
 	}
 }
 
@@ -95,7 +96,8 @@ var _ reconcile.Reconciler = &ReconcileUserSignup{}
 // ReconcileUserSignup reconciles a UserSignup object
 type ReconcileUserSignup struct {
 	*statusUpdater
-	scheme *runtime.Scheme
+	scheme            *runtime.Scheme
+	getMemberClusters cluster.GetMemberClustersFunc
 }
 
 // Reconcile reads that state of the cluster for a UserSignup object and makes changes based on the state read
@@ -286,7 +288,7 @@ func (r *ReconcileUserSignup) ensureNewMurIfApproved(reqLogger logr.Logger, user
 			targetCluster = userSignup.Spec.TargetCluster
 		} else {
 			// Automatic cluster selection based on cluster readiness
-			members := cluster.GetMemberClusters(cluster.Ready, cluster.CapacityNotExhausted)
+			members := r.getMemberClusters(cluster.Ready, cluster.CapacityNotExhausted)
 			if len(members) > 0 {
 				targetCluster = members[0].Name
 			} else {

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type GetMemberClusterFunc func(clusters ...ClientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool)
+
+func NewGetMemberClusters(memberClusters ...*cluster.CachedToolchainCluster) cluster.GetMemberClustersFunc {
+	return func(conditions ...cluster.Condition) []*cluster.CachedToolchainCluster {
+		clusters := map[string]*cluster.CachedToolchainCluster{}
+		for _, memberCluster := range memberClusters {
+			clusters[memberCluster.Name] = memberCluster
+		}
+		filteredClusters := cluster.Filter(cluster.Member, clusters, conditions...)
+		var filteredClustersInOrder []*cluster.CachedToolchainCluster
+		for _, givenCluster := range memberClusters {
+			for _, filteredCluster := range filteredClusters {
+				if givenCluster.Name == filteredCluster.Name {
+					filteredClustersInOrder = append(filteredClustersInOrder, givenCluster)
+					break
+				}
+			}
+
+		}
+		return filteredClustersInOrder
+	}
+}
+
+func NewMemberCluster(t *testing.T, name string, status v1.ConditionStatus) *cluster.CachedToolchainCluster {
+	return NewMemberClusterWithClient(test.NewFakeClient(t), name, status)
+}
+
+func NewMemberClusterWithClient(cl client.Client, name string, status v1.ConditionStatus) *cluster.CachedToolchainCluster {
+	toolchainCluster, _ := NewGetMemberCluster(true, status)(ClusterClient(name, cl))(name)
+	return toolchainCluster
+}
+
+func NewGetMemberCluster(ok bool, status v1.ConditionStatus) GetMemberClusterFunc {
+	if !ok {
+		return func(clusters ...ClientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool) {
+			return func(name string) (*cluster.CachedToolchainCluster, bool) {
+				return nil, false
+			}
+		}
+	}
+	return func(clusters ...ClientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool) {
+		mapping := map[string]client.Client{}
+		for _, clusterClient := range clusters {
+			n, cl := clusterClient()
+			mapping[n] = cl
+		}
+		return func(name string) (*cluster.CachedToolchainCluster, bool) {
+			cl, ok := mapping[name]
+			if !ok {
+				return nil, false
+			}
+			return &cluster.CachedToolchainCluster{
+				Client:            cl,
+				Name:              name,
+				Type:              cluster.Member,
+				OperatorNamespace: test.MemberOperatorNs,
+				OwnerClusterName:  test.HostClusterName,
+				ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
+					Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
+						Type:   toolchainv1alpha1.ToolchainClusterReady,
+						Status: status,
+					}},
+				},
+			}, true
+		}
+	}
+}
+
+type ClientForCluster func() (string, client.Client)
+
+func ClusterClient(name string, cl client.Client) ClientForCluster {
+	return func() (string, client.Client) {
+		return name, cl
+	}
+}

--- a/test/toolchainstatus.go
+++ b/test/toolchainstatus.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ToolchainStatusOption func(*toolchainv1alpha1.ToolchainStatus)
+
+func WithMember(name string, options ...MemberToolchainStatusOption) ToolchainStatusOption {
+	return func(status *toolchainv1alpha1.ToolchainStatus) {
+		member := toolchainv1alpha1.Member{
+			ClusterName: name,
+		}
+		for _, modify := range options {
+			modify(&member)
+		}
+		status.Status.Members = append(status.Status.Members, member)
+	}
+}
+
+type MemberToolchainStatusOption func(*toolchainv1alpha1.Member)
+
+func WithNodeRoleUsage(role string, usage int) MemberToolchainStatusOption {
+	return func(status *toolchainv1alpha1.Member) {
+		if status.MemberStatus.ResourceUsage.MemoryUsagePerNodeRole == nil {
+			status.MemberStatus.ResourceUsage.MemoryUsagePerNodeRole = map[string]int{}
+		}
+		status.MemberStatus.ResourceUsage.MemoryUsagePerNodeRole[role] = usage
+	}
+}
+
+func NewToolchainStatus(options ...func(*toolchainv1alpha1.ToolchainStatus)) *toolchainv1alpha1.ToolchainStatus {
+	toolchainStatus := &toolchainv1alpha1.ToolchainStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configuration.DefaultToolchainStatusName,
+			Namespace: test.HostOperatorNs,
+		},
+	}
+	for _, modify := range options {
+		modify(toolchainStatus)
+	}
+	return toolchainStatus
+}

--- a/test/usersignup.go
+++ b/test/usersignup.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
+	uuid "github.com/satori/go.uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func WithTargetCluster(targetCluster string) UserSignupModifier {
+	return func(userSignup *v1alpha1.UserSignup) {
+		userSignup.Spec.TargetCluster = targetCluster
+	}
+}
+
+func Approved() UserSignupModifier {
+	return func(userSignup *v1alpha1.UserSignup) {
+		userSignup.Spec.Approved = true
+	}
+}
+
+func Deactivated() UserSignupModifier {
+	return func(userSignup *v1alpha1.UserSignup) {
+		userSignup.Spec.Deactivated = true
+	}
+}
+
+func VerificationRequired() UserSignupModifier {
+	return func(userSignup *v1alpha1.UserSignup) {
+		userSignup.Spec.VerificationRequired = true
+	}
+}
+
+func WithUsername(username string) UserSignupModifier {
+	return func(userSignup *v1alpha1.UserSignup) {
+		userSignup.Spec.Username = username
+	}
+}
+
+type UserSignupModifier func(*v1alpha1.UserSignup)
+
+func NewUserSignup(modifiers ...UserSignupModifier) *v1alpha1.UserSignup {
+	signup := &v1alpha1.UserSignup{
+		ObjectMeta: NewUserSignupObjectMeta("foo", "foo@redhat.com"),
+		Spec: v1alpha1.UserSignupSpec{
+			Username: "foo@redhat.com",
+		},
+	}
+	for _, modify := range modifiers {
+		modify(signup)
+	}
+	return signup
+}
+
+func NewUserSignupObjectMeta(name, email string) metav1.ObjectMeta {
+	if name == "" {
+		name = uuid.NewV4().String()
+	}
+
+	md5hash := md5.New()
+	// Ignore the error, as this implementation cannot return one
+	_, _ = md5hash.Write([]byte(email))
+	emailHash := hex.EncodeToString(md5hash.Sum(nil))
+
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: test.HostOperatorNs,
+		Annotations: map[string]string{
+			toolchainv1alpha1.UserSignupUserEmailAnnotationKey: email,
+		},
+		Labels: map[string]string{
+			toolchainv1alpha1.UserSignupUserEmailHashLabelKey: emailHash,
+			"toolchain.dev.openshift.com/approved":            "false",
+		},
+	}
+}


### PR DESCRIPTION
Rename:
`newGetMemberCluster` -> `NewGetMemberCluster` and moved to  `test/cluster.go`
`clusterClient` -> `ClusterClient` and moved to `test/cluster.go`
`newToolchainStatus` -> `NewToolchainStatus` and moved to  `test/toolchainstatus.go`
`newObjectMeta` -> `NewUserSignupObjectMeta` and moved to  `test/usersignup.go`
`operatorNamespace` -> `test.HostOperatorNs`
`defaultToolchainStatusName` -> `configuration.DefaultToolchainStatusName`

Introduced `getMemberClusters cluster.GetMemberClustersFunc` param in UserSignup controller for easy mocking.

replaced all initialization of `UserSignup` with `NewUserSignup()` function 
