### PR TITLE
updating templates to remove href

### DIFF
--- a/deploy/templates/notificationtemplates/userdeactivated/notification.html
+++ b/deploy/templates/notificationtemplates/userdeactivated/notification.html
@@ -41,12 +41,13 @@
 >
 
     <p>
-        You are receiving this email because you have a <a href="{{.RegistrationURL}}">Red Hat OpenShift Dev Sandbox Beta</a>
+        You are receiving this email because you have a Red Hat OpenShift Dev Sandbox Beta
         account associated with {{.UserEmail}}.
     </p>
 
     <p>
-        Your account is now deactivated and all your data on Red Hat OpenShift Dev Sandbox has been deleted. You can request new access by signing up again.
+        Your account is now deactivated and all your data on Red Hat OpenShift Dev Sandbox has been deleted.
+        You can request new access by signing up again at {{.RegistrationURL}}
     </p>
 
     <p>

--- a/deploy/templates/notificationtemplates/userprovisioned/notification.html
+++ b/deploy/templates/notificationtemplates/userprovisioned/notification.html
@@ -41,7 +41,7 @@
 >
 
     <p>
-        You are receiving this email because you have a <a href="{{.RegistrationURL}}">Red Hat OpenShift Dev Sandbox Beta</a>
+        You are receiving this email because you have Red Hat OpenShift Dev Sandbox Beta
         account associated with {{.UserEmail}}.
     </p>
 
@@ -51,7 +51,7 @@
     </p>
 
     <p>
-        Please log in to <a href="{{.RegistrationURL}}">Red Hat OpenShift Dev Sandbox Beta</a> to begin using your account.
+        Please log in to {{.RegistrationURL}} to begin using your account.
     </p>
 
     <p>

--- a/pkg/templates/notificationtemplates/notification_generator_test.go
+++ b/pkg/templates/notificationtemplates/notification_generator_test.go
@@ -24,7 +24,7 @@ func TestGetNotificationTemplate(t *testing.T) {
 			require.NotNil(t, template)
 			assert.True(t, found)
 			assert.Equal(t, "Notice: Your account is deactivated for Red Hat OpenShift Dev Sandbox Beta", template.Subject)
-			assert.Contains(t, template.Content, "Your account is now deactivated and all your data on Red Hat OpenShift Dev Sandbox has been deleted. You can request new access by signing up again.")
+			assert.Contains(t, template.Content, "Your account is now deactivated and all your data on Red Hat OpenShift Dev Sandbox has been deleted.")
 		})
 		t.Run("get userprovisioned notification template", func(t *testing.T) {
 			// when


### PR DESCRIPTION
Fixes the notification template href issue where the href fails to appear on emails sent by the staging environment. 

Jira: https://issues.redhat.com/browse/CRT-836