### PR TITLE
adding devsandbox email to templates

### DIFF
--- a/deploy/templates/notificationtemplates/userdeactivated/notification.html
+++ b/deploy/templates/notificationtemplates/userdeactivated/notification.html
@@ -50,6 +50,10 @@
     </p>
 
     <p>
+        If you have feedback, we would love to hear it. Please feel free to reach us at devsandbox@redhat.com.
+    </p>
+
+    <p>
         Thanks,<br />
         The Red Hat OpenShift Dev Sandbox team
     </p>

--- a/deploy/templates/notificationtemplates/userdeactivated/notification.html
+++ b/deploy/templates/notificationtemplates/userdeactivated/notification.html
@@ -50,7 +50,7 @@
     </p>
 
     <p>
-        You can reach us at devsandbox@redhat.com for assistance and feedback.
+        We appreciate your feedback at devsandbox@redhat.com to help us improve our service.
     </p>
 
     <p>

--- a/deploy/templates/notificationtemplates/userdeactivated/notification.html
+++ b/deploy/templates/notificationtemplates/userdeactivated/notification.html
@@ -50,7 +50,7 @@
     </p>
 
     <p>
-        If you have feedback, we would love to hear it. Please feel free to reach us at devsandbox@redhat.com.
+        You can reach us at devsandbox@redhat.com for assistance and feedback.
     </p>
 
     <p>

--- a/deploy/templates/notificationtemplates/userprovisioned/notification.html
+++ b/deploy/templates/notificationtemplates/userprovisioned/notification.html
@@ -55,6 +55,10 @@
     </p>
 
     <p>
+        If you have feedback, we would love to hear it. Please feel free to reach us at devsandbox@redhat.com.
+    </p>
+
+    <p>
         Thanks,<br />
         The Red Hat OpenShift Dev Sandbox team
     </p>

--- a/deploy/templates/notificationtemplates/userprovisioned/notification.html
+++ b/deploy/templates/notificationtemplates/userprovisioned/notification.html
@@ -55,7 +55,7 @@
     </p>
 
     <p>
-        If you have feedback, we would love to hear it. Please feel free to reach us at devsandbox@redhat.com.
+        You can reach us at devsandbox@redhat.com for assistance and feedback.
     </p>
 
     <p>


### PR DESCRIPTION
adding devsandbox@redhat.com to provisioned and deactivated notification templates.
Jira: https://issues.redhat.com/browse/CRT-625

copying contents regarding the email for the templates from this document: https://docs.google.com/document/d/1KaN9BrsYpTvWnZZ_svWeTPIJY4UUJcnudM3gryRYi9k/edit