### PR TITLE
chore: add more logs when updating NSTemplateTier resources

### DIFF
--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
@@ -324,7 +324,7 @@ func TestCreateOrUpdateResources(t *testing.T) {
 				err := nstemplatetiers.CreateOrUpdateResources(s, clt, namespace, assets)
 				// then
 				require.Error(t, err)
-				assert.Regexp(t, "unable to create NSTemplateTiers: unable to create the '\\w+' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to create resource of kind: NSTemplateTier, version: v1alpha1: an error", err.Error())
+				assert.Regexp(t, "unable to create NSTemplateTiers: unable to create or update the '\\w+' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: an error", err.Error())
 			})
 
 			t.Run("failed to update nstemplatetiers", func(t *testing.T) {
@@ -348,7 +348,7 @@ func TestCreateOrUpdateResources(t *testing.T) {
 				err := nstemplatetiers.CreateOrUpdateResources(s, clt, namespace, testassets)
 				// then
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unable to create NSTemplateTiers: unable to create the 'advanced' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to update the resource")
+				assert.Contains(t, err.Error(), "unable to create NSTemplateTiers: unable to create or update the 'advanced' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to update the resource")
 			})
 		})
 


### PR DESCRIPTION
adds more logs to the logic that creates or updates `NSTemplateTier` resources based on the changes from the bundled templates.

This should help us with monitoring any possible changes in the Tier resources

Paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/206