### PR TITLE
Gather and expose custom metrics

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -149,7 +149,6 @@ func main() {
 	addMetrics(ctx, cfg)
 
 	metrics.RegisterCustomMetrics()
-	defer metrics.UnregisterCustomMetrics()
 
 	stopChannel := signals.SetupSignalHandler()
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-sdk v0.19.2
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.5.1
 	github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cast v1.3.1

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -10,6 +10,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/toolchain-common/pkg/predicate"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -164,6 +165,8 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 		logger.Error(err, "failed to update usersignup")
 		return reconcile.Result{}, err
 	}
+
+	metrics.UserSignupAutoDeactivatedTotal.Increment()
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -158,6 +158,10 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	// Deactivate the user
+	if usersignup.Spec.Deactivated == true {
+		// The UserSignup is already set for deactivation, nothing left to do
+		return reconcile.Result{}, nil
+	}
 	usersignup.Spec.Deactivated = true
 
 	logger.Info("deactivating the user")

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -11,6 +11,8 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
+	"github.com/codeready-toolchain/host-operator/pkg/metrics"
+	. "github.com/codeready-toolchain/host-operator/test"
 	tiertest "github.com/codeready-toolchain/host-operator/test/nstemplatetier"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
@@ -147,6 +149,7 @@ func TestReconcile(t *testing.T) {
 			require.False(t, res.Requeue, "requeue should not be set")
 			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
 			assertThatUserSignupDeactivated(t, cl, username, true)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupAutoDeactivatedTotal)
 		})
 
 		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'other' tier
