### PR TITLE
Change deactivation controller predicate

### DIFF
--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -11,7 +11,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
-	"github.com/codeready-toolchain/toolchain-common/pkg/predicate"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,7 +46,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource MasterUserRecord
-	err = c.Watch(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}}, &handler.EnqueueRequestForObject{}, predicate.OnlyUpdateWhenGenerationNotChanged{})
+	err = c.Watch(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}}, &handler.EnqueueRequestForObject{}, CreateAndUpdateOnlyPredicate{})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/deactivation/predicate.go
+++ b/pkg/controller/deactivation/predicate.go
@@ -1,0 +1,27 @@
+package deactivation
+
+import "sigs.k8s.io/controller-runtime/pkg/event"
+
+// CreateAndUpdateOnlyPredicate will filter out all events except Create and Update
+type CreateAndUpdateOnlyPredicate struct {
+}
+
+// Update implements default UpdateEvent filter for validating no generation change
+func (CreateAndUpdateOnlyPredicate) Update(e event.UpdateEvent) bool {
+	return true
+}
+
+// Create implements Predicate
+func (CreateAndUpdateOnlyPredicate) Create(e event.CreateEvent) bool {
+	return true
+}
+
+// Delete implements Predicate
+func (CreateAndUpdateOnlyPredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+// Generic implements Predicate
+func (CreateAndUpdateOnlyPredicate) Generic(e event.GenericEvent) bool {
+	return false
+}


### PR DESCRIPTION
A problem was discovered where the deactivation controller was not being reconciled on a pod restart in some situations eg. Pod killed or scaling the deployment down and then back up. However, when using `make dev-deploy-e2e-local` the logs show that the deactivation controller was being reconciled.

In the cases where the reconcile was not happening, the deactivation controller receives a Create event which was being filtered out by the `OnlyUpdateWhenGenerationNotChanged` predicate but in the cases where the reconcile was happening Update events were received.

We want the deactivation controller to reconcile when the host-operator is restarted for any reason so we're introducing a new predicate that will reconcile on any Create or Update event.