### PR TITLE
Enable phone verification in e2e tests

### DIFF
--- a/deploy/env/e2e-tests.yaml
+++ b/deploy/env/e2e-tests.yaml
@@ -2,13 +2,10 @@ registration-service:
   environment: 'e2e-tests'
   replicas: 2
   verification:
-    #enabled: 'true'
-    enabled: 'false'
+    enabled: 'true'
     excluded-email-domains: 'redhat.com,acme.com'
-  #twilio:
-    #account-sid: ''
-    #auth-token: ''
-    #from-number: ''
+  twilio:
+    from-number: '+15005550006'
 host-operator:
   duration-before-change-request-deletion: '5s'
   duration-before-notification-deletion: '5s'


### PR DESCRIPTION
This PR simply enables the phone verification feature for e2e tests.

This is part of the changes required for https://issues.redhat.com/browse/CRT-792.
