### PR TITLE
chore: Update email text for provision and deactivation

### DIFF
--- a/deploy/templates/notificationtemplates/userdeactivated/notification.html
+++ b/deploy/templates/notificationtemplates/userdeactivated/notification.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>
-        Notice: Your Red Hat CodeReady Toolchain account has been deactivated
+        Notice: Your account is deactivated for Red Hat OpenShift Dev Sandbox Beta
     </title>
     <style>
         a:hover {
@@ -41,17 +41,17 @@
 >
 
     <p>
-        You are receiving this email because you have an online <a href={{.RegistrationURL}}>Red Hat CodeReady Toolchain</a>
+        You are receiving this email because you have a <a href={{.RegistrationURL}}>Red Hat OpenShift Dev Sandbox Beta</a>
         account associated with {{.UserEmail}}.
     </p>
 
     <p>
-        Your <a href={{.RegistrationURL }}>Red Hat CodeReady Toolchain</a> account has been deactivated.
+        Your account is now deactivated and all your data on Red Hat OpenShift Dev Sandbox has been deleted. You can request new access by signing up again.
     </p>
 
     <p>
         Thanks,<br />
-        The Red Hat CodeReady Toolchain team
+        The Red Hat OpenShift Dev Sandbox team
     </p>
 </div>
 </body>

--- a/deploy/templates/notificationtemplates/userdeactivated/subject.txt
+++ b/deploy/templates/notificationtemplates/userdeactivated/subject.txt
@@ -1,1 +1,1 @@
-Notice: Your Red Hat CodeReady Toolchain account has been deactivated
+Notice: Your account is deactivated for Red Hat OpenShift Dev Sandbox Beta

--- a/deploy/templates/notificationtemplates/userprovisioned/notification.html
+++ b/deploy/templates/notificationtemplates/userprovisioned/notification.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>
-        Notice: Your Red Hat CodeReady Toolchain account has been provisioned
+        Notice: Your account is provisioned for Red Hat OpenShift Dev Sandbox Beta
     </title>
     <style>
         a:hover {
@@ -41,18 +41,22 @@
 >
 
     <p>
-        You are receiving this email because you have an online <a href={{.RegistrationURL}}>Red Hat CodeReady Toolchain</a>
+        You are receiving this email because you have a <a href={{.RegistrationURL}}>Red Hat OpenShift Dev Sandbox Beta</a>
         account associated with {{.UserEmail}}.
     </p>
 
     <p>
-        Your <a href={{.RegistrationURL }}>Red Hat CodeReady Toolchain</a> account has been provisioned and is ready to use. Please log in to
-        <a href={{.RegistrationURL}}>Red Hat CodeReady Toolchain</a> to begin using your account.
+        Your account has been provisioned and is ready to use. Your account will be active for 14 days. 
+        At the end of the active period, your access will be deactivated and all your data on the Dev Sandbox will be deleted.
+    </p>
+
+    <p>
+        Please log in to <a href={{.RegistrationURL}}>Red Hat OpenShift Dev Sandbox Beta</a> to begin using your account.
     </p>
 
     <p>
         Thanks,<br />
-        The Red Hat CodeReady Toolchain team
+        The Red Hat OpenShift Dev Sandbox team
     </p>
 </div>
 </body>

--- a/deploy/templates/notificationtemplates/userprovisioned/subject.txt
+++ b/deploy/templates/notificationtemplates/userprovisioned/subject.txt
@@ -1,1 +1,1 @@
-Notice: Your Red Hat CodeReady Toolchain account has been provisioned
+Notice: Your account is provisioned for Red Hat OpenShift Dev Sandbox Beta

--- a/pkg/templates/notificationtemplates/notification_generator_test.go
+++ b/pkg/templates/notificationtemplates/notification_generator_test.go
@@ -23,8 +23,8 @@ func TestGetNotificationTemplate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, template)
 			assert.True(t, found)
-			assert.Equal(t, "Notice: Your Red Hat CodeReady Toolchain account has been deactivated", template.Subject)
-			assert.Contains(t, template.Content, "Your <a href={{.RegistrationURL }}>Red Hat CodeReady Toolchain</a> account has been deactivated.")
+			assert.Equal(t, "Notice: Your account is deactivated for Red Hat OpenShift Dev Sandbox Beta", template.Subject)
+			assert.Contains(t, template.Content, "Your account is now deactivated and all your data on Red Hat OpenShift Dev Sandbox has been deleted. You can request new access by signing up again.")
 		})
 		t.Run("get userprovisioned notification template", func(t *testing.T) {
 			// when
@@ -34,8 +34,8 @@ func TestGetNotificationTemplate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, template)
 			assert.True(t, found)
-			assert.Equal(t, "Notice: Your Red Hat CodeReady Toolchain account has been provisioned", template.Subject)
-			assert.Contains(t, template.Content, "Your <a href={{.RegistrationURL }}>Red Hat CodeReady Toolchain</a> account has been provisioned and is ready to use.")
+			assert.Equal(t, "Notice: Your account is provisioned for Red Hat OpenShift Dev Sandbox Beta", template.Subject)
+			assert.Contains(t, template.Content, "Your account has been provisioned and is ready to use. Your account will be active for 14 days.")
 		})
 		t.Run("ensure cache is used", func(t *testing.T) {
 			// when
@@ -47,8 +47,8 @@ func TestGetNotificationTemplate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, template)
 			require.NotEmpty(t, template["userprovisioned"])
-			assert.Equal(t, "Notice: Your Red Hat CodeReady Toolchain account has been provisioned", template["userprovisioned"].Subject)
-			assert.Contains(t, template["userprovisioned"].Content, "You are receiving this email because you have an online <a href={{.RegistrationURL}}>Red Hat CodeReady Toolchain</a>")
+			assert.Equal(t, "Notice: Your account is provisioned for Red Hat OpenShift Dev Sandbox Beta", template["userprovisioned"].Subject)
+			assert.Contains(t, template["userprovisioned"].Content, "Your account has been provisioned and is ready to use. Your account will be active for 14 days.")
 			assert.Equal(t, template["userprovisioned"], *UserProvisioned)
 		})
 	})


### PR DESCRIPTION
Updates the email text for both the provisioned and deactivated emails that are sent to users.

Changes:
- new deactivation email
- updated provisioned email to specify active period of 14 days
- updated naming to "Red Hat OpenShift Dev Sandbox Beta"