### PR TITLE
Add handling for forbidden username prefixes

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -93,13 +93,20 @@ const (
 	// varDeactivationDomainsExcluded is a string of comma-separated domains that should be excluded from automatic user deactivation
 	// For example: "@redhat.com,@ibm.com"
 	varDeactivationDomainsExcluded = "deactivation.domains.excluded"
+
+	// varForbiddenUsernamePrefixes defines the prefixes that a username may not have when signing up.  If a
+	// username has a forbidden prefix, then the username compliance prefix is added to the username
+	varForbiddenUsernamePrefixes = "username.forbidden.prefixes"
+
+	DefaultForbiddenUsernamePrefixes = "openshift,kubernetes"
 )
 
 // Config encapsulates the Viper configuration registry which stores the
 // configuration data in-memory.
 type Config struct {
-	host         *viper.Viper
-	secretValues map[string]string
+	host                      *viper.Viper
+	secretValues              map[string]string
+	forbiddenUsernamePrefixes []string
 }
 
 // initConfig creates an initial, empty configuration.
@@ -113,6 +120,12 @@ func initConfig(secret map[string]string) *Config {
 	c.host.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	c.host.SetTypeByDefaultValue(true)
 	c.setConfigDefaults()
+
+	if c.host.GetString(varForbiddenUsernamePrefixes) != "" {
+		c.forbiddenUsernamePrefixes = strings.FieldsFunc(c.host.GetString(varForbiddenUsernamePrefixes), func(c rune) bool {
+			return c == ','
+		})
+	}
 
 	return &c
 }
@@ -161,6 +174,7 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varEnvironment, defaultEnvironment)
 	c.host.SetDefault(varMasterUserRecordUpdateFailureThreshold, 2) // allow 1 failure, try again and then give up if failed again
 	c.host.SetDefault(varToolchainStatusRefreshTime, defaultToolchainStatusRefreshTime)
+	c.host.SetDefault(varForbiddenUsernamePrefixes, DefaultForbiddenUsernamePrefixes)
 }
 
 // GetToolchainStatusName returns the configured name of the member status resource
@@ -249,4 +263,8 @@ func (c *Config) GetDeactivationDomainsExcludedList() []string {
 	return strings.FieldsFunc(c.host.GetString(varDeactivationDomainsExcluded), func(c rune) bool {
 		return c == ','
 	})
+}
+
+func (c *Config) GetForbiddenUsernamePrefixes() []string {
+	return c.forbiddenUsernamePrefixes
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -98,7 +98,7 @@ const (
 	// username has a forbidden prefix, then the username compliance prefix is added to the username
 	varForbiddenUsernamePrefixes = "username.forbidden.prefixes"
 
-	DefaultForbiddenUsernamePrefixes = "openshift,kubernetes"
+	DefaultForbiddenUsernamePrefixes = "openshift,kubernetes,kube-"
 )
 
 // Config encapsulates the Viper configuration registry which stores the
@@ -120,12 +120,6 @@ func initConfig(secret map[string]string) *Config {
 	c.host.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	c.host.SetTypeByDefaultValue(true)
 	c.setConfigDefaults()
-
-	if c.host.GetString(varForbiddenUsernamePrefixes) != "" {
-		c.forbiddenUsernamePrefixes = strings.FieldsFunc(c.host.GetString(varForbiddenUsernamePrefixes), func(c rune) bool {
-			return c == ','
-		})
-	}
 
 	return &c
 }
@@ -174,7 +168,9 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varEnvironment, defaultEnvironment)
 	c.host.SetDefault(varMasterUserRecordUpdateFailureThreshold, 2) // allow 1 failure, try again and then give up if failed again
 	c.host.SetDefault(varToolchainStatusRefreshTime, defaultToolchainStatusRefreshTime)
-	c.host.SetDefault(varForbiddenUsernamePrefixes, DefaultForbiddenUsernamePrefixes)
+	c.host.SetDefault(varForbiddenUsernamePrefixes, strings.FieldsFunc(DefaultForbiddenUsernamePrefixes, func(c rune) bool {
+		return c == ','
+	}))
 }
 
 // GetToolchainStatusName returns the configured name of the member status resource
@@ -266,5 +262,5 @@ func (c *Config) GetDeactivationDomainsExcludedList() []string {
 }
 
 func (c *Config) GetForbiddenUsernamePrefixes() []string {
-	return c.forbiddenUsernamePrefixes
+	return c.host.GetStringSlice(varForbiddenUsernamePrefixes)
 }

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -288,3 +288,14 @@ func TestGetDeactivationDomainsExcludedList(t *testing.T) {
 		assert.Equal(t, expected, config.GetDeactivationDomainsExcludedList())
 	})
 }
