### PR TITLE
Use unique names for ToolchainStatus notifications

### DIFF
--- a/pkg/controller/toolchainstatus/toolchainstatus_controller.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller.go
@@ -364,9 +364,11 @@ func (r *ReconcileToolchainStatus) sendToolchainStatusUnreadyNotification(logger
 		return err
 	}
 
+	tsValue := time.Now().Format("20060102150405")
+
 	notification := &toolchainv1alpha1.Notification{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "toolchainstatus-unready",
+			Name:      fmt.Sprintf("toolchainstatus-unready-%s", tsValue),
 			Namespace: toolchainStatus.Namespace,
 		},
 		Spec: toolchainv1alpha1.NotificationSpec{

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -900,6 +900,7 @@ func TestToolchainStatusNotifications(t *testing.T) {
 						// Confirm the notification has been created
 						notification := assertToolchainStatusNotificationCreated(t, fakeClient)
 						require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-unready-"))
+						require.Len(t, notification.ObjectMeta.Name, 38)
 
 						require.NotNil(t, notification)
 						require.Equal(t, notification.Spec.Subject, "ToolchainStatus has been in an unready status for an extended period")

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -832,10 +833,8 @@ func TestToolchainStatusNotifications(t *testing.T) {
 				assert.Equal(t, requeueResult, res)
 
 				// Confirm the notification has been created
-				var notification toolchainv1alpha1.Notification
-				err = fakeClient.Get(context.Background(), test.NamespacedName(test.HostOperatorNs, "toolchainstatus-unready"),
-					&notification)
-				require.NoError(t, err)
+				notification := assertToolchainStatusNotificationCreated(t, fakeClient)
+				require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-unready-"))
 
 				require.NotNil(t, notification)
 				require.Equal(t, notification.Spec.Subject, "ToolchainStatus has been in an unready status for an extended period")
@@ -899,10 +898,8 @@ func TestToolchainStatusNotifications(t *testing.T) {
 						assert.Equal(t, requeueResult, res)
 
 						// Confirm the notification has been created
-						var notification toolchainv1alpha1.Notification
-						err = fakeClient.Get(context.Background(), test.NamespacedName(test.HostOperatorNs, "toolchainstatus-unready"),
-							&notification)
-						require.NoError(t, err)
+						notification := assertToolchainStatusNotificationCreated(t, fakeClient)
+						require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-unready-"))
 
 						require.NotNil(t, notification)
 						require.Equal(t, notification.Spec.Subject, "ToolchainStatus has been in an unready status for an extended period")
@@ -927,6 +924,16 @@ func overrideLastTransitionTime(t *testing.T, toolchainStatus *toolchainv1alpha1
 	}
 
 	require.True(t, found)
+}
+
+func assertToolchainStatusNotificationCreated(t *testing.T, fakeClient *test.FakeClient) *toolchainv1alpha1.Notification {
+	notifications := &toolchainv1alpha1.NotificationList{}
+	err := fakeClient.List(context.Background(), notifications, &client.ListOptions{
+		Namespace: test.HostOperatorNs,
+	})
+	require.NoError(t, err)
+	require.Len(t, notifications.Items, 1)
+	return &notifications.Items[0]
 }
 
 func assertToolchainStatusNotificationNotCreated(t *testing.T, fakeClient *test.FakeClient) {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CRT-881

Signed-off-by: Shane Bryzak <sbryzak@gmail.com>