### PR TITLE
feat: add waiting list for unapproved UserSignups 

### DIFF
--- a/pkg/controller/usersignup/approval_test.go
+++ b/pkg/controller/usersignup/approval_test.go
@@ -44,7 +44,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member1", clusterName)
+		assert.Equal(t, "member1", clusterName.getClusterName())
 	})
 
 	t.Run("with two clusters and enough capacity in both of them so it returns the first one", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member1", clusterName)
+		assert.Equal(t, "member1", clusterName.getClusterName())
 	})
 
 	t.Run("with two clusters where the first one reaches resource threshold", func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member2", clusterName)
+		assert.Equal(t, "member2", clusterName.getClusterName())
 	})
 
 	t.Run("with two clusters where the first one reaches max number of UserAccounts", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member2", clusterName)
+		assert.Equal(t, "member2", clusterName.getClusterName())
 	})
 
 	t.Run("with two clusters, none of them is returned since it reaches max number of MURs", func(t *testing.T) {
@@ -118,9 +118,9 @@ func TestGetClusterIfApproved(t *testing.T) {
 		approved, clusterName, err := getClusterIfApproved(fakeClient, config, signup, clusters)
 
 		// then
-		require.EqualError(t, err, "no suitable member cluster found - capacity was reached")
+		require.NoError(t, err)
 		assert.False(t, approved)
-		assert.Empty(t, clusterName)
+		assert.Equal(t, notFound, clusterName)
 	})
 
 	t.Run("with two clusters and enough capacity only in second one using the default values", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member2", clusterName)
+		assert.Equal(t, "member2", clusterName.getClusterName())
 	})
 
 	t.Run("with two clusters and enough capacity in none of them using the default memory values", func(t *testing.T) {
@@ -156,9 +156,9 @@ func TestGetClusterIfApproved(t *testing.T) {
 		approved, clusterName, err := getClusterIfApproved(fakeClient, config, signup, clusters)
 
 		// then
-		require.EqualError(t, err, "no suitable member cluster found - capacity was reached")
+		require.NoError(t, err)
 		assert.False(t, approved)
-		assert.Empty(t, clusterName)
+		assert.Equal(t, notFound, clusterName)
 	})
 
 	t.Run("automatic approval not enabled and user not approved", func(t *testing.T) {
@@ -172,7 +172,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.False(t, approved)
-		assert.Empty(t, clusterName)
+		assert.Equal(t, unknown, clusterName)
 	})
 
 	t.Run("HostOperatorConfig not found and user not approved", func(t *testing.T) {
@@ -186,7 +186,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.False(t, approved)
-		assert.Empty(t, clusterName)
+		assert.Equal(t, unknown, clusterName)
 	})
 
 	t.Run("HostOperatorConfig not found and user approved without target cluster", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member1", clusterName)
+		assert.Equal(t, "member1", clusterName.getClusterName())
 	})
 
 	t.Run("automatic approval not enabled, user approved but no cluster has capacity", func(t *testing.T) {
@@ -216,9 +216,9 @@ func TestGetClusterIfApproved(t *testing.T) {
 		approved, clusterName, err := getClusterIfApproved(fakeClient, config, signup, clusters)
 
 		// then
-		require.EqualError(t, err, "no suitable member cluster found - capacity was reached")
+		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Empty(t, clusterName)
+		assert.Equal(t, notFound, clusterName)
 	})
 
 	t.Run("automatic approval not enabled, user approved and second cluster has capacity", func(t *testing.T) {
@@ -237,7 +237,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member2", clusterName)
+		assert.Equal(t, "member2", clusterName.getClusterName())
 	})
 
 	t.Run("automatic approval not enabled, user approved, no cluster has capacity but targetCluster is specified", func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member1", clusterName)
+		assert.Equal(t, "member1", clusterName.getClusterName())
 	})
 
 	t.Run("with two clusters and enough capacity in both of them but first one is not ready", func(t *testing.T) {
@@ -273,7 +273,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, approved)
-		assert.Equal(t, "member2", clusterName)
+		assert.Equal(t, "member2", clusterName.getClusterName())
 	})
 
 	t.Run("failures", func(t *testing.T) {
@@ -291,7 +291,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 			// then
 			require.EqualError(t, err, "unable to read HostOperatorConfig resource: some error")
 			assert.False(t, approved)
-			assert.Empty(t, clusterName)
+			assert.Equal(t, unknown, clusterName)
 		})
 
 		t.Run("unable to read ToolchainStatus", func(t *testing.T) {
@@ -311,7 +311,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 			// then
 			require.EqualError(t, err, "unable to read ToolchainStatus resource: some error")
 			assert.False(t, approved)
-			assert.Empty(t, clusterName)
+			assert.Equal(t, unknown, clusterName)
 		})
 	})
 }
