### PR TITLE
Enable auto deactivation on basic and advanced tiers and exclusion

### DIFF
--- a/deploy/env/dev.yaml
+++ b/deploy/env/dev.yaml
@@ -1,3 +1,5 @@
 registration-service:
   environment: 'dev'
   replicas: 2
+host-operator:
+  deactivation-domains-excluded: '@redhat.com'

--- a/deploy/env/e2e-tests.yaml
+++ b/deploy/env/e2e-tests.yaml
@@ -14,3 +14,4 @@ host-operator:
   duration-before-notification-deletion: '5s'
   environment: 'e2e-tests'
   toolchainstatus-refresh-time: '1s'
+  deactivation-domains-excluded: '@excluded.com'

--- a/deploy/env/prod.yaml
+++ b/deploy/env/prod.yaml
@@ -17,3 +17,4 @@ host-operator:
     name: host-operator-secret
   config-map:
     name: host-operator-config
+  deactivation-domains-excluded: '@redhat.com'

--- a/deploy/templates/nstemplatetiers/advanced/tier.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/tier.yaml
@@ -11,6 +11,7 @@ objects:
   spec:
     clusterResources:
       templateRef: ${CLUSTER_TEMPL_REF}
+    deactivationTimeoutDays: 14
     namespaces:
       - templateRef: ${CODE_TEMPL_REF}
       - templateRef: ${DEV_TEMPL_REF}

--- a/deploy/templates/nstemplatetiers/basic/tier.yaml
+++ b/deploy/templates/nstemplatetiers/basic/tier.yaml
@@ -11,6 +11,7 @@ objects:
   spec:
     clusterResources:
       templateRef: ${CLUSTER_TEMPL_REF}
+    deactivationTimeoutDays: 14
     namespaces:
       - templateRef: ${CODE_TEMPL_REF}
       - templateRef: ${DEV_TEMPL_REF}

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
@@ -126,7 +126,7 @@ func TestCreateOrUpdateResources(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, int64(1), tier.ObjectMeta.Generation)
 				if tier.Name == "nocluster" {
-					assert.Nil(t, tier.Spec.ClusterResources) // "team" tier should not have cluster resources set
+					assert.Nil(t, tier.Spec.ClusterResources) // "nocluster" tier should not have cluster resources set
 				} else {
 					require.NotNil(t, tier.Spec.ClusterResources)
 					assert.Equal(t, expectedTemplateRefs[tierName]["clusterresources"][0], tier.Spec.ClusterResources.TemplateRef)


### PR DESCRIPTION
This PR changes the following:

- automatic user deactivation for the basic and advanced tiers. The team tier will remain the same (no `deactivationTimeoutDays` configured) so users in that tier will not be automatically deactivated
- adds `@redhat.com` to the auto deactivation exclusion list for both prod and dev environments
- adds `@excluded.com` to the auto deactivation exclusion list for the test environments

e2e PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/169
- tests the auto exclusion list configured with `@excluded.com`

Related issue:
https://issues.redhat.com/browse/CRT-815