@@ -162,6 +165,7 @@ func TestReconcile(t *testing.T) {
 			require.False(t, res.Requeue, "requeue should not be set")
 			require.True(t, res.RequeueAfter == 0, "requeue should not be set")
 			assertThatUserSignupDeactivated(t, cl, username, true)
+			AssertMetricsCounterEquals(t, 2, metrics.UserSignupAutoDeactivatedTotal)
 		})
 
 	})

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -139,7 +139,6 @@ func TestReconcile(t *testing.T) {
 		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'basic' tier
 		t.Run("usersignup should be deactivated - basic tier (30 days)", func(t *testing.T) {
 			// given
-			defer metrics.Reset()
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutBasicTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
 			r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupFoobar)
@@ -156,7 +155,6 @@ func TestReconcile(t *testing.T) {
 		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'other' tier
 		t.Run("usersignup should be deactivated - other tier (60 days)", func(t *testing.T) {
 			// given
-			defer metrics.Reset()
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutOtherTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *otherTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
 			r, req, cl := prepareReconcile(t, mur.Name, otherTier, mur, userSignupFoobar)
@@ -242,6 +240,7 @@ func TestReconcile(t *testing.T) {
 }
 
 func prepareReconcile(t *testing.T, name string, initObjs ...runtime.Object) (reconcile.Reconciler, reconcile.Request, *test.FakeClient) {
+	metrics.ResetCounters()
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -150,6 +150,15 @@ func TestReconcile(t *testing.T) {
 			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
 			assertThatUserSignupDeactivated(t, cl, username, true)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupAutoDeactivatedTotal)
+
+			t.Run("usersignup already deactivated", func(t *testing.T) {
+				// additional reconciles should find the usersignup is already deactivated
+				res, err := r.Reconcile(req)
+				// then
+				require.NoError(t, err)
+				require.False(t, res.Requeue, "requeue should not be set")
+				require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
+			})
 		})
 
 		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'other' tier

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -139,6 +139,7 @@ func TestReconcile(t *testing.T) {
 		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'basic' tier
 		t.Run("usersignup should be deactivated - basic tier (30 days)", func(t *testing.T) {
 			// given
+			defer metrics.Reset()
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutBasicTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
 			r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupFoobar)
@@ -155,6 +156,7 @@ func TestReconcile(t *testing.T) {
 		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'other' tier
 		t.Run("usersignup should be deactivated - other tier (60 days)", func(t *testing.T) {
 			// given
+			defer metrics.Reset()
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutOtherTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *otherTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
 			r, req, cl := prepareReconcile(t, mur.Name, otherTier, mur, userSignupFoobar)
@@ -165,7 +167,7 @@ func TestReconcile(t *testing.T) {
 			require.False(t, res.Requeue, "requeue should not be set")
 			require.True(t, res.RequeueAfter == 0, "requeue should not be set")
 			assertThatUserSignupDeactivated(t, cl, username, true)
-			AssertMetricsCounterEquals(t, 2, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupAutoDeactivatedTotal)
 		})
 
 	})

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -386,12 +386,12 @@ func (r *ReconcileUserSignup) ensureNewMurIfApproved(reqLogger logr.Logger, user
 func (r *ReconcileUserSignup) setStateLabel(reqLogger logr.Logger, userSignup *toolchainv1alpha1.UserSignup, value string) error {
 	oldValue := userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey]
 	if oldValue != value {
-		updateMetricsByState(oldValue, value)
 		userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] = value
 		if err := r.client.Update(context.TODO(), userSignup); err != nil {
 			return r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusFailedToUpdateStateLabel, err,
 				"unable to update state label at UserSignup resource")
 		}
+		updateMetricsByState(oldValue, value)
 		return nil
 	}
 	return nil

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
-	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	crtCfg "github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/host-operator/pkg/counter"
+	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/host-operator/pkg/templates/notificationtemplates"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
@@ -44,7 +44,7 @@ const defaultTierName = "basic"
 
 // Add creates a new UserSignup Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, crtConfig *configuration.Config) error {
+func Add(mgr manager.Manager, crtConfig *crtCfg.Config) error {
 	return add(mgr, newReconciler(mgr, crtConfig))
 }
 
@@ -358,7 +358,9 @@ func (r *ReconcileUserSignup) ensureNewMurIfApproved(reqLogger logr.Logger, user
 }
 
 func (r *ReconcileUserSignup) setStateLabel(reqLogger logr.Logger, userSignup *toolchainv1alpha1.UserSignup, value string) error {
-	if userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] != value {
+	oldValue := userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey]
+	if oldValue != value {
+		updateMetricsByState(oldValue, value)
 		userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] = value
 		if err := r.client.Update(context.TODO(), userSignup); err != nil {
 			return r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusFailedToUpdateStateLabel, err,
@@ -367,6 +369,13 @@ func (r *ReconcileUserSignup) setStateLabel(reqLogger logr.Logger, userSignup *t
 		return nil
 	}
 	return nil
+}
+
+func updateMetricsByState(oldState, newState string) {
+	metrics.UserSignupUniqueTotal.ConditionalIncrement(oldState == "")
+	metrics.UserSignupProvisionedTotal.ConditionalIncrement(newState == toolchainv1alpha1.UserSignupStateLabelValueApproved)
+	metrics.UserSignupDeactivatedTotal.ConditionalIncrement(newState == toolchainv1alpha1.UserSignupStateLabelValueDeactivated)
+	metrics.UserSignupBannedTotal.ConditionalIncrement(newState == toolchainv1alpha1.UserSignupStateLabelValueBanned)
 }
 
 func getNsTemplateTier(cl client.Client, tierName, namespace string) (*toolchainv1alpha1.NSTemplateTier, error) {
@@ -462,6 +471,7 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 			"Error creating MasterUserRecord")
 	}
 	counter.IncrementMasterUserRecordCount()
+
 	logger.Info("Created MasterUserRecord", "Name", mur.Name, "TargetCluster", targetCluster)
 	return nil
 }

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -59,9 +59,9 @@ var basicNSTemplateTier = newNsTemplateTier("basic", "code", "dev", "stage")
 
 func TestUserSignupCreateMUROk(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
-	defer metrics.Reset()
 	userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
 	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "not-ready"
 	r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
@@ -98,11 +98,14 @@ func TestUserSignupCreateMUROk(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal) // zero because we started with a not-ready state instead of empty as per usual
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
 	AssertThatCounterHas(t, 2)
 }
 
 func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -121,6 +124,11 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	murs := &v1alpha1.MasterUserRecordList{}
 	err = r.client.List(context.TODO(), murs)
@@ -196,10 +204,16 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 			})
 	})
 	AssertThatCounterHas(t, 2)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 }
 
 func TestUserSignupWithMissingEmailLabelFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -218,6 +232,8 @@ func TestUserSignupWithMissingEmailLabelFails(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "not-ready", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		v1alpha1.Condition{
 			Type:    v1alpha1.UserSignupComplete,
@@ -230,6 +246,7 @@ func TestUserSignupWithMissingEmailLabelFails(t *testing.T) {
 
 func TestUserSignupWithInvalidEmailHashLabelFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -254,6 +271,8 @@ func TestUserSignupWithInvalidEmailHashLabelFails(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "not-ready", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		v1alpha1.Condition{
 			Type:    v1alpha1.UserSignupComplete,
@@ -266,6 +285,7 @@ func TestUserSignupWithInvalidEmailHashLabelFails(t *testing.T) {
 
 func TestUpdateOfApprovedLabelFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -293,10 +313,13 @@ func TestUpdateOfApprovedLabelFails(t *testing.T) {
 			Message: "some error",
 		})
 	AssertThatCounterHas(t, 1)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 }
 
 func TestUserSignupWithMissingEmailHashLabelFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -318,6 +341,8 @@ func TestUserSignupWithMissingEmailHashLabelFails(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "not-ready", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		v1alpha1.Condition{
 			Type:    v1alpha1.UserSignupComplete,
@@ -330,6 +355,7 @@ func TestUserSignupWithMissingEmailHashLabelFails(t *testing.T) {
 
 func TestUserSignupFailedMissingNSTemplateTier(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -363,11 +389,14 @@ func TestUserSignupFailedMissingNSTemplateTier(t *testing.T) {
 			Reason: "UserIsActive",
 		})
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 	AssertThatCounterHas(t, 1)
 }
 
 func TestUnapprovedUserSignupWhenNoClusterReady(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 2)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -406,12 +435,15 @@ func TestUnapprovedUserSignupWhenNoClusterReady(t *testing.T) {
 		})
 
 	assert.Equal(t, "pending", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	AssertThatCounterHas(t, 2)
 }
 
 func TestUserSignupFailedNoClusterWithCapacityAvailable(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -449,12 +481,15 @@ func TestUserSignupFailedNoClusterWithCapacityAvailable(t *testing.T) {
 		})
 
 	assert.Equal(t, "pending", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	AssertThatCounterHas(t, 1)
 }
 
 func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -473,6 +508,8 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	murs := &v1alpha1.MasterUserRecordList{}
 	err = r.client.List(context.TODO(), murs)
@@ -511,6 +548,8 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, userSignup.Status.CompliantUsername, mur.Name)
 		assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			v1alpha1.Condition{
 				Type:   v1alpha1.UserSignupApproved,
@@ -532,6 +571,7 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 
 func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -550,6 +590,8 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	murs := &v1alpha1.MasterUserRecordList{}
 	err = r.client.List(context.TODO(), murs)
@@ -589,6 +631,8 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 		require.Equal(t, userSignup.Status.CompliantUsername, mur.Name)
 
 		assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			v1alpha1.Condition{
@@ -611,6 +655,7 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 
 func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -629,6 +674,8 @@ func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "pending", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	// There should be no MasterUserRecords
 	murs := &v1alpha1.MasterUserRecordList{}
@@ -657,6 +704,7 @@ func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 
 func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(WithTargetCluster("east"))
@@ -675,6 +723,8 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	murs := &v1alpha1.MasterUserRecordList{}
 	err = r.client.List(context.TODO(), murs)
@@ -715,6 +765,8 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 		require.Equal(t, userSignup.Status.CompliantUsername, mur.Name)
 
 		assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			v1alpha1.Condition{
@@ -737,6 +789,7 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 
 func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(WithTargetCluster("east"))
@@ -754,6 +807,8 @@ func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "pending", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		v1alpha1.Condition{
@@ -776,6 +831,7 @@ func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 
 func TestUserSignupMURCreateFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -803,11 +859,14 @@ func TestUserSignupMURCreateFails(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 }
 
 func TestUserSignupMURReadFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -834,11 +893,14 @@ func TestUserSignupMURReadFails(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 }
 
 func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -867,11 +929,14 @@ func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal) // zero since starting state was approved
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)      // zero since starting state was approved
 	assert.Empty(t, userSignup.Status.Conditions)
 }
 
 func TestUserSignupSetStatusApprovedAutomaticallyFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -899,12 +964,15 @@ func TestUserSignupSetStatusApprovedAutomaticallyFails(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "not-ready", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 	assert.Empty(t, userSignup.Status.Conditions)
 
 }
 
 func TestUserSignupSetStatusNoClustersAvailableFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -936,11 +1004,14 @@ func TestUserSignupSetStatusNoClustersAvailableFails(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "pending", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 }
 
 func TestUserSignupWithExistingMUROK(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -978,6 +1049,8 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 	err = r.client.Get(context.TODO(), key, instance)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", instance.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	require.Equal(t, mur.Name, instance.Status.CompliantUsername)
 	test.AssertContainsCondition(t, instance.Status.Conditions, v1alpha1.Condition{
@@ -989,6 +1062,7 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 
 func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -1029,6 +1103,8 @@ func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 	err = r.client.Get(context.TODO(), key, instance)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", instance.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	t.Run("second reconcile", func(t *testing.T) {
 		// when
@@ -1040,6 +1116,8 @@ func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 		err = r.client.Get(context.TODO(), key, instance)
 		require.NoError(t, err)
 		assert.Equal(t, "approved", instance.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 		require.Equal(t, "foo-2", instance.Status.CompliantUsername)
 
@@ -1065,6 +1143,7 @@ func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 
 func TestUserSignupWithSpecialCharOK(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(WithUsername("foo#$%^bar@redhat.com"))
@@ -1080,6 +1159,8 @@ func TestUserSignupWithSpecialCharOK(t *testing.T) {
 
 	murtest.AssertThatMasterUserRecord(t, "foo-bar", r.client).HasNoConditions()
 	AssertThatCounterHas(t, 2)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 }
 
 func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
@@ -1105,6 +1186,7 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 
 	t.Run("when MUR exists, then it should be deleted", func(t *testing.T) {
 		// given
+		metrics.Reset()
 		InitializeCounter(t, 1)
 		defer counter.Reset()
 		mur := murtest.NewMasterUserRecord(t, "john-doe", murtest.MetaNamespace(test.HostOperatorNs))
@@ -1120,6 +1202,9 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 		err = r.client.Get(context.TODO(), key, userSignup)
 		require.NoError(t, err)
 		assert.Equal(t, "deactivated", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal) // 0 because usersignup was originally deactivated
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)      // 1 because state was initially empty
 
 		// Confirm the status is now set to Deactivating
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
@@ -1148,6 +1233,7 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 
 	t.Run("when MUR doesn't exist, then the condition should be set to Deactivated", func(t *testing.T) {
 		// given
+		metrics.Reset()
 		InitializeCounter(t, 2)
 		defer counter.Reset()
 		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), basicNSTemplateTier)
@@ -1162,6 +1248,9 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 		err = r.client.Get(context.TODO(), key, userSignup)
 		require.NoError(t, err)
 		assert.Equal(t, "deactivated", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal) // zero because state didn't change
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 
 		// Confirm the status has been set to Deactivated
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
@@ -1216,11 +1305,13 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 			CompliantUsername: "john-doe",
 		},
 	}
+	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "deactivated"
 	userSignup.Labels["toolchain.dev.openshift.com/approved"] = "true"
 	key := test.NamespacedName(test.HostOperatorNs, userSignup.Name)
 
 	t.Run("when the deactivation notification cannot be created", func(t *testing.T) {
 		// given
+		metrics.Reset()
 		InitializeCounter(t, 2)
 		defer counter.Reset()
 		r, req, cl := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), basicNSTemplateTier)
@@ -1263,6 +1354,10 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 				Message: "unable to create deactivation notification",
 			})
 		AssertThatCounterHas(t, 2)
+		assert.Equal(t, "deactivated", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal) // zero because state didn't change
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 
 		// A deactivated notification should not have been created
 		notification := &v1alpha1.Notification{}
@@ -1284,12 +1379,13 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 			CompliantUsername: "john-doe",
 		},
 	}
-	userSignup.Labels["toolchain.dev.openshift.com/approved"] = "true"
 	key := test.NamespacedName(test.HostOperatorNs, userSignup.Name)
 
 	t.Run("when reactivating the usersignup successfully", func(t *testing.T) {
 		// given
 		// start with a usersignup that has the Notification Created status set to "true" but Spec.Deactivated is set to "false" which signals a user which has been just reactivated.
+		userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "deactivated"
+		userSignup.Labels["toolchain.dev.openshift.com/approved"] = "true"
 		userSignup.Status.Conditions = []v1alpha1.Condition{
 			{
 				Type:   v1alpha1.UserSignupComplete,
@@ -1307,6 +1403,7 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 				Reason: "NotificationCRCreated",
 			},
 		}
+		metrics.Reset()
 		InitializeCounter(t, 2)
 		defer counter.Reset()
 		ready := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
@@ -1343,6 +1440,11 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 		// A mur should be created so the counter should be 3
 		AssertThatCounterHas(t, 3)
 
+		assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+
 		// There should not be a notification created because the user was reactivated
 		ntest.AssertNoNotificationsExist(t, r.client)
 	})
@@ -1350,6 +1452,8 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 	t.Run("when resetting the usersignup deactivation notification status fails", func(t *testing.T) {
 		// given
 		// start with a usersignup that has the Notification Created status set to "true" but Spec.Deactivated is set to "false" which signals a user which has been just reactivated.
+		userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "deactivated"
+		userSignup.Labels["toolchain.dev.openshift.com/approved"] = "true"
 		userSignup.Status.Conditions = []v1alpha1.Condition{
 			{
 				Type:   v1alpha1.UserSignupComplete,
@@ -1367,6 +1471,7 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 				Reason: "NotificationCRCreated",
 			},
 		}
+		metrics.Reset()
 		InitializeCounter(t, 2)
 		defer counter.Reset()
 		r, req, cl := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), basicNSTemplateTier)
@@ -1410,6 +1515,12 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 			})
 		AssertThatCounterHas(t, 2)
 
+		// State is still deactivated because the status update failed
+		assert.Equal(t, "deactivated", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+
 		// A deactivation notification should not be created because this is the reactivation case
 		ntest.AssertNoNotificationsExist(t, r.client)
 	})
@@ -1439,10 +1550,12 @@ func TestUserSignupDeactivatingWhenMURExists(t *testing.T) {
 		},
 	}
 	userSignup.Labels["toolchain.dev.openshift.com/approved"] = "true"
+	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "approved"
 	key := test.NamespacedName(test.HostOperatorNs, userSignup.Name)
 
 	t.Run("when MUR exists, then it should be deleted", func(t *testing.T) {
 		// given
+		metrics.Reset()
 		InitializeCounter(t, 1)
 		defer counter.Reset()
 		mur := murtest.NewMasterUserRecord(t, "edward-jones", murtest.MetaNamespace(test.HostOperatorNs))
@@ -1462,6 +1575,9 @@ func TestUserSignupDeactivatingWhenMURExists(t *testing.T) {
 			err = r.client.Get(context.TODO(), key, userSignup)
 			require.NoError(t, err)
 			assert.Equal(t, "deactivated", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 
 			// Confirm the status is still set to Deactivating
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
@@ -1514,15 +1630,21 @@ func TestUserSignupDeactivatingWhenMURExists(t *testing.T) {
 					Status: v1.ConditionTrue,
 					Reason: "NotificationCRCreated",
 				})
+			// metrics should be the same after the 2nd reconcile
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 		})
 	})
 }
 
 func TestUserSignupBanned(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
+	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "approved"
 
 	bannedUser := &v1alpha1.BannedUser{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1546,6 +1668,10 @@ func TestUserSignupBanned(t *testing.T) {
 	err = r.client.Get(context.TODO(), test.NamespacedName(test.HostOperatorNs, userSignup.Name), userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "banned", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupBannedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 
 	// Confirm the status is set to Banned
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
@@ -1567,6 +1693,7 @@ func TestUserSignupBanned(t *testing.T) {
 
 func TestUserSignupVerificationRequired(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(VerificationRequired())
@@ -1581,6 +1708,10 @@ func TestUserSignupVerificationRequired(t *testing.T) {
 	err = r.client.Get(context.TODO(), test.NamespacedName(test.HostOperatorNs, userSignup.Name), userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "not-ready", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	// Confirm the status is set to VerificationRequired
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
@@ -1605,6 +1736,7 @@ func TestUserSignupVerificationRequired(t *testing.T) {
 
 func TestUserSignupBannedMURExists(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -1622,6 +1754,7 @@ func TestUserSignupBannedMURExists(t *testing.T) {
 		},
 		CompliantUsername: "foo",
 	}
+	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "approved"
 	userSignup.Labels["toolchain.dev.openshift.com/approved"] = "true"
 
 	bannedUser := &v1alpha1.BannedUser{
@@ -1649,6 +1782,10 @@ func TestUserSignupBannedMURExists(t *testing.T) {
 	err = r.client.Get(context.TODO(), key, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "banned", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupBannedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 
 	// Confirm the status is set to Banning
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
@@ -1680,6 +1817,11 @@ func TestUserSignupBannedMURExists(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "banned", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		// metrics should be the same after the 2nd reconcile
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupBannedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 
 		// Confirm the status is now set to Banned
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
@@ -1704,6 +1846,7 @@ func TestUserSignupBannedMURExists(t *testing.T) {
 
 func TestUserSignupListBannedUsersFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -1724,6 +1867,7 @@ func TestUserSignupListBannedUsersFails(t *testing.T) {
 
 func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := &v1alpha1.UserSignup{
@@ -1747,6 +1891,7 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 			CompliantUsername: "alice-mayweather",
 		},
 	}
+	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "approved"
 	userSignup.Labels["toolchain.dev.openshift.com/approved"] = "true"
 
 	key := test.NamespacedName(test.HostOperatorNs, userSignup.Name)
@@ -1776,6 +1921,9 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 		err = r.client.Get(context.TODO(), key, userSignup)
 		require.NoError(t, err)
 		assert.Equal(t, "deactivated", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+		AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
 
 		// Confirm the status is set to UnableToDeleteMUR
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
@@ -1791,17 +1939,23 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 				Message: "unable to delete mur",
 			})
 		AssertThatCounterHas(t, 1)
-	})
 
-	t.Run("second reconcile - there should not be a notification created since the mur deletion failed even if reconciled again", func(t *testing.T) {
-		_, err := r.Reconcile(req)
-		require.Error(t, err)
-		ntest.AssertNoNotificationsExist(t, r.client)
+		t.Run("second reconcile - there should not be a notification created since the mur deletion failed even if reconciled again", func(t *testing.T) {
+			_, err := r.Reconcile(req)
+			require.Error(t, err)
+			ntest.AssertNoNotificationsExist(t, r.client)
+			// the metrics should be the same, deactivation should only be counted once
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+		})
 	})
 }
 
+// TestDeathBy100Signups tests the logic of generateCompliantUsername() which allows no more than 100 attempts to find a vacant name
 func TestDeathBy100Signups(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 100)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -1810,6 +1964,7 @@ func TestDeathBy100Signups(t *testing.T) {
 	args = append(args, userSignup)
 	args = append(args, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()))
 
+	// create 100 MURs that follow the naming pattern used by generateCompliantUsername()
 	args = append(args, &v1alpha1.MasterUserRecord{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -1845,6 +2000,9 @@ func TestDeathBy100Signups(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "approved", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		v1alpha1.Condition{
@@ -1869,6 +2027,7 @@ func TestDeathBy100Signups(t *testing.T) {
 
 func TestUserSignupWithMultipleExistingMURNotOK(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -1922,10 +2081,14 @@ func TestUserSignupWithMultipleExistingMURNotOK(t *testing.T) {
 		},
 	)
 	AssertThatCounterHas(t, 1)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
 }
 
 func TestManuallyApprovedUserSignupWhenNoMembersAvailable(t *testing.T) {
 	// given
+	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -1942,6 +2105,10 @@ func TestManuallyApprovedUserSignupWhenNoMembersAvailable(t *testing.T) {
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
 	require.NoError(t, err)
 	assert.Equal(t, "pending", userSignup.Labels[v1alpha1.UserSignupStateLabelKey])
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
+
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		v1alpha1.Condition{
 			Type:   v1alpha1.UserSignupApproved,
@@ -1959,6 +2126,7 @@ func TestManuallyApprovedUserSignupWhenNoMembersAvailable(t *testing.T) {
 			Status: v1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
+
 }
 
 func prepareReconcile(t *testing.T, name string, getMemberClusters cluster.GetMemberClustersFunc, initObjs ...runtime.Object) (*ReconcileUserSignup, reconcile.Request, *test.FakeClient) {

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -59,7 +59,6 @@ var basicNSTemplateTier = newNsTemplateTier("basic", "code", "dev", "stage")
 
 func TestUserSignupCreateMUROk(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
@@ -105,7 +104,6 @@ func TestUserSignupCreateMUROk(t *testing.T) {
 
 func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -213,7 +211,6 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 
 func TestUserSignupWithMissingEmailLabelFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -246,7 +243,6 @@ func TestUserSignupWithMissingEmailLabelFails(t *testing.T) {
 
 func TestUserSignupWithInvalidEmailHashLabelFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -285,7 +281,6 @@ func TestUserSignupWithInvalidEmailHashLabelFails(t *testing.T) {
 
 func TestUpdateOfApprovedLabelFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -319,7 +314,6 @@ func TestUpdateOfApprovedLabelFails(t *testing.T) {
 
 func TestUserSignupWithMissingEmailHashLabelFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -355,7 +349,6 @@ func TestUserSignupWithMissingEmailHashLabelFails(t *testing.T) {
 
 func TestUserSignupFailedMissingNSTemplateTier(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -396,7 +389,6 @@ func TestUserSignupFailedMissingNSTemplateTier(t *testing.T) {
 
 func TestUnapprovedUserSignupWhenNoClusterReady(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 2)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -443,7 +435,6 @@ func TestUnapprovedUserSignupWhenNoClusterReady(t *testing.T) {
 
 func TestUserSignupFailedNoClusterWithCapacityAvailable(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -489,7 +480,6 @@ func TestUserSignupFailedNoClusterWithCapacityAvailable(t *testing.T) {
 
 func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -571,7 +561,6 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 
 func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -655,7 +644,6 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 
 func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -704,7 +692,6 @@ func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 
 func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(WithTargetCluster("east"))
@@ -789,7 +776,6 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 
 func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(WithTargetCluster("east"))
@@ -831,7 +817,6 @@ func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 
 func TestUserSignupMURCreateFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -866,7 +851,6 @@ func TestUserSignupMURCreateFails(t *testing.T) {
 
 func TestUserSignupMURReadFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -900,7 +884,6 @@ func TestUserSignupMURReadFails(t *testing.T) {
 
 func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -936,7 +919,6 @@ func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
 
 func TestUserSignupSetStatusApprovedAutomaticallyFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -972,7 +954,6 @@ func TestUserSignupSetStatusApprovedAutomaticallyFails(t *testing.T) {
 
 func TestUserSignupSetStatusNoClustersAvailableFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -1011,7 +992,6 @@ func TestUserSignupSetStatusNoClustersAvailableFails(t *testing.T) {
 
 func TestUserSignupWithExistingMUROK(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -1062,7 +1042,6 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 
 func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -1143,7 +1122,6 @@ func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 
 func TestUserSignupWithSpecialCharOK(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(WithUsername("foo#$%^bar@redhat.com"))
@@ -1186,7 +1164,6 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 
 	t.Run("when MUR exists, then it should be deleted", func(t *testing.T) {
 		// given
-		metrics.Reset()
 		InitializeCounter(t, 1)
 		defer counter.Reset()
 		mur := murtest.NewMasterUserRecord(t, "john-doe", murtest.MetaNamespace(test.HostOperatorNs))
@@ -1233,7 +1210,6 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 
 	t.Run("when MUR doesn't exist, then the condition should be set to Deactivated", func(t *testing.T) {
 		// given
-		metrics.Reset()
 		InitializeCounter(t, 2)
 		defer counter.Reset()
 		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), basicNSTemplateTier)
@@ -1311,7 +1287,6 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 
 	t.Run("when the deactivation notification cannot be created", func(t *testing.T) {
 		// given
-		metrics.Reset()
 		InitializeCounter(t, 2)
 		defer counter.Reset()
 		r, req, cl := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), basicNSTemplateTier)
@@ -1403,7 +1378,6 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 				Reason: "NotificationCRCreated",
 			},
 		}
-		metrics.Reset()
 		InitializeCounter(t, 2)
 		defer counter.Reset()
 		ready := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
@@ -1471,7 +1445,6 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 				Reason: "NotificationCRCreated",
 			},
 		}
-		metrics.Reset()
 		InitializeCounter(t, 2)
 		defer counter.Reset()
 		r, req, cl := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), basicNSTemplateTier)
@@ -1555,7 +1528,6 @@ func TestUserSignupDeactivatingWhenMURExists(t *testing.T) {
 
 	t.Run("when MUR exists, then it should be deleted", func(t *testing.T) {
 		// given
-		metrics.Reset()
 		InitializeCounter(t, 1)
 		defer counter.Reset()
 		mur := murtest.NewMasterUserRecord(t, "edward-jones", murtest.MetaNamespace(test.HostOperatorNs))
@@ -1640,7 +1612,6 @@ func TestUserSignupDeactivatingWhenMURExists(t *testing.T) {
 
 func TestUserSignupBanned(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -1693,7 +1664,6 @@ func TestUserSignupBanned(t *testing.T) {
 
 func TestUserSignupVerificationRequired(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(VerificationRequired())
@@ -1736,7 +1706,6 @@ func TestUserSignupVerificationRequired(t *testing.T) {
 
 func TestUserSignupBannedMURExists(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -1846,7 +1815,6 @@ func TestUserSignupBannedMURExists(t *testing.T) {
 
 func TestUserSignupListBannedUsersFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -1867,7 +1835,6 @@ func TestUserSignupListBannedUsersFails(t *testing.T) {
 
 func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := &v1alpha1.UserSignup{
@@ -1955,7 +1922,6 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 // TestDeathBy100Signups tests the logic of generateCompliantUsername() which allows no more than 100 attempts to find a vacant name
 func TestDeathBy100Signups(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 100)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -2027,7 +1993,6 @@ func TestDeathBy100Signups(t *testing.T) {
 
 func TestUserSignupWithMultipleExistingMURNotOK(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup()
@@ -2088,7 +2053,6 @@ func TestUserSignupWithMultipleExistingMURNotOK(t *testing.T) {
 
 func TestManuallyApprovedUserSignupWhenNoMembersAvailable(t *testing.T) {
 	// given
-	metrics.Reset()
 	InitializeCounter(t, 1)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved())
@@ -2130,6 +2094,8 @@ func TestManuallyApprovedUserSignupWhenNoMembersAvailable(t *testing.T) {
 }
 
 func prepareReconcile(t *testing.T, name string, getMemberClusters cluster.GetMemberClustersFunc, initObjs ...runtime.Object) (*ReconcileUserSignup, reconcile.Request, *test.FakeClient) {
+	metrics.ResetCounters()
+
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
@@ -2349,7 +2315,7 @@ func TestMigrateMur(t *testing.T) {
 func TestUpdateMetricsByState(t *testing.T) {
 	t.Run("common state changes", func(t *testing.T) {
 		t.Run("empty -> not-ready - increment UserSignupUniqueTotal", func(t *testing.T) {
-			metrics.Reset()
+			metrics.ResetCounters()
 			updateMetricsByState("", "not-ready")
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -2359,7 +2325,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 		})
 
 		t.Run("not-ready -> pending - no change", func(t *testing.T) {
-			metrics.Reset()
+			metrics.ResetCounters()
 			updateMetricsByState("not-ready", "pending")
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -2369,7 +2335,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 		})
 
 		t.Run("pending -> approved - increment UserSignupProvisionedTotal", func(t *testing.T) {
-			metrics.Reset()
+			metrics.ResetCounters()
 			updateMetricsByState("pending", "approved")
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -2379,7 +2345,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 		})
 
 		t.Run("approved -> deactivated - increment UserSignupDeactivatedTotal", func(t *testing.T) {
-			metrics.Reset()
+			metrics.ResetCounters()
 			updateMetricsByState("approved", "deactivated")
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -2389,7 +2355,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 		})
 
 		t.Run("deactivated -> banned - increment UserSignupBannedTotal", func(t *testing.T) {
-			metrics.Reset()
+			metrics.ResetCounters()
 			updateMetricsByState("deactivated", "banned")
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupBannedTotal)
@@ -2401,7 +2367,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 
 	t.Run("uncommon state changes", func(t *testing.T) {
 		t.Run("old value is not empty", func(t *testing.T) {
-			metrics.Reset()
+			metrics.ResetCounters()
 			updateMetricsByState("any-value", "")
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -2411,7 +2377,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 		})
 
 		t.Run("new value is not-ready - no change", func(t *testing.T) {
-			metrics.Reset()
+			metrics.ResetCounters()
 			updateMetricsByState("any-value", "not-ready")
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -2421,7 +2387,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 		})
 
 		t.Run("new value is not a valid state - no change", func(t *testing.T) {
-			metrics.Reset()
+			metrics.ResetCounters()
 			updateMetricsByState("any-value", "x")
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -2164,62 +2164,81 @@ func TestMigrateMur(t *testing.T) {
 }
 
 func TestUpdateMetricsByState(t *testing.T) {
-	metrics.Reset()
-	t.Run("old value is not ready", func(t *testing.T) {
-		updateMetricsByState("not-ready", "")
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+	t.Run("common scenarios", func(t *testing.T) {
+		metrics.Reset()
+		t.Run("empty -> not-ready - increment UserSignupUniqueTotal", func(t *testing.T) {
+			updateMetricsByState("", "not-ready")
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
+		})
+
+		t.Run("not-ready -> pending - no change", func(t *testing.T) {
+			updateMetricsByState("not-ready", "pending")
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
+		})
+
+		t.Run("pending -> approved - increment UserSignupProvisionedTotal", func(t *testing.T) {
+			updateMetricsByState("pending", "approved")
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
+		})
+
+		t.Run("approved -> deactivated - increment UserSignupDeactivatedTotal", func(t *testing.T) {
+			updateMetricsByState("approved", "deactivated")
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
+		})
+
+		t.Run("deactivated -> banned - increment UserSignupBannedTotal", func(t *testing.T) {
+			updateMetricsByState("deactivated", "banned")
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
+		})
 	})
 
-	t.Run("old value is empty - increment UserSignupUniqueTotal", func(t *testing.T) {
-		updateMetricsByState("", "")
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	})
+	t.Run("generic scenarios", func(t *testing.T) {
+		metrics.Reset()
+		t.Run("old value is not empty", func(t *testing.T) {
+			updateMetricsByState("any-value", "")
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+		})
 
-	t.Run("new value is pending - no change", func(t *testing.T) {
-		updateMetricsByState("any-value", "pending")
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	})
+		t.Run("new value is not-ready - no change", func(t *testing.T) {
+			updateMetricsByState("any-value", "not-ready")
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+		})
 
-	t.Run("new value is approved - increment UserSignupProvisionedTotal", func(t *testing.T) {
-		updateMetricsByState("any-value", "approved")
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	})
-
-	t.Run("new value is deactivated - increment UserSignupDeactivatedTotal", func(t *testing.T) {
-		updateMetricsByState("any-value", "deactivated")
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	})
-
-	t.Run("new value is banned - increment UserSignupBannedTotal", func(t *testing.T) {
-		updateMetricsByState("any-value", "banned")
-		AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupBannedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupDeactivatedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupProvisionedTotal)
-		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
+		t.Run("new value is not a valid state - no change", func(t *testing.T) {
+			updateMetricsByState("any-value", "x")
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupProvisionedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+		})
 	})
 }
-
-// func AssertThatCounterHas(t *testing.T, numberOfMurs int) {
-// 	AssertThatCounterHas(t, numberOfMurs)
-// }

--- a/pkg/counter/cache.go
+++ b/pkg/counter/cache.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -52,6 +53,7 @@ func reset() {
 func IncrementMasterUserRecordCount() {
 	write(func() {
 		cachedCounts.MasterUserRecordCount++
+		metrics.MasterUserRecordGauge.Set(float64(cachedCounts.MasterUserRecordCount))
 	})
 }
 
@@ -64,17 +66,18 @@ func DecrementMasterUserRecordCount(log logr.Logger) {
 			log.Error(fmt.Errorf("the count of MasterUserRecords is zero"),
 				"unable to decrement the number of MasterUserRecords")
 		}
+		metrics.MasterUserRecordGauge.Set(float64(cachedCounts.MasterUserRecordCount))
 	})
 }
 
-// IncrementUserAccountCount increments the number of UserAccount fo the given member cluster in the cached counter
+// IncrementUserAccountCount increments the number of UserAccount for the given member cluster in the cached counter
 func IncrementUserAccountCount(clusterName string) {
 	write(func() {
 		cachedCounts.UserAccountsPerClusterCounts[clusterName]++
 	})
 }
 
-// DecrementUserAccountCount decreases the number of UserAccount fo the given member cluster in the cached counter
+// DecrementUserAccountCount decreases the number of UserAccount for the given member cluster in the cached counter
 func DecrementUserAccountCount(log logr.Logger, clusterName string) {
 	write(func() {
 		if cachedCounts.UserAccountsPerClusterCounts[clusterName] != 0 || !cachedCounts.initialized {
@@ -140,6 +143,7 @@ CachedCountsPerCluster:
 			UserAccountCount: count,
 		})
 	}
+	metrics.MasterUserRecordGauge.Set(float64(cachedCounts.MasterUserRecordCount))
 	return nil
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,147 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var log = logf.Log.WithName("toolchain_metrics")
+
+// Counter is a wrapper of the prometheus counter type
+type Counter struct {
+	Name              string
+	Help              string
+	prometheusCounter prometheus.Counter
+}
+
+// Collector returns a collector for the metric
+func (m Counter) Collector() prometheus.Collector {
+	return m.prometheusCounter
+}
+
+// Increment the counter if it has been initialized
+func (m Counter) Increment() {
+	m.prometheusCounter.Inc()
+}
+
+// ConditionalIncrement increments the Counter if the condition is true
+func (m Counter) ConditionalIncrement(condition bool) {
+	if condition {
+		m.prometheusCounter.Inc()
+	}
+}
+
+// Gauge is a wrapper of the prometheus gauge type
+type Gauge struct {
+	Name            string
+	Help            string
+	prometheusGauge prometheus.Gauge
+}
+
+// Collector returns a collector for the metric
+func (m Gauge) Collector() prometheus.Collector {
+	return m.prometheusGauge
+}
+
+// Set the gauge if it has been initialized
+func (m Gauge) Set(value float64) {
+	m.prometheusGauge.Set(value)
+}
+
+// counters
+var (
+	// UserSignupUniqueTotal should be incremented only the first time a user signup is created, there should be 1 for each unique user
+	UserSignupUniqueTotal = initCounter("user_signups_total", "Total number of unique User Signups")
+
+	// UserSignupProvisionedTotal should be incremented each time a user signup is provisioned, can be multiple times per user if they reactivate multiple times
+	UserSignupProvisionedTotal = initCounter("user_signups_provisioned_total", "Total number of Provisioned User Signups")
+
+	// UserSignupBannedTotal should be incremented each time a user signup is banned
+	UserSignupBannedTotal = initCounter("user_signups_banned_total", "Total number of Banned User Signups")
+
+	// UserSignupDeactivatedTotal should be incremented each time a user signup is deactivated, can be multiple times per user if they reactivate multiple times
+	UserSignupDeactivatedTotal = initCounter("user_signups_deactivated_total", "Total number of Deactivated User Signups")
+
+	// UserSignupAutoDeactivatedTotal should be incremented each time a user signup is automatically deactivated, can be multiple times per user if they reactivate multiple times
+	UserSignupAutoDeactivatedTotal = initCounter("user_signups_auto_deactivated_total", "Total number of Automatically Deactivated User Signups")
+)
+
+// gauges
+var (
+	// MasterUserRecordGauge should reflect the current number of master user records in the system
+	MasterUserRecordGauge = initGauge("master_user_record_current", "Current number of Master User Records")
+)
+
+// collections
+var (
+	allCounters = []*Counter{}
+	allGauges   = []*Gauge{}
+)
+
+func initCounter(name, help string) *Counter {
+	c := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: name,
+		Help: help,
+	})
+	m := &Counter{
+		Name:              name,
+		Help:              help,
+		prometheusCounter: c,
+	}
+	allCounters = append(allCounters, m)
+	return m
+}
+
+func initGauge(name, help string) *Gauge {
+	g := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: name,
+		Help: help,
+	})
+	m := &Gauge{
+		Name:            name,
+		Help:            help,
+		prometheusGauge: g,
+	}
+	allGauges = append(allGauges, m)
+	return m
+}
+
+// RegisterCustomMetrics registers the custom metrics
+func RegisterCustomMetrics() {
+	// register metrics
+	for _, m := range allCounters {
+		k8smetrics.Registry.MustRegister(m.prometheusCounter)
+	}
+	for _, m := range allGauges {
+		k8smetrics.Registry.MustRegister(m.prometheusGauge)
+	}
+	log.Info("custom metrics registered successfully")
+}
+
+// UnregisterCustomMetrics unregisters the custom metrics
+func UnregisterCustomMetrics() {
+	for _, m := range allCounters {
+		k8smetrics.Registry.Unregister(m.prometheusCounter)
+	}
+	for _, m := range allGauges {
+		k8smetrics.Registry.Unregister(m.prometheusGauge)
+	}
+	log.Info("custom metrics unregistered successfully")
+}
+
+// Reset function for use in tests only
+func Reset() {
+	for _, m := range allCounters {
+		m.prometheusCounter = prometheus.NewCounter(prometheus.CounterOpts{
+			Name: m.Name,
+			Help: m.Help,
+		})
+	}
+	for _, m := range allGauges {
+		m.prometheusGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: m.Name,
+			Help: m.Help,
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -10,8 +10,8 @@ var log = logf.Log.WithName("toolchain_metrics")
 
 // Counter is a wrapper of the prometheus counter type
 type Counter struct {
-	Name              string
-	Help              string
+	name              string
+	help              string
 	prometheusCounter prometheus.Counter
 }
 
@@ -34,8 +34,8 @@ func (m Counter) ConditionalIncrement(condition bool) {
 
 // Gauge is a wrapper of the prometheus gauge type
 type Gauge struct {
-	Name            string
-	Help            string
+	name            string
+	help            string
 	prometheusGauge prometheus.Gauge
 }
 
@@ -85,8 +85,8 @@ func initCounter(name, help string) *Counter {
 		Help: help,
 	})
 	m := &Counter{
-		Name:              name,
-		Help:              help,
+		name:              name,
+		help:              help,
 		prometheusCounter: c,
 	}
 	allCounters = append(allCounters, m)
@@ -99,8 +99,8 @@ func initGauge(name, help string) *Gauge {
 		Help: help,
 	})
 	m := &Gauge{
-		Name:            name,
-		Help:            help,
+		name:            name,
+		help:            help,
 		prometheusGauge: g,
 	}
 	allGauges = append(allGauges, m)
@@ -134,14 +134,14 @@ func UnregisterCustomMetrics() {
 func Reset() {
 	for _, m := range allCounters {
 		m.prometheusCounter = prometheus.NewCounter(prometheus.CounterOpts{
-			Name: m.Name,
-			Help: m.Help,
+			Name: m.name,
+			Help: m.help,
 		})
 	}
 	for _, m := range allGauges {
 		m.prometheusGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: m.Name,
-			Help: m.Help,
+			Name: m.name,
+			Help: m.help,
 		})
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -121,16 +121,10 @@ func RegisterCustomMetrics() {
 	log.Info("custom metrics registered successfully")
 }
 
-// Reset function for use in tests only
-func Reset() {
+// ResetCounters function for use in tests only
+func ResetCounters() {
 	for _, m := range allCounters {
 		m.prometheusCounter = prometheus.NewCounter(prometheus.CounterOpts{
-			Name: m.name,
-			Help: m.help,
-		})
-	}
-	for _, m := range allGauges {
-		m.prometheusGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: m.name,
 			Help: m.help,
 		})

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,6 +6,8 @@ import (
 	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+const metricsPrefix = "sandbox_"
+
 var log = logf.Log.WithName("toolchain_metrics")
 
 // Counter is a wrapper of the prometheus counter type
@@ -81,11 +83,11 @@ var (
 
 func initCounter(name, help string) *Counter {
 	c := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: name,
+		Name: metricsPrefix + name,
 		Help: help,
 	})
 	m := &Counter{
-		name:              name,
+		name:              metricsPrefix + name,
 		help:              help,
 		prometheusCounter: c,
 	}
@@ -95,11 +97,11 @@ func initCounter(name, help string) *Counter {
 
 func initGauge(name, help string) *Gauge {
 	g := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: name,
+		Name: metricsPrefix + name,
 		Help: help,
 	})
 	m := &Gauge{
-		name:            name,
+		name:            metricsPrefix + name,
 		help:            help,
 		prometheusGauge: g,
 	}
@@ -117,17 +119,6 @@ func RegisterCustomMetrics() {
 		k8smetrics.Registry.MustRegister(m.prometheusGauge)
 	}
 	log.Info("custom metrics registered successfully")
-}
-
-// UnregisterCustomMetrics unregisters the custom metrics
-func UnregisterCustomMetrics() {
-	for _, m := range allCounters {
-		k8smetrics.Registry.Unregister(m.prometheusCounter)
-	}
-	for _, m := range allGauges {
-		k8smetrics.Registry.Unregister(m.prometheusGauge)
-	}
-	log.Info("custom metrics unregistered successfully")
 }
 
 // Reset function for use in tests only

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -51,7 +51,7 @@ func TestRegisterCustomMetrics(t *testing.T) {
 	}
 }
 
-func TestReset(t *testing.T) {
+func TestResetCounters(t *testing.T) {
 	// given
 	c := initCounter("test_counter", "test counter description")
 	g := initGauge("test_gauge", "test gauge description")
@@ -59,9 +59,9 @@ func TestReset(t *testing.T) {
 	// when
 	c.Increment()
 	g.Set(22)
-	Reset()
+	ResetCounters()
 
 	// then
 	assert.Equal(t, float64(0), prom_testutil.ToFloat64(c.prometheusCounter))
-	assert.Equal(t, float64(0), prom_testutil.ToFloat64(g.prometheusGauge))
+	assert.Equal(t, float64(22), prom_testutil.ToFloat64(g.prometheusGauge))
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -3,8 +3,7 @@ package metrics
 import (
 	"testing"
 
-	// . "github.com/codeready-toolchain/host-operator/test"
-	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/stretchr/testify/assert"
 	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -20,7 +19,7 @@ func TestInitCounter(t *testing.T) {
 	// then
 	assert.Equal(t, "sandbox_test_counter", m.name)
 	assert.Equal(t, "test counter description", m.help)
-	assert.Equal(t, float64(1), prom_testutil.ToFloat64(m.prometheusCounter))
+	assert.Equal(t, float64(1), promtestutil.ToFloat64(m.prometheusCounter))
 }
 
 func TestInitGauge(t *testing.T) {
@@ -33,7 +32,7 @@ func TestInitGauge(t *testing.T) {
 	// then
 	assert.Equal(t, "sandbox_test_gauge", m.name)
 	assert.Equal(t, "test gauge description", m.help)
-	assert.Equal(t, float64(22), prom_testutil.ToFloat64(m.prometheusGauge))
+	assert.Equal(t, float64(22), promtestutil.ToFloat64(m.prometheusGauge))
 }
 
 func TestRegisterCustomMetrics(t *testing.T) {
@@ -62,6 +61,6 @@ func TestResetCounters(t *testing.T) {
 	ResetCounters()
 
 	// then
-	assert.Equal(t, float64(0), prom_testutil.ToFloat64(c.prometheusCounter))
-	assert.Equal(t, float64(22), prom_testutil.ToFloat64(g.prometheusGauge))
+	assert.Equal(t, float64(0), promtestutil.ToFloat64(c.prometheusCounter))
+	assert.Equal(t, float64(22), promtestutil.ToFloat64(g.prometheusGauge))
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"testing"
+
+	// . "github.com/codeready-toolchain/host-operator/test"
+	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/stretchr/testify/assert"
+	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func TestInitCounter(t *testing.T) {
+	// given
+	m := initCounter("test_counter", "test counter description")
+
+	// when
+	m.Increment()
+
+	// then
+	assert.Equal(t, "sandbox_test_counter", m.name)
+	assert.Equal(t, "test counter description", m.help)
+	assert.Equal(t, float64(1), prom_testutil.ToFloat64(m.prometheusCounter))
+}
+
+func TestInitGauge(t *testing.T) {
+	// given
+	m := initGauge("test_gauge", "test gauge description")
+
+	// when
+	m.Set(22)
+
+	// then
+	assert.Equal(t, "sandbox_test_gauge", m.name)
+	assert.Equal(t, "test gauge description", m.help)
+	assert.Equal(t, float64(22), prom_testutil.ToFloat64(m.prometheusGauge))
+}
+
+func TestRegisterCustomMetrics(t *testing.T) {
+	// when
+	RegisterCustomMetrics()
+
+	// then
+	// verify all metrics were registered successfully
+	for _, m := range allCounters {
+		assert.True(t, k8smetrics.Registry.Unregister(m.prometheusCounter))
+	}
+
+	for _, m := range allGauges {
+		assert.True(t, k8smetrics.Registry.Unregister(m.prometheusGauge))
+	}
+}
+
+func TestReset(t *testing.T) {
+	// given
+	c := initCounter("test_counter", "test counter description")
+	g := initGauge("test_gauge", "test gauge description")
+
+	// when
+	c.Increment()
+	g.Set(22)
+	Reset()
+
+	// then
+	assert.Equal(t, float64(0), prom_testutil.ToFloat64(c.prometheusCounter))
+	assert.Equal(t, float64(0), prom_testutil.ToFloat64(g.prometheusGauge))
+}

--- a/test/counter.go
+++ b/test/counter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/counter"
+	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,7 @@ func AssertThatUninitializedCounterHas(t *testing.T, numberOfMurs int, numberOfU
 }
 
 func AssertThatCounterHas(t *testing.T, numberOfMurs int, numberOfUasPerCluster ...ExpectedNumberOfUserAccounts) {
+	AssertMetricsGaugeEquals(t, numberOfMurs, metrics.MasterUserRecordGauge)
 	counts, err := counter.GetCounts()
 	assert.NoError(t, err)
 	verifyCounts(t, counts, numberOfMurs, numberOfUasPerCluster...)
@@ -65,6 +67,7 @@ func InitializeCounterWithoutReset(t *testing.T, numberOfMurs int, numberOfUasPe
 }
 
 func initializeCounter(t *testing.T, cl *test.FakeClient, numberOfMurs int, numberOfUasPerCluster ...ExpectedNumberOfUserAccounts) *v1alpha1.ToolchainStatus {
+	metrics.MasterUserRecordGauge.Set(float64(numberOfMurs))
 	if len(numberOfUasPerCluster) > 0 && numberOfMurs == 0 {
 		require.FailNow(t, "When specifying number of UserAccounts per member cluster, you need to specify a count of MURs that is higher than zero")
 	}

--- a/test/metric.go
+++ b/test/metric.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 
-	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func AssertMetricsCounterEquals(t *testing.T, expected int, counter *metrics.Counter) {
-	assert.Equal(t, float64(expected), prom_testutil.ToFloat64(counter.Collector()))
+	assert.Equal(t, float64(expected), promtestutil.ToFloat64(counter.Collector()))
 }
 
 func AssertMetricsGaugeEquals(t *testing.T, expected int, gauge *metrics.Gauge) {
-	assert.Equal(t, float64(expected), prom_testutil.ToFloat64(gauge.Collector()))
+	assert.Equal(t, float64(expected), promtestutil.ToFloat64(gauge.Collector()))
 }

--- a/test/metric.go
+++ b/test/metric.go
@@ -1,0 +1,18 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/host-operator/pkg/metrics"
+
+	prom_testutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertMetricsCounterEquals(t *testing.T, expected int, counter *metrics.Counter) {
+	assert.Equal(t, float64(expected), prom_testutil.ToFloat64(counter.Collector()))
+}
+
+func AssertMetricsGaugeEquals(t *testing.T, expected int, gauge *metrics.Gauge) {
+	assert.Equal(t, float64(expected), prom_testutil.ToFloat64(gauge.Collector()))
+}


### PR DESCRIPTION
This PR adds to https://github.com/codeready-toolchain/host-operator/pull/286 which exposes the metrics endpoint.

## Metrics 
Metric | Type | Description 
--- | --- | ---
user_signups_total | Counter | Total number of unique User Signups
user_signups_provisioned_total | Counter | Total number of Provisioned User Signups
user_signups_banned_total | Counter | Total number of Banned User Signups
user_signups_deactivated_total | Counter | Total number of Deactivated User Signups
user_signups_auto_deactivated_total | Counter | Total number of Automatically Deactivated User Signups
master_user_record_current | Gauge | Current number of Master User Records (mirrors the MUR counter from the cache)

## Scenario with some metrics from the endpoint
### Scenario

1. single usersignup created
1. deactivate
1. reactivated
1. deactivated again
1. reactivated again

### Metrics snippets from endpoint
```
# HELP user_signups_auto_deactivated_total Total number of Automatically Deactivated User Signups
# TYPE user_signups_auto_deactivated_total counter
user_signups_auto_deactivated_total 0
# HELP user_signups_banned_total Total number of Banned User Signups
# TYPE user_signups_banned_total counter
user_signups_banned_total 0
# HELP user_signups_deactivated_total Total number of Deactivated User Signups
# TYPE user_signups_deactivated_total counter
user_signups_deactivated_total 2
# HELP user_signups_provisioned_total Total number of Provisioned User Signups
# TYPE user_signups_provisioned_total counter
user_signups_provisioned_total 2
# HELP user_signups_total Total number of unique User Signups
# TYPE user_signups_total counter
user_signups_total 1
```

```
# HELP master_user_record_current Current number of Master User Records
# TYPE master_user_record_current gauge
master_user_record_current 1
```

### PR checklist
- [x] ensure counters aren't incremented after operator restart (using UserSignup state labels)
- [x] ensure provisioned and deactivated counts are still handled correctly after reactivation (should still increment)
- [x] unit tests
- [x] e2e tests (https://github.com/codeready-toolchain/toolchain-e2e/pull/186)