@@ -331,5 +331,5 @@ func TestGetClusterIfApprovedWhenCounterIsNotInitialized(t *testing.T) {
 	// then
 	require.EqualError(t, err, "unable to get the number of provisioned users: counter is not initialized")
 	assert.False(t, approved)
-	assert.Empty(t, clusterName)
+	assert.Equal(t, unknown, clusterName)
 }

--- a/pkg/controller/usersignup/predicate.go
+++ b/pkg/controller/usersignup/predicate.go
@@ -17,7 +17,13 @@ type UserSignupChangedPredicate struct {
 	controllerPredicate.Funcs
 }
 
-// Update implements default UpdateEvent filter for validating generation change
+// Update filters update events and let the reconcile loop to be triggered when any of the following conditions is met:
+//
+// * generation number has changed
+//
+// * annotation toolchain.dev.openshift.com/user-email has changed
+//
+// * label toolchain.dev.openshift.com/email-hash has changed
 func (p UserSignupChangedPredicate) Update(e event.UpdateEvent) bool {
 	if !checkMetaObjects(changedLog, e) {
 		return false

--- a/pkg/controller/usersignup/predicate.go
+++ b/pkg/controller/usersignup/predicate.go
@@ -1,11 +1,17 @@
 package usersignup
 
 import (
+	"github.com/codeready-toolchain/host-operator/pkg/controller/hostoperatorconfig"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	controllerPredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var changedLog = logf.Log.WithName("user_signup_changed_predicate")
 
 type UserSignupChangedPredicate struct {
 	controllerPredicate.Funcs
@@ -13,20 +19,7 @@ type UserSignupChangedPredicate struct {
 
 // Update implements default UpdateEvent filter for validating generation change
 func (p UserSignupChangedPredicate) Update(e event.UpdateEvent) bool {
-	if e.MetaOld == nil {
-		log.Error(nil, "Update event has no old metadata", "event", e)
-		return false
-	}
-	if e.ObjectOld == nil {
-		log.Error(nil, "Update event has no old runtime object to update", "event", e)
-		return false
-	}
-	if e.ObjectNew == nil {
-		log.Error(nil, "Update event has no new runtime object for update", "event", e)
-		return false
-	}
-	if e.MetaNew == nil {
-		log.Error(nil, "Update event has no new metadata", "event", e)
+	if !checkMetaObjects(changedLog, e) {
 		return false
 	}
 	if e.MetaNew.GetGeneration() == e.MetaOld.GetGeneration() &&
@@ -43,4 +36,67 @@ func (p UserSignupChangedPredicate) AnnotationChanged(e event.UpdateEvent, annot
 
 func (p UserSignupChangedPredicate) LabelChanged(e event.UpdateEvent, labelName string) bool {
 	return e.MetaOld.GetLabels()[labelName] != e.MetaNew.GetLabels()[labelName]
+}
+
+var configLog = logf.Log.WithName("automatic_approval_predicate")
+
+// OnlyWhenAutomaticApprovalIsEnabled let the reconcile to be triggered only when the automatic approval is enabled
+type OnlyWhenAutomaticApprovalIsEnabled struct {
+	client client.Client
+}
+
+// Update implements default UpdateEvent filter for validating no generation change
+func (p OnlyWhenAutomaticApprovalIsEnabled) Update(e event.UpdateEvent) bool {
+	if !checkMetaObjects(configLog, e) {
+		return false
+	}
+	return p.checkIfAutomaticApprovalIsEnabled(e.MetaNew.GetNamespace())
+}
+
+// Create implements Predicate
+func (OnlyWhenAutomaticApprovalIsEnabled) Create(e event.CreateEvent) bool {
+	return false
+}
+
+// Delete implements Predicate
+func (OnlyWhenAutomaticApprovalIsEnabled) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+// Generic implements Predicate
+func (p OnlyWhenAutomaticApprovalIsEnabled) Generic(e event.GenericEvent) bool {
+	if e.Meta == nil {
+		log.Error(nil, "Generic event has no object metadata", "event", e)
+		return false
+	}
+	return p.checkIfAutomaticApprovalIsEnabled(e.Meta.GetNamespace())
+}
+
+func (p OnlyWhenAutomaticApprovalIsEnabled) checkIfAutomaticApprovalIsEnabled(namespace string) bool {
+	config, err := hostoperatorconfig.GetConfig(p.client, namespace)
+	if err != nil {
+		configLog.Error(nil, "unable to get HostOperatorConfig resource", "namespace", namespace)
+		return false
+	}
+	return config.AutomaticApproval.Enabled
+}
+
+func checkMetaObjects(log logr.Logger, e event.UpdateEvent) bool {
+	if e.MetaOld == nil {
+		log.Error(nil, "Update event has no old metadata", "event", e)
+		return false
+	}
+	if e.ObjectOld == nil {
+		log.Error(nil, "Update event has no old runtime object to update", "event", e)
+		return false
+	}
+	if e.ObjectNew == nil {
+		log.Error(nil, "Update event has no new runtime object for update", "event", e)
+		return false
+	}
+	if e.MetaNew == nil {
+		log.Error(nil, "Update event has no new metadata", "event", e)
+		return false
+	}
+	return true
 }

--- a/pkg/controller/usersignup/unapproved/cache.go
+++ b/pkg/controller/usersignup/unapproved/cache.go
@@ -1,0 +1,74 @@
+package unapproved
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("unapproved_usersignup_cache")
+
+type cache struct {
+	sync.RWMutex
+	userSignupsByCreation []string
+	client                client.Client
+}
+
+func (c *cache) getOldestPendingApproval(namespace string) *toolchainv1alpha1.UserSignup {
+	c.Lock()
+	defer c.Unlock()
+	oldest := c.getFirstExisting(namespace)
+	if oldest == nil {
+		c.loadLatest(namespace)
+		oldest = c.getFirstExisting(namespace)
+	}
+	return oldest
+}
+
+func (c *cache) loadLatest(namespace string) {
+	labels := map[string]string{toolchainv1alpha1.UserSignupStateLabelKey: toolchainv1alpha1.UserSignupStateLabelValuePending}
+	opts := client.MatchingLabels(labels)
+	userSignupList := &toolchainv1alpha1.UserSignupList{}
+	if err := c.client.List(context.TODO(), userSignupList, opts); err != nil {
+		err = errors.Wrapf(err, "unable to list UserSignup resources with label '%s' having value '%s'",
+			toolchainv1alpha1.UserSignupStateLabelKey, toolchainv1alpha1.UserSignupStateLabelValuePending)
+		log.Error(err, "could not get the oldest unapproved UserSignup")
+		return
+	}
+	userSignups := userSignupList.Items
+	sort.Slice(userSignups, func(i, j int) bool {
+		return userSignups[i].CreationTimestamp.Time.Before(userSignups[j].CreationTimestamp.Time)
+	})
+	for _, userSignup := range userSignups {
+		c.userSignupsByCreation = append(c.userSignupsByCreation, userSignup.Name)
+	}
+}
+
+func (c *cache) getFirstExisting(namespace string) *toolchainv1alpha1.UserSignup {
+	if len(c.userSignupsByCreation) == 0 {
+		return nil
+	}
+	name := c.userSignupsByCreation[0]
+	userSignup := &toolchainv1alpha1.UserSignup{}
+	if err := c.client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, userSignup); err != nil {
+		if apierrors.IsNotFound(err) {
+			c.userSignupsByCreation = c.userSignupsByCreation[1:]
+			return c.getFirstExisting(namespace)
+		}
+		log.Error(err, "could not get the oldest unapproved UserSignup")
+		return nil
+	}
+	if userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] != toolchainv1alpha1.UserSignupStateLabelValuePending {
+		c.userSignupsByCreation = c.userSignupsByCreation[1:]
+		return c.getFirstExisting(namespace)
+	}
+
+	return userSignup
+}

--- a/pkg/controller/usersignup/unapproved/cache_test.go
+++ b/pkg/controller/usersignup/unapproved/cache_test.go
@@ -1,0 +1,194 @@
+package unapproved
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/apis"
+	. "github.com/codeready-toolchain/host-operator/test"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestGetOldestPendingApproval(t *testing.T) {
+	// given
+	withoutStateLabel := NewUserSignup()
+	notReady := NewUserSignup(WithStateLabel("not-ready"))
+	pending := NewUserSignup(WithStateLabel("pending"))
+	approved := NewUserSignup(WithStateLabel("approved"))
+	deactivated := NewUserSignup(WithStateLabel("deactivated"))
+	banned := NewUserSignup(WithStateLabel("banned"))
+	cache, cl := newCache(t, withoutStateLabel, notReady, pending, approved, deactivated, banned)
+
+	// when
+	foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+	// then
+	assert.Len(t, cache.userSignupsByCreation, 1)
+	assert.Equal(t, pending.Name, foundPending.Name)
+	assert.Equal(t, pending.Spec, foundPending.Spec)
+	approve(t, cl, pending)
+
+	t.Run("won't return any since all are approved", func(t *testing.T) {
+		// when
+		foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+		// then
+		assert.Len(t, cache.userSignupsByCreation, 0)
+		assert.Nil(t, foundPending)
+	})
+
+	t.Run("will pick the newly added (reactivated) pending UserSignup", func(t *testing.T) {
+		// given
+		WithStateLabel("pending")(deactivated)
+		err := cl.Update(context.TODO(), deactivated)
+		require.NoError(t, err)
+
+		// when
+		foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+		// then
+		assert.Len(t, cache.userSignupsByCreation, 1)
+		assert.Equal(t, deactivated.Name, foundPending.Name)
+		assert.Equal(t, deactivated.Spec, foundPending.Spec)
+
+		t.Run("should keep unapproved resource", func(t *testing.T) {
+			// when
+			foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+			// then
+			assert.Len(t, cache.userSignupsByCreation, 1)
+			assert.Equal(t, deactivated.Name, foundPending.Name)
+			assert.Equal(t, deactivated.Spec, foundPending.Spec)
+		})
+	})
+}
+
+func approve(t *testing.T, cl *test.FakeClient, signup *v1alpha1.UserSignup) {
+	WithStateLabel("approved")(signup)
+	err := cl.Update(context.TODO(), signup)
+	require.NoError(t, err)
+}
+
+func TestGetOldestPendingApprovalWithMultipleUserSignups(t *testing.T) {
+	// given
+	withoutStateLabel := NewUserSignup()
+	// we need to create the UserSignups with different timestamp in the range of seconds because
+	// the k8s resource keeps the time in RFC3339 format where the smallest unit are seconds.
+	pending1 := NewUserSignup(WithStateLabel("pending"), CreatedBefore(5*time.Second))
+	pending2 := NewUserSignup(WithStateLabel("pending"), CreatedBefore(3*time.Second))
+	pending3 := NewUserSignup(WithStateLabel("pending"), CreatedBefore(2*time.Second))
+	cache, cl := newCache(t, withoutStateLabel, pending2, pending3, pending1)
+
+	// when
+	foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+	// then
+	assert.Len(t, cache.userSignupsByCreation, 3)
+	assert.Equal(t, pending1.Name, foundPending.Name)
+	assert.Equal(t, pending1.Spec, foundPending.Spec)
+	approve(t, cl, pending1)
+
+	t.Run("should keep two UserSignup since the pending4 hasn't been loaded yet", func(t *testing.T) {
+		// given
+		pending4 := NewUserSignup(WithStateLabel("pending"))
+		err := cl.Create(context.TODO(), pending4)
+		require.NoError(t, err)
+
+		// when
+		foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+		// then
+		assert.Len(t, cache.userSignupsByCreation, 2)
+		assert.Equal(t, pending2.Name, foundPending.Name)
+		assert.Equal(t, pending2.Spec, foundPending.Spec)
+		approve(t, cl, pending2)
+
+		t.Run("should keep one UserSignup since the pending4 hasn't been loaded yet and previous ones were removed", func(t *testing.T) {
+			// when
+			foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+			// then
+			assert.Len(t, cache.userSignupsByCreation, 1)
+			assert.Equal(t, pending3.Name, foundPending.Name)
+			assert.Equal(t, pending3.Spec, foundPending.Spec)
+			approve(t, cl, pending3)
+
+			t.Run("should load the pending4 resource", func(t *testing.T) {
+				// when
+				foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+				// then
+				assert.Len(t, cache.userSignupsByCreation, 1)
+				assert.Equal(t, pending4.Name, foundPending.Name)
+				assert.Equal(t, pending4.Spec, foundPending.Spec)
+			})
+		})
+	})
+}
+
+func TestGetOldestPendingApprovalWithMultipleUserSignupsInParallel(t *testing.T) {
+	// given
+	cache, cl := newCache(t)
+
+	var latch sync.WaitGroup
+	latch.Add(1)
+	var waitForFinished sync.WaitGroup
+
+	waitForFinished.Add(3000)
+	for i := 0; i < 1000; i++ {
+		go func() {
+			defer waitForFinished.Done()
+			latch.Wait()
+			pending1 := NewUserSignup(WithStateLabel("pending"))
+			pending2 := NewUserSignup(WithStateLabel("pending"))
+			allSingups := []*v1alpha1.UserSignup{
+				NewUserSignup(WithStateLabel("not-ready")),
+				NewUserSignup(WithStateLabel("deactivated")),
+				NewUserSignup(WithStateLabel("approved")),
+				pending1,
+				pending2,
+			}
+			for _, signup := range allSingups {
+				err := cl.Create(context.TODO(), signup)
+				require.NoError(t, err)
+			}
+
+			for _, pending := range []*v1alpha1.UserSignup{pending1, pending2} {
+				go func(toApprove *v1alpha1.UserSignup) {
+					defer waitForFinished.Done()
+					oldestPendingApproval := cache.getOldestPendingApproval(test.HostOperatorNs)
+					require.NotNil(t, oldestPendingApproval)
+					approve(t, cl, toApprove)
+				}(pending)
+			}
+		}()
+	}
+
+	// when
+	latch.Done()
+	waitForFinished.Wait()
+
+	// when
+	foundPending := cache.getOldestPendingApproval(test.HostOperatorNs)
+
+	// then
+	assert.Nil(t, foundPending)
+}
+
+func newCache(t *testing.T, initObjects ...runtime.Object) (*cache, *test.FakeClient) {
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+
+	fakeClient := test.NewFakeClient(t, initObjects...)
+	return &cache{
+		client: fakeClient,
+	}, fakeClient
+}

--- a/pkg/controller/usersignup/unapproved/mapper.go
+++ b/pkg/controller/usersignup/unapproved/mapper.go
@@ -1,0 +1,34 @@
+package unapproved
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// UserSignupMapper maps any object to an oldest unapproved UserSignup
+type UserSignupMapper struct {
+	unapprovedCache *cache
+}
+
+// NewUserSignupMapper creates an instance of UserSignupMapper that maps any object to an oldest unapproved UserSignup
+func NewUserSignupMapper(client client.Client) UserSignupMapper {
+	return UserSignupMapper{
+		unapprovedCache: &cache{
+			client: client,
+		},
+	}
+}
+
+var _ handler.Mapper = UserSignupMapper{}
+
+func (b UserSignupMapper) Map(obj handler.MapObject) []reconcile.Request {
+	userSignup := b.unapprovedCache.getOldestPendingApproval(obj.Meta.GetNamespace())
+	if userSignup == nil {
+		return []reconcile.Request{}
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Namespace: userSignup.Namespace, Name: userSignup.Name},
+	}}
+}

--- a/pkg/controller/usersignup/unapproved/mapper_test.go
+++ b/pkg/controller/usersignup/unapproved/mapper_test.go
@@ -1,0 +1,69 @@
+package unapproved
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/codeready-toolchain/host-operator/test"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+func TestMapperReturnsOldest(t *testing.T) {
+	// given
+	pending := NewUserSignup(WithStateLabel("pending"))
+	approved := NewUserSignup(WithStateLabel("approved"))
+	deactivated := NewUserSignup(WithStateLabel("deactivated"))
+	cl := test.NewFakeClient(t, pending, approved, deactivated)
+	mapper := NewUserSignupMapper(cl)
+
+	// when
+	requests := mapper.Map(handler.MapObject{
+		Meta: NewToolchainStatus().GetObjectMeta(),
+	})
+
+	// then
+	require.Len(t, requests, 1)
+	assert.Equal(t, requests[0].Name, pending.Name)
+	assert.Equal(t, requests[0].Namespace, test.HostOperatorNs)
+	approve(t, cl, pending)
+}
+
+func TestMapperReturnsEmptyRequestsWhenNoPendingIsFound(t *testing.T) {
+	// given
+	banned := NewUserSignup(WithStateLabel("banned"))
+	approved := NewUserSignup(WithStateLabel("approved"))
+	deactivated := NewUserSignup(WithStateLabel("deactivated"))
+	cl := test.NewFakeClient(t, banned, approved, deactivated)
+	mapper := NewUserSignupMapper(cl)
+
+	// when
+	requests := mapper.Map(handler.MapObject{
+		Meta: NewToolchainStatus().GetObjectMeta(),
+	})
+
+	// then
+	assert.Empty(t, requests)
+}
+
+func TestMapperReturnsEmptyRequestsWhenClientReturnsError(t *testing.T) {
+	// given
+	cl := test.NewFakeClient(t)
+	cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		return fmt.Errorf("some error")
+	}
+	mapper := NewUserSignupMapper(cl)
+
+	// when
+	requests := mapper.Map(handler.MapObject{
+		Meta: NewToolchainStatus().GetObjectMeta(),
+	})
+
+	// then
+	assert.Empty(t, requests)
+}

--- a/test/usersignup.go
+++ b/test/usersignup.go
@@ -3,6 +3,7 @@ package test
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"time"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
@@ -42,11 +43,23 @@ func WithUsername(username string) UserSignupModifier {
 	}
 }
 
+func WithStateLabel(stateValue string) UserSignupModifier {
+	return func(userSignup *v1alpha1.UserSignup) {
+		userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = stateValue
+	}
+}
+
+func CreatedBefore(before time.Duration) UserSignupModifier {
+	return func(userSignup *v1alpha1.UserSignup) {
+		userSignup.ObjectMeta.CreationTimestamp = metav1.Time{Time: time.Now().Add(-before)}
+	}
+}
+
 type UserSignupModifier func(*v1alpha1.UserSignup)
 
 func NewUserSignup(modifiers ...UserSignupModifier) *v1alpha1.UserSignup {
 	signup := &v1alpha1.UserSignup{
-		ObjectMeta: NewUserSignupObjectMeta("foo", "foo@redhat.com"),
+		ObjectMeta: NewUserSignupObjectMeta("", "foo@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
 			Username: "foo@redhat.com",
 		},
@@ -75,7 +88,7 @@ func NewUserSignupObjectMeta(name, email string) metav1.ObjectMeta {
 		},
 		Labels: map[string]string{
 			toolchainv1alpha1.UserSignupUserEmailHashLabelKey: emailHash,
-			"toolchain.dev.openshift.com/approved":            "false",
 		},
+		CreationTimestamp: metav1.Now(),
 	}
 }


### PR DESCRIPTION
This PR adds some kind of waiting list for unapproved UserSignups. The waiting list is just an abstraction - it represents all UserSignups with the label `state=pending`.
On this waiting list are user signups that:
* are not approved manually 
* cannot be approved automatically because either automatic approval is disabled or there is no member cluster with available capacity
* are approved manually but there is no member cluster with available capacity

How this "waiting list abstraction" works?
We have a new watcher that:
* watches `ToolchainStatus` CRD - this means that the watcher will be triggered every 5s
* has a predicate to trigger a reconcile loop only when the automatic approval is enabled
* maps the ToolchainStatus update event to the oldest unapproved UserSignup

So as you can see the main point is in the mapper logic when we trigger a reconcile loop for the oldest unapproved UserSignup. To optimize the mapper logic (so it doesn't list all unapproved UserSignups every time) we use a cache. When the cache is clear, then the logic lists all `UserSignups` with the label `state=pending`, sorts them by the creation time, and stores UserSignup names in a slice. Then the logic picks the first item from the slice for every run. An item can be removed from the slice only when the UserSignup is either approved or deleted.

paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/182