### PR TITLE
fix: keep member status list empty when no ToolchainCluster CR is present

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20201111002557-384eb4d46f9c
+	github.com/codeready-toolchain/api v0.0.0-20201208173147-3fa9c0601d08
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,9 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167 h1:SpP0O1myYOMZieSwPh9/wy3OeYnO+rOphpZahdrB3NA=
 github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20201111002557-384eb4d46f9c h1:J72Q1Cpb6JANXIuNLu88bSNx0H2jiw02u8694vhI3WA=
-github.com/codeready-toolchain/api v0.0.0-20201111002557-384eb4d46f9c/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/api v0.0.0-20201208173147-3fa9c0601d08 h1:4ZXo/vRs54es1txmrU2/AtGVHC4OnCTWUaKnuE/pxOM=
+github.com/codeready-toolchain/api v0.0.0-20201208173147-3fa9c0601d08/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff h1:vBNOeBFLOFJm8Eb3KTGNUqMHUPF/TBPF6ZT2y+izHTs=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff/go.mod h1:TC5Q5FtNUwzpHNMLAkJXaxkifHwPJlZtrvnTWKIY+2M=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller.go
@@ -312,9 +312,6 @@ func (r *ReconcileToolchainStatus) membersHandleStatus(reqLogger logr.Logger, to
 	if len(memberClusters) == 0 {
 		err := fmt.Errorf("no member clusters found")
 		reqLogger.Error(err, "number of member clusters is zero")
-		memberStatusNotFoundCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberStatusNoClustersFoundReason, err.Error())
-		noMemberStatus := customMemberStatus(*memberStatusNotFoundCondition)
-		members[""] = noMemberStatus
 		ready = false
 	}
 	for _, memberCluster := range memberClusters {
@@ -399,8 +396,8 @@ func compareAndAssignMemberStatuses(reqLogger logr.Logger, toolchainStatus *tool
 		if ok {
 			toolchainStatus.Status.Members[index].MemberStatus = newMemberStatus
 			delete(members, memberStatus.ClusterName)
-		} else if memberStatus.ClusterName != "" && memberStatus.UserAccountCount > 0 {
-			err := fmt.Errorf("toolchainCluster not found for member cluster %s that was previously registered in the host", memberStatus.ClusterName)
+		} else if memberStatus.UserAccountCount > 0 {
+			err := fmt.Errorf("ToolchainCluster CR wasn't found for member cluster `%s` that was previously registered in the host", memberStatus.ClusterName)
 			reqLogger.Error(err, "the member cluster seems to be removed")
 			memberStatusNotFoundCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberToolchainClusterRemovedReason, err.Error())
 			toolchainStatus.Status.Members[index].MemberStatus = customMemberStatus(*memberStatusNotFoundCondition)

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller.go
@@ -399,7 +399,7 @@ func compareAndAssignMemberStatuses(reqLogger logr.Logger, toolchainStatus *tool
 		} else if memberStatus.UserAccountCount > 0 {
 			err := fmt.Errorf("ToolchainCluster CR wasn't found for member cluster `%s` that was previously registered in the host", memberStatus.ClusterName)
 			reqLogger.Error(err, "the member cluster seems to be removed")
-			memberStatusNotFoundCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberToolchainClusterRemovedReason, err.Error())
+			memberStatusNotFoundCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusMemberToolchainClusterMissingReason, err.Error())
 			toolchainStatus.Status.Members[index].MemberStatus = customMemberStatus(*memberStatusNotFoundCondition)
 			allOk = false
 		} else {

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -448,7 +448,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 				HasRegistrationServiceStatus(registrationServiceReady())
 		})
 