+
+func TestForbiddenUsernamePrefixesHaveCorrectDefaults(t *testing.T) {
+	restore := test.SetEnvVarAndRestore(t, "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
+
+	config := getDefaultConfiguration(t)
+	require.Len(t, config.GetForbiddenUsernamePrefixes(), 3)
+	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "openshift")
+	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "kubernetes")
+	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "kube-")
+}

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -412,6 +412,15 @@ func getNsTemplateTier(cl client.Client, tierName, namespace string) (*toolchain
 
 func (r *ReconcileUserSignup) generateCompliantUsername(instance *toolchainv1alpha1.UserSignup) (string, error) {
 	replaced := transformUsername(instance.Spec.Username)
+
+	// Check for any forbidden prefixes
+	for _, prefix := range r.crtConfig.GetForbiddenUsernamePrefixes() {
+		if strings.HasPrefix(replaced, prefix) {
+			replaced = fmt.Sprintf("%s%s", "crt-", replaced)
+			break
+		}
+	}
+
 	validationErrors := validation.IsQualifiedName(replaced)
 	if len(validationErrors) > 0 {
 		return "", fmt.Errorf(fmt.Sprintf("transformed username [%s] is invalid", replaced))

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -2176,31 +2176,43 @@ func assertName(t *testing.T, expected, username string) {
 
 func TestUsernameWithForbiddenPrefix(t *testing.T) {
 	// given
+	fakeClient := test.NewFakeClient(t)
+	config, err := configuration.LoadConfig(fakeClient)
+	require.NoError(t, err)
+
 	InitializeCounter(t, 1)
 	defer counter.Reset()
-	userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
-	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "not-ready"
 
-	userSignup.Spec.Username = "openshift-Bob"
+	// Confirm we have 3 forbidden prefixes by default
+	require.Len(t, config.GetForbiddenUsernamePrefixes(), 3)
+	names := []string{"-Bob", "-Dave", "Linda"}
 
-	r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
+	for i, prefix := range config.GetForbiddenUsernamePrefixes() {
+		userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
+		userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "not-ready"
 
-	// when
-	_, err := r.Reconcile(req)
-	require.NoError(t, err)
+		userSignup.Spec.Username = fmt.Sprintf("%s%s", prefix, names[i])
 
-	// then verify that the username has been prefixed - first lookup the UserSignup again
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
-	require.NoError(t, err)
+		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
 
-	// Lookup the MUR
-	murs := &v1alpha1.MasterUserRecordList{}
-	err = r.client.List(context.TODO(), murs, client.InNamespace(test.HostOperatorNs))
-	require.NoError(t, err)
-	require.Len(t, murs.Items, 1)
-	mur := murs.Items[0]
-	require.Equal(t, userSignup.Name, mur.Labels[v1alpha1.MasterUserRecordUserIDLabelKey])
-	require.Equal(t, "crt-openshift-Bob", mur.Name)
+		// when
+		_, err := r.Reconcile(req)
+		require.NoError(t, err)
+
+		// then verify that the username has been prefixed - first lookup the UserSignup again
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
+		require.NoError(t, err)
+
+		// Lookup the MUR
+		murs := &v1alpha1.MasterUserRecordList{}
+		err = r.client.List(context.TODO(), murs, client.InNamespace(test.HostOperatorNs))
+		require.NoError(t, err)
+		require.Len(t, murs.Items, 1)
+		mur := murs.Items[0]
+		require.Equal(t, userSignup.Name, mur.Labels[v1alpha1.MasterUserRecordUserIDLabelKey])
+		require.Equal(t, fmt.Sprintf("crt-%s%s", prefix, names[i]), mur.Name)
+
+	}
 }
 
 // Test the scenario where the existing usersignup CompliantUsername becomes outdated eg. transformUsername func is changed

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -2174,6 +2174,35 @@ func assertName(t *testing.T, expected, username string) {
 	assert.Equal(t, expected, transformUsername(username))
 }
 
+func TestUsernameWithForbiddenPrefix(t *testing.T) {
+	// given
+	InitializeCounter(t, 1)
+	defer counter.Reset()
+	userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
+	userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "not-ready"
+
+	userSignup.Spec.Username = "openshift-Bob"
+
+	r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
+
+	// when
+	_, err := r.Reconcile(req)
+	require.NoError(t, err)
+
+	// then verify that the username has been prefixed - first lookup the UserSignup again
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
+	require.NoError(t, err)
+
+	// Lookup the MUR
+	murs := &v1alpha1.MasterUserRecordList{}
+	err = r.client.List(context.TODO(), murs, client.InNamespace(test.HostOperatorNs))
+	require.NoError(t, err)
+	require.Len(t, murs.Items, 1)
+	mur := murs.Items[0]
+	require.Equal(t, userSignup.Name, mur.Labels[v1alpha1.MasterUserRecordUserIDLabelKey])
+	require.Equal(t, "crt-openshift-Bob", mur.Name)
+}
+
 // Test the scenario where the existing usersignup CompliantUsername becomes outdated eg. transformUsername func is changed
 func TestChangedCompliantUsername(t *testing.T) {
 	// starting with a UserSignup that exists and was approved and has the now outdated CompliantUsername


### PR DESCRIPTION
This PR introduces a change to `UserSignupController` in order to check that usernames don't begin with a forbidden prefix, such as "openshift" or "kubernetes".  If the username does start with one of these strings, it will be prefixed with "crt-".

Fixes https://issues.redhat.com/browse/CRT-783

Signed-off-by: Shane Bryzak <sbryzak@gmail.com>