### PR TITLE
chore: take the console & che url from ToolchainStatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
-	gopkg.in/h2non/gock.v1 v1.0.14
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.3
 	k8s.io/apiextensions-apiserver v0.18.3

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -3,14 +3,12 @@ package apis
 import (
 	"github.com/codeready-toolchain/api/pkg/apis"
 
-	routev1 "github.com/openshift/api/route/v1"
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme) error {
-	addToSchemes := append(apis.AddToSchemes, routev1.Install)
-	addToSchemes = append(addToSchemes, extensionsv1.AddToScheme)
+	addToSchemes := append(apis.AddToSchemes, extensionsv1.AddToScheme)
 	return addToSchemes.AddToScheme(s)
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -72,30 +72,6 @@ const (
 	// varMailgunSenderEmail specifies the host operator mailgun senders email
 	varMailgunSenderEmail = "mailgun.sender.email"
 
-	// varConsoleNamespace is the console route namespace
-	varConsoleNamespace = "console.namespace"
-
-	// defaultConsoleNamespace is the default console route namespace
-	defaultConsoleNamespace = "openshift-console"
-
-	// varConsoleRouteName is the console route name
-	varConsoleRouteName = "console.route.name"
-
-	// defaultConsoleRouteName is the default console route name
-	defaultConsoleRouteName = "console"
-
-	// varCheNamespace is the che route namespace
-	varCheNamespace = "che.namespace"
-
-	// defaultCheNamespace is the default che route namespace
-	defaultCheNamespace = "toolchain-che"
-
-	// varCheRouteName is the che dashboard route
-	varCheRouteName = "che.route.name"
-
-	// defaultCheRouteName is the default che dashboard route
-	defaultCheRouteName = "che"
-
 	// varEnvironment specifies the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
 	varEnvironment = "environment"
 
@@ -179,10 +155,6 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varTemplateUpdateRequestMaxPoolSize, defaultTemplateUpdateRequestMaxPoolSize)
 	c.host.SetDefault(varNotificationDeliveryService, NotificationDeliveryServiceMailgun)
 	c.host.SetDefault(varDurationBeforeNotificationDeletion, defaultDurationBeforeNotificationDeletion)
-	c.host.SetDefault(varConsoleNamespace, defaultConsoleNamespace)
-	c.host.SetDefault(varConsoleRouteName, defaultConsoleRouteName)
-	c.host.SetDefault(varCheNamespace, defaultCheNamespace)
-	c.host.SetDefault(varCheRouteName, defaultCheRouteName)
 	c.host.SetDefault(varEnvironment, defaultEnvironment)
 	c.host.SetDefault(varMasterUserRecordUpdateFailureThreshold, 2) // allow 1 failure, try again and then give up if failed again
 	c.host.SetDefault(varToolchainStatusRefreshTime, defaultToolchainStatusRefreshTime)
@@ -231,26 +203,6 @@ func (c *Config) GetMailgunAPIKey() string {
 // GetMailgunSenderEmail returns the host operator mailgun sender's email address
 func (c *Config) GetMailgunSenderEmail() string {
 	return c.secretValues[varMailgunSenderEmail]
-}
-
-// GetConsoleNamespace returns the console route namespace
-func (c *Config) GetConsoleNamespace() string {
-	return c.host.GetString(varConsoleNamespace)
-}
-
-// GetConsoleRouteName returns the console route name
-func (c *Config) GetConsoleRouteName() string {
-	return c.host.GetString(varConsoleRouteName)
-}
-
-// GetCheNamespace returns the Che route namespace
-func (c *Config) GetCheNamespace() string {
-	return c.host.GetString(varCheNamespace)
-}
-
-// GetCheRouteName returns the name of the Che dashboard route
-func (c *Config) GetCheRouteName() string {
-	return c.host.GetString(varCheRouteName)
 }
 
 // GetEnvironment returns the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -140,10 +140,6 @@ func TestLoadFromConfigMap(t *testing.T) {
 
 		// then
 		assert.Equal(t, "https://registration.crt-placeholder.com", config.GetRegistrationServiceURL())
-		assert.Equal(t, "console", config.GetConsoleRouteName())
-		assert.Equal(t, "openshift-console", config.GetConsoleNamespace())
-		assert.Equal(t, "che", config.GetCheRouteName())
-		assert.Equal(t, "toolchain-che", config.GetCheNamespace())
 
 	})
 	t.Run("env overwrite", func(t *testing.T) {
@@ -151,10 +147,6 @@ func TestLoadFromConfigMap(t *testing.T) {
 		restore := test.SetEnvVarsAndRestore(t,
 			test.Env("HOST_OPERATOR_CONFIG_MAP_NAME", "test-config"),
 			test.Env("HOST_OPERATOR_REGISTRATION_SERVICE_URL", ""),
-			test.Env("HOST_OPERATOR_CONSOLE_NAMESPACE", ""),
-			test.Env("HOST_OPERATOR_CONSOLE_ROUTE_NAME", ""),
-			test.Env("HOST_OPERATOR_CHE_NAMESPACE", ""),
-			test.Env("HOST_OPERATOR_CHE_ROUTE_NAME", ""),
 			test.Env("MEMBER_OPERATOR_TEST_TEST", ""),
 			test.Env("HOST_OPERATOR_TEST_TEST", ""))
 		defer restore()
@@ -166,10 +158,6 @@ func TestLoadFromConfigMap(t *testing.T) {
 			},
 			Data: map[string]string{
 				"registration.service.url": "test-url",
-				"console.namespace":        "test-console-namespace",
-				"console.route.name":       "test-console-route-name",
-				"che.namespace":            "test-che-namespace",
-				"che.route.name":           "test-che-route-name",
 				"test-test":                "test-test",
 			},
 		}
@@ -182,22 +170,10 @@ func TestLoadFromConfigMap(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Equal(t, "test-url", config.GetRegistrationServiceURL())
-		assert.Equal(t, "test-console-namespace", config.GetConsoleNamespace())
-		assert.Equal(t, "test-console-route-name", config.GetConsoleRouteName())
-		assert.Equal(t, "test-che-namespace", config.GetCheNamespace())
-		assert.Equal(t, "test-che-route-name", config.GetCheRouteName())
 
 		// test env vars are parsed and created correctly
 		regServiceURL := os.Getenv("HOST_OPERATOR_REGISTRATION_SERVICE_URL")
 		assert.Equal(t, regServiceURL, "test-url")
-		consoleNamespace := os.Getenv("HOST_OPERATOR_CONSOLE_NAMESPACE")
-		assert.Equal(t, consoleNamespace, "test-console-namespace")
-		consoleRouteName := os.Getenv("HOST_OPERATOR_CONSOLE_ROUTE_NAME")
-		assert.Equal(t, consoleRouteName, "test-console-route-name")
-		cheNamespace := os.Getenv("HOST_OPERATOR_CHE_NAMESPACE")
-		assert.Equal(t, cheNamespace, "test-che-namespace")
-		cheRouteName := os.Getenv("HOST_OPERATOR_CHE_ROUTE_NAME")
-		assert.Equal(t, cheRouteName, "test-che-route-name")
 		testTest := os.Getenv("HOST_OPERATOR_TEST_TEST")
 		assert.Equal(t, testTest, "test-test")
 	})

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -135,8 +135,12 @@ func (s *Synchronizer) withClusterDetails(status toolchainv1alpha1.UserAccountSt
 
 		for _, memberStatus := range toolchainStatus.Status.Members {
 			if memberStatus.ClusterName == status.Cluster.Name {
-				if memberStatus.MemberStatus.Routes == nil || condition.IsNotTrue(memberStatus.MemberStatus.Routes.Conditions, toolchainv1alpha1.ConditionReady) {
-					return status, fmt.Errorf("routes are not properly set in ToolchainStatus resource")
+				if memberStatus.MemberStatus.Routes == nil {
+					return status, fmt.Errorf("routes are not set in ToolchainStatus resource")
+				}
+				if condition.IsNotTrue(memberStatus.MemberStatus.Routes.Conditions, toolchainv1alpha1.ConditionReady) {
+					ready, _ := condition.FindConditionByType(memberStatus.MemberStatus.Routes.Conditions, toolchainv1alpha1.ConditionReady)
+					return status, fmt.Errorf("routes are not properly set in ToolchainStatus - the reason is: `%s` with message: `%s`", ready.Reason, ready.Message)
 				}
 				status.Cluster.ConsoleURL = memberStatus.MemberStatus.Routes.ConsoleURL
 				status.Cluster.CheDashboardURL = memberStatus.MemberStatus.Routes.CheDashboardURL

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"time"
@@ -14,14 +13,12 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/templates/notificationtemplates"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
-	routev1 "github.com/openshift/api/route/v1"
-	"github.com/pkg/errors"
-	kuberrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -126,88 +123,30 @@ func (s *Synchronizer) synchronizeStatus() error {
 // withClusterDetails returns the given user account status with additional information about
 // the target cluster such as API endpoint and Console URL if not set yet
 func (s *Synchronizer) withClusterDetails(status toolchainv1alpha1.UserAccountStatusEmbedded) (toolchainv1alpha1.UserAccountStatusEmbedded, error) {
-	var err error
 	if status.Cluster.Name != "" {
+		toolchainStatus := &toolchainv1alpha1.ToolchainStatus{}
+		if err := s.hostClient.Get(context.TODO(), types.NamespacedName{Namespace: s.record.Namespace, Name: s.config.GetToolchainStatusName()}, toolchainStatus); err != nil {
+			return status, errors.Wrapf(err, "unable to read ToolchainStatus resource")
+		}
+
 		if status.Cluster.APIEndpoint == "" {
 			status.Cluster.APIEndpoint = s.memberCluster.APIEndpoint
 		}
-		status, err = s.withConsoleURL(status)
-		if err != nil {
-			return status, err
-		}
-		status, err = s.withCheDashboardURL(status)
-	}
-	return status, err
-}
 
-// withConsoleURL returns the given user account status with Console URL set if it's not already set yet
-func (s *Synchronizer) withConsoleURL(status toolchainv1alpha1.UserAccountStatusEmbedded) (toolchainv1alpha1.UserAccountStatusEmbedded, error) {
-	if status.Cluster.ConsoleURL == "" {
-		route := &routev1.Route{}
-		namespacedName := types.NamespacedName{Namespace: s.config.GetConsoleNamespace(), Name: s.config.GetConsoleRouteName()}
-		if err := s.memberCluster.Client.Get(context.TODO(), namespacedName, route); err != nil {
-			if kuberrors.IsNotFound(err) {
-				// It can happen if running in old OpenShift version like 3.x (minishift) in dev environment
-				// TODO do this only if run in dev environment
-				consoleURL, consoleErr := s.openShift3XConsoleURL(s.memberCluster.APIEndpoint)
-				if consoleErr != nil {
-					// Log the openShift3XConsoleURL() error but return the original missing route error
-					s.logger.Error(err, "OpenShit 3.x web console unreachable", "url", consoleURL)
-					return status, errors.Wrapf(err, "unable to get web console route for cluster %s", s.memberCluster.Name)
+		for _, memberStatus := range toolchainStatus.Status.Members {
+			if memberStatus.ClusterName == status.Cluster.Name {
+				if memberStatus.MemberStatus.Routes == nil || condition.IsNotTrue(memberStatus.MemberStatus.Routes.Conditions, toolchainv1alpha1.ConditionReady) {
+					return status, fmt.Errorf("routes are not properly set in ToolchainStatus resource")
 				}
-				s.logger.Info("OpenShit 3.x web console URL used", "url", consoleURL)
-				status.Cluster.ConsoleURL = consoleURL
+				status.Cluster.ConsoleURL = memberStatus.MemberStatus.Routes.ConsoleURL
+				status.Cluster.CheDashboardURL = memberStatus.MemberStatus.Routes.CheDashboardURL
 				return status, nil
 			}
-			s.logger.Error(err, "unable to get console route")
-			return status, err
 		}
-
-		status.Cluster.ConsoleURL = fmt.Sprintf("https://%s/%s", route.Spec.Host, route.Spec.Path)
+		return status, fmt.Errorf("the appropriate status of the member cluster '%s' wasn't found in ToolchainCluster CR - the present member statuses: %v",
+			status.Cluster.Name, toolchainStatus.Status.Members)
 	}
 	return status, nil
-}
-
-// withCheDashboardURL returns the given user account status with Che Dashboard URL set if it's not already set yet
-func (s *Synchronizer) withCheDashboardURL(status toolchainv1alpha1.UserAccountStatusEmbedded) (toolchainv1alpha1.UserAccountStatusEmbedded, error) {
-	if status.Cluster.CheDashboardURL == "" {
-		route := &routev1.Route{}
-		namespacedName := types.NamespacedName{Namespace: s.config.GetCheNamespace(), Name: s.config.GetCheRouteName()}
-		err := s.memberCluster.Client.Get(context.TODO(), namespacedName, route)
-		if err != nil {
-			if kuberrors.IsNotFound(err) {
-				// It can happen if Che Operator is not installed
-				s.logger.Info("unable to get che dashboard route (operator not installed?)")
-				return status, nil
-			}
-			s.logger.Error(err, "unable to get che dashboard route")
-			return status, err
-		}
-		scheme := "https"
-		if route.Spec.TLS == nil || *route.Spec.TLS == (routev1.TLSConfig{}) {
-			scheme = "http"
-		}
-		status.Cluster.CheDashboardURL = fmt.Sprintf("%s://%s/%s", scheme, route.Spec.Host, route.Spec.Path)
-	}
-	return status, nil
-}
-
-// openShift3XConsoleURL checks if <apiEndpoint>/console URL is reachable.
-// This URL is used by web console in OpenShift 3.x
-func (s *Synchronizer) openShift3XConsoleURL(apiEndpoint string) (string, error) {
-	url := fmt.Sprintf("%s/console", apiEndpoint)
-	resp, err := consoleClient.Get(url)
-	if err != nil {
-		return url, err
-	}
-	defer func() {
-		_, _ = ioutil.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-	}()
-	if resp.StatusCode != http.StatusOK {
-		return url, errors.Errorf("status is not 200 OK: %s", resp.Status)
-	}
-	return url, nil
 }
 
 // alignDisabled updates the status to Disabled if all all the embedded UserAccounts have Disabled status

--- a/pkg/controller/masteruserrecord/sync_test.go
+++ b/pkg/controller/masteruserrecord/sync_test.go
@@ -519,7 +519,7 @@ func TestSynchronizeUserAccountFailed(t *testing.T) {
 					err = sync.synchronizeStatus()
 
 					// then
-					assert.EqualError(t, err, "routes are not properly set in ToolchainStatus resource")
+					assert.Error(t, err)
 				}
 			})
 		})

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller.go
@@ -282,12 +282,13 @@ func (r *ReconcileToolchainStatus) membersHandleStatus(reqLogger logr.Logger, to
 			continue
 		}
 
-		// take only the overall conditions and resource usage from the MemberStatus
+		// take only the overall conditions, resource usage and routes from the MemberStatus
 		// (ie. don't include status of member operator, host connection, etc.) in order to keep readability.
 		// member status details can be viewed on the member cluster directly.
 		memberStatus := toolchainv1alpha1.MemberStatusStatus{
 			Conditions:    memberStatusObj.Status.Conditions,
 			ResourceUsage: memberStatusObj.Status.ResourceUsage,
+			Routes:        memberStatusObj.Status.Routes,
 		}
 		if condition.IsNotTrue(memberStatusObj.Status.Conditions, toolchainv1alpha1.ConditionReady) {
 			// the memberstatus is not ready so set the component error to bubble up the error to the overall toolchain status

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -757,6 +757,11 @@ func newMemberStatus(condition *toolchainv1alpha1.Condition) *toolchainv1alpha1.
 					"master": 45,
 				},
 			},
+			Routes: &toolchainv1alpha1.Routes{
+				ConsoleURL:      "http://console.openshift.com/url",
+				CheDashboardURL: "http://console.openshift.com/url",
+				Conditions:      []toolchainv1alpha1.Condition{ToBeReady()},
+			},
 		},
 	}
 }
@@ -910,6 +915,11 @@ func memberClusterSingleReady() toolchainv1alpha1.Member {
 					"master": 45,
 				},
 			},
