### PR TITLE
Move twilio phone number to secret

### DIFF
--- a/deploy/env/e2e-tests.yaml
+++ b/deploy/env/e2e-tests.yaml
@@ -4,8 +4,6 @@ registration-service:
   verification:
     enabled: 'true'
     excluded-email-domains: 'redhat.com,acme.com'
-  twilio:
-    from-number: '+15005550006'
 host-operator:
   duration-before-change-request-deletion: '5s'
   duration-before-notification-deletion: '5s'

--- a/deploy/env/prod.yaml
+++ b/deploy/env/prod.yaml
@@ -15,8 +15,6 @@ registration-service:
                   "public-client": true
                 }'
     public-keys-url: 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs'
-  twilio:
-    from-number: '+14158513935'
 host-operator:
   secret:
     name: host-operator-secret

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -167,11 +167,6 @@ objects:
                     configMapKeyRef:
                       name: registration-service
                       key: verification.message_template
-                - name: REGISTRATION_TWILIO_FROM_NUMBER
-                  valueFrom:
-                    configMapKeyRef:
-                      name: registration-service
-                      key: twilio.from_number
               resources:
                 requests:
                   cpu: "50m"
@@ -232,7 +227,6 @@ objects:
       verification.code_expires_in_min: ${VERIFICATION_CODE_EXPIRES_IN_MIN}
       verification.excluded_email_domains: ${VERIFICATION_EXCLUDED_EMAIL_DOMAINS}
       verification.message_template: ${VERIFICATION_MESSAGE_TEMPLATE}
-      twilio.from_number: ${TWILIO_FROM_NUMBER}
 parameters:
   - name: NAMESPACE
     value: 'toolchain-host-operator'
@@ -259,6 +253,4 @@ parameters:
   - name: VERIFICATION_EXCLUDED_EMAIL_DOMAINS
     value: ''
   - name: VERIFICATION_MESSAGE_TEMPLATE
-    value: ''
-  - name: TWILIO_FROM_NUMBER
     value: ''


### PR DESCRIPTION
We can't keep it in env/prod.yaml because we need to use different numbers in prod and stage. So, let's keep it in the host operator secret as we do for the rest of twilio configuration.
The secret is already setup correctly: https://github.com/codeready-toolchain/sandbox-sre/blob/7e5a36466d2b5be02b6067834d5f9eb31e5e11a1/config/sandbox.x8i5.p1.openshiftapps.com/host/operator_secret.yaml#L18
We just need to drop the reg-service env var from the deployment and start loading it from the secret.
Also see https://github.com/codeready-toolchain/registration-service/pull/152

Will fail until https://github.com/codeready-toolchain/registration-service/pull/152 and https://github.com/codeready-toolchain/toolchain-e2e/pull/213 are merged.