### PR TITLE
Wait for UserAccount to be deleted before deleting MUR

### DIFF
--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -296,7 +296,7 @@ func (r *ReconcileMasterUserRecord) manageCleanUp(logger logr.Logger, mur *toolc
 			"failed to update MasterUserRecord while deleting finalizer")
 	}
 	counter.DecrementMasterUserRecordCount(logger)
-	log.Info("Finalizer removed from MasterUserRecord")
+	logger.Info("Finalizer removed from MasterUserRecord")
 	return 0, nil
 }
 

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -127,9 +127,12 @@ func (r *ReconcileMasterUserRecord) Reconcile(request reconcile.Request) (reconc
 		}
 		// If the UserAccount is being deleted, delete the UserAccounts in members.
 	} else if coputil.HasFinalizer(mur, murFinalizerName) {
-		if err = r.manageCleanUp(logger, mur); err != nil {
-			logger.Error(err, "unable to clean up MasterUserRecord as part of deletion, sometimes this can happen because the deletion has not completed yet")
+		requeueTime, err := r.manageCleanUp(logger, mur)
+		if err != nil {
+			logger.Error(err, "unable to clean up MasterUserRecord as part of deletion")
 			return reconcile.Result{}, err
+		} else if requeueTime > 0 {
+			return reconcile.Result{Requeue: true, RequeueAfter: requeueTime}, err
 		}
 	}
 
@@ -276,58 +279,61 @@ func (r *ReconcileMasterUserRecord) useExistingConditionOfType(condType toolchai
 	}
 }
 
-func (r *ReconcileMasterUserRecord) manageCleanUp(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord) error {
+func (r *ReconcileMasterUserRecord) manageCleanUp(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord) (time.Duration, error) {
 	for _, ua := range mur.Spec.UserAccounts {
-		if err := r.deleteUserAccount(logger, ua.TargetCluster, mur.Name); err != nil {
-			return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToDeleteUserAccountsReason), err,
+		requeueTime, err := r.deleteUserAccount(logger, ua.TargetCluster, mur.Name)
+		if err != nil {
+			logger.Error(err, "unable to clean up MasterUserRecord as part of deletion")
+			return 0, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToDeleteUserAccountsReason), err,
 				"failed to delete UserAccount in the member cluster '%s'", ua.TargetCluster)
+		} else if requeueTime > 0 {
+			return requeueTime, nil
 		}
 	}
 	// Remove finalizer from MasterUserRecord
 	coputil.RemoveFinalizer(mur, murFinalizerName)
 	if err := r.client.Update(context.Background(), mur); err != nil {
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToRemoveFinalizerReason), err,
+		return 0, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToRemoveFinalizerReason), err,
 			"failed to update MasterUserRecord while deleting finalizer")
 	}
 	counter.DecrementMasterUserRecordCount(logger)
 	log.Info("Finalizer removed from MasterUserRecord")
-	return nil
+	return 0, nil
 }
 
-func (r *ReconcileMasterUserRecord) deleteUserAccount(logger logr.Logger, targetCluster, name string) error {
+func (r *ReconcileMasterUserRecord) deleteUserAccount(logger logr.Logger, targetCluster, name string) (time.Duration, error) {
+	requeueTime := 10 * time.Second
 	// get & check member cluster
 	memberCluster, err := r.getMemberCluster(targetCluster)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	// Get the User associated with the UserAccount
 	userAcc := &toolchainv1alpha1.UserAccount{}
 	namespacedName := types.NamespacedName{Namespace: memberCluster.OperatorNamespace, Name: name}
 	if err = memberCluster.Client.Get(context.TODO(), namespacedName, userAcc); err != nil {
 		if errors.IsNotFound(err) {
-			return nil
+			log.Info("UserAccount deleted")
+			return 0, nil
 		}
-		return err
+		return 0, err
 	}
 
 	if coputil.IsBeingDeleted(userAcc) {
-		return fmt.Errorf("UserAccount deletion in progress")
+		// if the UserAccount is being deleted, allow up to 1 minute of retries before reporting an error
+		deletionTimestamp := userAcc.GetDeletionTimestamp()
+		if time.Since(deletionTimestamp.Time) > 60*time.Second {
+			return 0, fmt.Errorf("UserAccount deletion has not completed in over 1 minute")
+		}
+		return requeueTime, nil
 	}
 
 	if err := memberCluster.Client.Delete(context.TODO(), userAcc); err != nil {
-		return err
+		return requeueTime, err
 	}
 	counter.DecrementUserAccountCount(logger, targetCluster)
 
-	// Verify the UserAccount is deleted
-	userAcc = &toolchainv1alpha1.UserAccount{}
-	if err = memberCluster.Client.Get(context.TODO(), namespacedName, userAcc); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	return fmt.Errorf("waiting for UserAccount deletion") // return error to reconcile again and wait for deletion
+	return requeueTime, nil
 }
 
 func toBeProvisioned() toolchainv1alpha1.Condition {

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -328,7 +328,7 @@ func (r *ReconcileMasterUserRecord) deleteUserAccount(logger logr.Logger, target
 	}
 
 	if err := memberCluster.Client.Delete(context.TODO(), userAcc); err != nil {
-		return requeueTime, err
+		return 0, err
 	}
 	counter.DecrementUserAccountCount(logger, targetCluster)
 

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -313,7 +313,7 @@ func (r *ReconcileMasterUserRecord) deleteUserAccount(logger logr.Logger, target
 	namespacedName := types.NamespacedName{Namespace: memberCluster.OperatorNamespace, Name: name}
 	if err = memberCluster.Client.Get(context.TODO(), namespacedName, userAcc); err != nil {
 		if errors.IsNotFound(err) {
-			log.Info("UserAccount deleted")
+			logger.Info("UserAccount deleted")
 			return 0, nil
 		}
 		return 0, err

--- a/pkg/controller/masteruserrecord/masteruserrecord_controller.go
+++ b/pkg/controller/masteruserrecord/masteruserrecord_controller.go
@@ -283,7 +283,6 @@ func (r *ReconcileMasterUserRecord) manageCleanUp(logger logr.Logger, mur *toolc
 	for _, ua := range mur.Spec.UserAccounts {
 		requeueTime, err := r.deleteUserAccount(logger, ua.TargetCluster, mur.Name)
 		if err != nil {
-			logger.Error(err, "unable to clean up MasterUserRecord as part of deletion")
 			return 0, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToDeleteUserAccountsReason), err,
 				"failed to delete UserAccount in the member cluster '%s'", ua.TargetCluster)
 		} else if requeueTime > 0 {


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/CRT-892

The MasterUserRecord was being deleted even if there was a failure deleting the related UserAccount(s). This change updates the logic related to deleting user accounts to verify the deletion is completed before continuing with the MasterUserRecord deletion.

With the change the MasterUserRecord would not be deleted and would propagate the error correctly.
eg.
```
status:
  conditions:
  - lastTransitionTime: "2020-12-11T01:36:17Z"
    message: waiting for UserAccount deletion
    reason: UnableToDeleteUserAccounts
    status: "False"
    type: Ready
```

Related e2e PR to make tests pass:
https://github.com/codeready-toolchain/toolchain-e2e/pull/218