+			Routes: &toolchainv1alpha1.Routes{
+				ConsoleURL:      "http://console.openshift.com/url",
+				CheDashboardURL: "http://console.openshift.com/url",
+				Conditions:      []toolchainv1alpha1.Condition{ToBeReady()},
+			},
 		},
 	}
 }
@@ -928,6 +938,11 @@ func memberClusterSingleNotReady(name, reason, msg string, resourceUsage map[str
 			},
 			ResourceUsage: toolchainv1alpha1.ResourceUsage{
 				MemoryUsagePerNodeRole: resourceUsage,
+			},
+			Routes: &toolchainv1alpha1.Routes{
+				ConsoleURL:      "http://console.openshift.com/url",
+				CheDashboardURL: "http://console.openshift.com/url",
+				Conditions:      []toolchainv1alpha1.Condition{ToBeReady()},
 			},
 		},
 	}

--- a/test/toolchainstatus.go
+++ b/test/toolchainstatus.go
@@ -4,6 +4,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -32,6 +33,17 @@ func WithNodeRoleUsage(role string, usage int) MemberToolchainStatusOption {
 	}
 }
 
+func WithRoutes(consoleURL, cheURL string, condition toolchainv1alpha1.Condition) MemberToolchainStatusOption {
+	return func(status *toolchainv1alpha1.Member) {
+		if status.MemberStatus.Routes == nil {
+			status.MemberStatus.Routes = &toolchainv1alpha1.Routes{}
+		}
+		status.MemberStatus.Routes.ConsoleURL = consoleURL
+		status.MemberStatus.Routes.CheDashboardURL = cheURL
+		status.MemberStatus.Routes.Conditions = []toolchainv1alpha1.Condition{condition}
+	}
+}
+
 func NewToolchainStatus(options ...func(*toolchainv1alpha1.ToolchainStatus)) *toolchainv1alpha1.ToolchainStatus {
 	toolchainStatus := &toolchainv1alpha1.ToolchainStatus{
 		ObjectMeta: metav1.ObjectMeta{
@@ -43,4 +55,18 @@ func NewToolchainStatus(options ...func(*toolchainv1alpha1.ToolchainStatus)) *to
 		modify(toolchainStatus)
 	}
 	return toolchainStatus
+}
+
+func ToBeReady() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.ConditionReady,
+		Status: v1.ConditionTrue,
+	}
+}
+
+func ToBeNotReady() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.ConditionReady,
+		Status: v1.ConditionFalse,
+	}
 }


### PR DESCRIPTION
This PR drops the direct retrieval of console & che routes from member clusters and takes the URL from the ToolchainStatus. 
It also drops unnecessary configuration parameters that were moved to member operator.

This PR depends on https://github.com/codeready-toolchain/member-operator/pull/213

In the future, we will change the registration-service logic so the URLs are not taken from `MUR.status` but from `ToolchainStatus`. Then we will be able to drop this logic from host-operator completely.