### PR TITLE
Change deactivation for testing and add che user annotation to -code namespaces

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -7,6 +7,7 @@ objects:
   kind: Namespace
   metadata:
     annotations:
+      che.eclipse.org/openshift-username: ${USERNAME}
       openshift.io/description: ${USERNAME}-code
       openshift.io/display-name: ${USERNAME}-code
       openshift.io/requester: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_code.yaml
@@ -7,6 +7,7 @@ objects:
   kind: Namespace
   metadata:
     annotations:
+      che.eclipse.org/openshift-username: ${USERNAME}
       openshift.io/description: ${USERNAME}-code
       openshift.io/display-name: ${USERNAME}-code
       openshift.io/requester: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/basic/tier.yaml
+++ b/deploy/templates/nstemplatetiers/basic/tier.yaml
@@ -11,7 +11,7 @@ objects:
   spec:
     clusterResources:
       templateRef: ${CLUSTER_TEMPL_REF}
-    deactivationTimeoutDays: 14
+    deactivationTimeoutDays: 1
     namespaces:
       - templateRef: ${CODE_TEMPL_REF}
       - templateRef: ${DEV_TEMPL_REF}


### PR DESCRIPTION
Changes the basic tier's deactivation period to 1 day temporarily for real-world testing.

Also includes a change to add the `che.eclipse.org/openshift-username: ${USERNAME}` annotation to -code namespaces. Background for context: https://github.com/eclipse/che/issues/15323#issuecomment-736153680