-		t.Run("ToolchainClustre CR of member clusters was removed", func(t *testing.T) {
+		t.Run("ToolchainCluster CR of member clusters was removed", func(t *testing.T) {
 			// given
 			defer counter.Reset()
 			toolchainStatus := NewToolchainStatus()

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -466,7 +466,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 			AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
 				HasConditions(componentsNotReady(string(memberConnectionsTag))).Exists().
 				HasHostOperatorStatus(hostOperatorStatusReady()).
-				HasMemberStatus(memberClusterSingleNotReady("member-cluster", "MemberToolchainClusterRemoved",
+				HasMemberStatus(memberClusterSingleNotReady("member-cluster", "MemberToolchainClusterMissing",
 					"ToolchainCluster CR wasn't found for member cluster `member-cluster` that was previously registered in the host", nil)).
 				HasRegistrationServiceStatus(registrationServiceReady())
 		})
@@ -603,7 +603,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 				AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
 					HasConditions(componentsNotReady(string(memberConnectionsTag))).
 					HasHostOperatorStatus(hostOperatorStatusReady()).
-					HasMemberStatus(memberClusterSingleReady(), memberClusterSingleNotReady("removed-cluster", "MemberToolchainClusterRemoved",
+					HasMemberStatus(memberClusterSingleReady(), memberClusterSingleNotReady("removed-cluster", "MemberToolchainClusterMissing",
 						"ToolchainCluster CR wasn't found for member cluster `removed-cluster` that was previously registered in the host", nil)).
 					HasRegistrationServiceStatus(registrationServiceReady())
 			})

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -433,8 +433,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 		t.Run("MemberStatus member clusters not found", func(t *testing.T) {
 			// given
 			defer counter.Reset()
-			memberStatus := newMemberStatusReady()
-			reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), newGetMemberClustersFuncEmpty, hostOperatorDeployment, memberStatus, registrationServiceDeployment, registrationService, toolchainStatus)
+			reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), newGetMemberClustersFuncEmpty, hostOperatorDeployment, registrationServiceDeployment, registrationService, toolchainStatus)
 
 			// when
 			res, err := reconciler.Reconcile(req)
@@ -445,7 +444,30 @@ func TestToolchainStatusConditions(t *testing.T) {
 			AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
 				HasConditions(componentsNotReady(string(memberConnectionsTag))).Exists().
 				HasHostOperatorStatus(hostOperatorStatusReady()).
-				HasMemberStatus(memberClusterSingleNotReady("", "NoMemberClustersFound", "no member clusters found", nil)).
+				HasMemberStatus().
+				HasRegistrationServiceStatus(registrationServiceReady())
+		})
+
+		t.Run("ToolchainClustre CR of member clusters was removed", func(t *testing.T) {
+			// given
+			defer counter.Reset()
+			toolchainStatus := NewToolchainStatus()
+			toolchainStatus.Status.Members = []toolchainv1alpha1.Member{
+				memberClusterSingleReady(),
+			}
+			reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), newGetMemberClustersFuncEmpty, hostOperatorDeployment, registrationServiceDeployment, registrationService, toolchainStatus)
+
+			// when
+			res, err := reconciler.Reconcile(req)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, requeueResult, res)
+			AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
+				HasConditions(componentsNotReady(string(memberConnectionsTag))).Exists().
+				HasHostOperatorStatus(hostOperatorStatusReady()).
+				HasMemberStatus(memberClusterSingleNotReady("member-cluster", "MemberToolchainClusterRemoved",
+					"ToolchainCluster CR wasn't found for member cluster `member-cluster` that was previously registered in the host", nil)).
 				HasRegistrationServiceStatus(registrationServiceReady())
 		})
 
@@ -582,7 +604,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 					HasConditions(componentsNotReady(string(memberConnectionsTag))).
 					HasHostOperatorStatus(hostOperatorStatusReady()).
 					HasMemberStatus(memberClusterSingleReady(), memberClusterSingleNotReady("removed-cluster", "MemberToolchainClusterRemoved",
-						"toolchainCluster not found for member cluster removed-cluster that was previously registered in the host", nil)).
+						"ToolchainCluster CR wasn't found for member cluster `removed-cluster` that was previously registered in the host", nil)).
 					HasRegistrationServiceStatus(registrationServiceReady())
 			})
 
@@ -666,7 +688,7 @@ func TestToolchainStatusReadyConditionTimestamps(t *testing.T) {
 		AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
 			HasConditions(componentsReady(), unreadyNotificationNotCreated()).
 			ReadyConditionLastUpdatedTimeNotEqual(before). // Last update timestamp updated
-			ReadyConditionLastTransitionTimeEqual(before)  // Last transition timestamp is not updated
+			ReadyConditionLastTransitionTimeEqual(before) // Last transition timestamp is not updated
 	})
 
 	t.Run("ready condition status has changed", func(t *testing.T) {
@@ -689,7 +711,7 @@ func TestToolchainStatusReadyConditionTimestamps(t *testing.T) {
 
 		AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
 			HasConditions(componentsNotReady(string(hostOperatorTag))).
-			ReadyConditionLastUpdatedTimeNotEqual(before).   // Last update timestamp updated
+			ReadyConditionLastUpdatedTimeNotEqual(before). // Last update timestamp updated
 			ReadyConditionLastTransitionTimeNotEqual(before) // Last transition timestamp is updated
 	})
 }
@@ -1294,6 +1316,7 @@ func memberClusterSingleReady() toolchainv1alpha1.Member {
 				Conditions:      []toolchainv1alpha1.Condition{ToBeReady()},
 			},
 		},
+		UserAccountCount: 10,
 	}
 }
 


### PR DESCRIPTION
fix: https://issues.redhat.com/browse/CRT-886

keep member status list empty when no member ToolchainCluster CR is present in the host cluster