### PR TITLE
Drop cpu/memory limits for host operator & add requests for reg-service

### DIFF
--- a/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain-host-operator.clusterserviceversion.yaml
@@ -341,9 +341,6 @@ spec:
                 imagePullPolicy: IfNotPresent
                 name: host-operator
                 resources:
-                  limits:
-                    cpu: "1"
-                    memory: 1G
                   requests:
                     cpu: 100m
                     memory: 250M

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -37,6 +37,3 @@ spec:
           requests:
             cpu: "100m"
             memory: "250M"
-          limits:
-            cpu: "1000m"
-            memory: "1000M"

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -172,6 +172,10 @@ objects:
                     configMapKeyRef:
                       name: registration-service
                       key: twilio.from_number
+              resources:
+                requests:
+                  cpu: "50m"
+                  memory: "100M"
   - kind: Service
     apiVersion: v1
     metadata:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -2413,9 +2413,6 @@ data:
                       imagePullPolicy: IfNotPresent
                       name: host-operator
                       resources:
-                        limits:
-                          cpu: "1"
-                          memory: 1G
                         requests:
                           cpu: 100m
                           memory: 250M


### PR DESCRIPTION
Same as here: https://github.com/codeready-toolchain/member-operator/pull/225

This PR also adds cpu/memory requests to the reg-service which we can adjust later.