### PR TITLE
Remove double // in reg-service health enpdoint URL

### DIFF
--- a/pkg/controller/toolchainstatus/toolchainstatus_controller.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller.go
@@ -44,7 +44,7 @@ var log = logf.Log.WithName("controller_toolchainstatus")
 const (
 	memberStatusName = "toolchain-member-status"
 
-	registrationServiceHealthEndpoint = "/api/v1/health"
+	registrationServiceHealthURL = "http://registration-service/api/v1/health"
 )
 
 // error messages
@@ -548,7 +548,6 @@ func (s regServiceSubstatusHandler) addRegistrationServiceDeploymentStatus(reqLo
 // addRegistrationServiceHealthStatus handles the RegistrationService.Health part of the toolchainstatus
 func (s regServiceSubstatusHandler) addRegistrationServiceHealthStatus(reqLogger logr.Logger, toolchainStatus *toolchainv1alpha1.ToolchainStatus) bool {
 	// get the JSON payload from the health endpoint
-	registrationServiceHealthURL := "http://registration-service/" + registrationServiceHealthEndpoint
 	resp, err := s.httpClientImpl.Get(registrationServiceHealthURL)
 	if err != nil {
 		reqLogger.Error(err, errMsgRegistrationServiceNotReady)

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -382,7 +382,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 				HasConditions(componentsNotReady(string(registrationServiceTag))).
 				HasHostOperatorStatus(hostOperatorStatusReady()).
 				HasMemberStatus(memberClusterSingleReady()).
-				HasRegistrationServiceStatus(registrationServiceHealthNotReady("bad response from http://registration-service//api/v1/health : statusCode=500"))
+				HasRegistrationServiceStatus(registrationServiceHealthNotReady("bad response from http://registration-service/api/v1/health : statusCode=500"))
 		})
 
 		t.Run("Registration health endpoint - invalid JSON", func(t *testing.T) {
@@ -688,7 +688,7 @@ func TestToolchainStatusReadyConditionTimestamps(t *testing.T) {
 		AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
 			HasConditions(componentsReady(), unreadyNotificationNotCreated()).
 			ReadyConditionLastUpdatedTimeNotEqual(before). // Last update timestamp updated
-			ReadyConditionLastTransitionTimeEqual(before) // Last transition timestamp is not updated
+			ReadyConditionLastTransitionTimeEqual(before)  // Last transition timestamp is not updated
 	})
 
 	t.Run("ready condition status has changed", func(t *testing.T) {
@@ -711,7 +711,7 @@ func TestToolchainStatusReadyConditionTimestamps(t *testing.T) {
 
 		AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
 			HasConditions(componentsNotReady(string(hostOperatorTag))).
-			ReadyConditionLastUpdatedTimeNotEqual(before). // Last update timestamp updated
+			ReadyConditionLastUpdatedTimeNotEqual(before).   // Last update timestamp updated
 			ReadyConditionLastTransitionTimeNotEqual(before) // Last transition timestamp is updated
 	})
 }


### PR DESCRIPTION
I see in the logs that the toolchainstatus controller calls `//api/v1/health` instead of `/api/v1/health`. This PR fixes it.