### PR TITLE
Increase CPU limit to 10 cores

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/cluster.yaml
@@ -10,7 +10,7 @@ objects:
   spec:
     quota:
       hard:
-        limits.cpu: 4000m
+        limits.cpu: 10000m
         limits.memory: 7Gi
         limits.ephemeral-storage: 7Gi
         requests.cpu: 1750m

--- a/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
@@ -64,7 +64,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 500m
         memory: 750Mi
       defaultRequest:
         cpu: 10m

--- a/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
@@ -64,7 +64,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 500m
         memory: 512Mi
       defaultRequest:
         cpu: 10m

--- a/deploy/templates/nstemplatetiers/basic/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/basic/cluster.yaml
@@ -10,7 +10,7 @@ objects:
   spec:
     quota:
       hard:
-        limits.cpu: 4000m
+        limits.cpu: 10000m
         limits.memory: 7Gi
         limits.ephemeral-storage: 7Gi
         requests.cpu: 1750m

--- a/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
@@ -64,7 +64,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 500m
         memory: 750Mi
       defaultRequest:
         cpu: 10m

--- a/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
@@ -64,7 +64,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 500m
         memory: 512Mi
       defaultRequest:
         cpu: 10m

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/cluster.yaml
@@ -10,7 +10,7 @@ objects:
   spec:
     quota:
       hard:
-        limits.cpu: 4000m
+        limits.cpu: 10000m
         limits.memory: 7Gi
         limits.ephemeral-storage: 7Gi
         requests.cpu: 1750m

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_dev.yaml
@@ -64,7 +64,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 500m
         memory: 750Mi
       defaultRequest:
         cpu: 10m

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
@@ -64,7 +64,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 500m
         memory: 512Mi
       defaultRequest:
         cpu: 10m

--- a/deploy/templates/nstemplatetiers/team/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/team/cluster.yaml
@@ -10,7 +10,7 @@ objects:
   spec:
     quota:
       hard:
-        limits.cpu: 4000m
+        limits.cpu: 10000m
         limits.memory: 15Gi
         limits.ephemeral-storage: 7Gi
         requests.cpu: 2000m

--- a/deploy/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_dev.yaml
@@ -64,7 +64,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 500m
         memory: 1Gi
       defaultRequest:
         cpu: 10m

--- a/deploy/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_stage.yaml
@@ -64,7 +64,7 @@ objects:
     limits:
     - type: "Container"
       default:
-        cpu: 150m
+        cpu: 500m
         memory: 1Gi
       defaultRequest:
         cpu: 10m

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -385,20 +385,20 @@ func assertClusterResourcesTemplate(t *testing.T, decoder runtime.Decoder, actua
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
 	switch tier {
-	case "basic":
+	case "basic", "basicdeactivationdisabled":
 		assert.Len(t, actual.Objects, 4)
-		containsObj(t, actual, clusterResourceQuotaObj("4000m", "1750m", "7Gi"))
+		containsObj(t, actual, clusterResourceQuotaObj("10000m", "1750m", "7Gi"))
 		containsObj(t, actual, idlerObj("${USERNAME}-dev", "28800"))
 		containsObj(t, actual, idlerObj("${USERNAME}-code", "28800"))
 		containsObj(t, actual, idlerObj("${USERNAME}-stage", "28800"))
 	case "team":
 		assert.Len(t, actual.Objects, 3) // No Idler for -code namespace (there is no -code namespace in team tier)
-		containsObj(t, actual, clusterResourceQuotaObj("4000m", "2000m", "15Gi"))
+		containsObj(t, actual, clusterResourceQuotaObj("10000m", "2000m", "15Gi"))
 		containsObj(t, actual, idlerObj("${USERNAME}-dev", "28800"))
 		containsObj(t, actual, idlerObj("${USERNAME}-stage", "28800"))
 	case "advanced":
 		assert.Len(t, actual.Objects, 1) // No Idlers
-		containsObj(t, actual, clusterResourceQuotaObj("4000m", "1750m", "7Gi"))
+		containsObj(t, actual, clusterResourceQuotaObj("10000m", "1750m", "7Gi"))
 	}
 }
 
@@ -418,7 +418,7 @@ func assertNamespaceTemplate(t *testing.T, decoder runtime.Decoder, actual templ
 	containsObj(t, actual, userEditRoleBindingObj(kind))
 
 	// LimitRange
-	cpuLimit := "150m"
+	cpuLimit := "500m"
 	memoryLimit := "512Mi"
 	memoryRequest := "64Mi"
 	cpuRequest := "10m"
@@ -654,7 +654,7 @@ spec:
         spec:
           quota: 
             hard:
-              limits.cpu: 4000m
+              limits.cpu: 10000m
               limits.memory: 7Gi
               requests.storage: 15Gi
               persistentvolumeclaims: "5"


### PR DESCRIPTION
After long discussion with Ilya and OpenShift folks we decided to increase user's CPU limit to 10 cores.
I'm also increasing the default CPU limit for -dev and -stage namespaces accordingly.

We can adjust the limits later.

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/210