### PR TITLE
User namespace networking

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -130,12 +130,12 @@ objects:
     name: allow-from-dev-namespace
     namespace: ${USERNAME}-code
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -144,12 +144,12 @@ objects:
     name: allow-from-stage-namespace
     namespace: ${USERNAME}-code
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -127,7 +127,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-dev-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-code
   spec:
     ingress:
@@ -135,17 +135,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-stage-namespace
-    namespace: ${USERNAME}-code
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage

--- a/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -11,6 +11,8 @@ objects:
       openshift.io/description: ${USERNAME}-code
       openshift.io/display-name: ${USERNAME}-code
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-code
     name: ${USERNAME}-code
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -120,6 +122,34 @@ objects:
               matchLabels:
                 network.openshift.io/policy-group: codeready-workspaces
     podSelector: {}
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-dev-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-stage-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
@@ -112,7 +112,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-code-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-dev
   spec:
     ingress:
@@ -120,17 +120,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-stage-namespace
-    namespace: ${USERNAME}-dev
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage

--- a/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
@@ -10,6 +10,8 @@ objects:
       openshift.io/description: ${USERNAME}-dev
       openshift.io/display-name: ${USERNAME}-dev
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-dev
     name: ${USERNAME}-dev
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -107,6 +109,34 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-code-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-code
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-stage-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
+    policyTypes:
+      - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_dev.yaml
@@ -115,12 +115,12 @@ objects:
     name: allow-from-code-namespace
     namespace: ${USERNAME}-dev
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -129,12 +129,12 @@ objects:
     name: allow-from-stage-namespace
     namespace: ${USERNAME}-dev
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
@@ -10,6 +10,8 @@ objects:
       openshift.io/description: ${USERNAME}-stage
       openshift.io/display-name: ${USERNAME}-stage
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-stage
     name: ${USERNAME}-stage
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -107,6 +109,34 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-code-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-code
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-dev-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+    policyTypes:
+      - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
@@ -112,7 +112,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-code-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-stage
   spec:
     ingress:
@@ -120,17 +120,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-dev-namespace
-    namespace: ${USERNAME}-stage
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev

--- a/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
@@ -115,12 +115,12 @@ objects:
     name: allow-from-code-namespace
     namespace: ${USERNAME}-stage
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -129,12 +129,12 @@ objects:
     name: allow-from-dev-namespace
     namespace: ${USERNAME}-stage
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_code.yaml
@@ -130,12 +130,12 @@ objects:
     name: allow-from-dev-namespace
     namespace: ${USERNAME}-code
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -144,12 +144,12 @@ objects:
     name: allow-from-stage-namespace
     namespace: ${USERNAME}-code
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_code.yaml
@@ -127,7 +127,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-dev-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-code
   spec:
     ingress:
@@ -135,17 +135,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-stage-namespace
-    namespace: ${USERNAME}-code
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage

--- a/deploy/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_code.yaml
@@ -11,6 +11,8 @@ objects:
       openshift.io/description: ${USERNAME}-code
       openshift.io/display-name: ${USERNAME}-code
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-code
     name: ${USERNAME}-code
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -120,6 +122,34 @@ objects:
               matchLabels:
                 network.openshift.io/policy-group: codeready-workspaces
     podSelector: {}
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-dev-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-stage-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
@@ -112,7 +112,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-code-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-dev
   spec:
     ingress:
@@ -120,17 +120,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-stage-namespace
-    namespace: ${USERNAME}-dev
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage

--- a/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
@@ -10,6 +10,8 @@ objects:
       openshift.io/description: ${USERNAME}-dev
       openshift.io/display-name: ${USERNAME}-dev
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-dev
     name: ${USERNAME}-dev
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -107,6 +109,34 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-code-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-code
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-stage-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
+    policyTypes:
+      - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_dev.yaml
@@ -115,12 +115,12 @@ objects:
     name: allow-from-code-namespace
     namespace: ${USERNAME}-dev
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -129,12 +129,12 @@ objects:
     name: allow-from-stage-namespace
     namespace: ${USERNAME}-dev
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
@@ -10,6 +10,8 @@ objects:
       openshift.io/description: ${USERNAME}-stage
       openshift.io/display-name: ${USERNAME}-stage
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-stage
     name: ${USERNAME}-stage
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -107,6 +109,34 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-code-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-code
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-dev-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+    policyTypes:
+      - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
@@ -112,7 +112,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-code-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-stage
   spec:
     ingress:
@@ -120,17 +120,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-dev-namespace
-    namespace: ${USERNAME}-stage
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev

--- a/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
@@ -115,12 +115,12 @@ objects:
     name: allow-from-code-namespace
     namespace: ${USERNAME}-stage
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -129,12 +129,12 @@ objects:
     name: allow-from-dev-namespace
     namespace: ${USERNAME}-stage
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_code.yaml
@@ -130,12 +130,12 @@ objects:
     name: allow-from-dev-namespace
     namespace: ${USERNAME}-code
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -144,12 +144,12 @@ objects:
     name: allow-from-stage-namespace
     namespace: ${USERNAME}-code
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_code.yaml
@@ -127,7 +127,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-dev-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-code
   spec:
     ingress:
@@ -135,17 +135,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-stage-namespace
-    namespace: ${USERNAME}-code
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_code.yaml
@@ -11,6 +11,8 @@ objects:
       openshift.io/description: ${USERNAME}-code
       openshift.io/display-name: ${USERNAME}-code
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-code
     name: ${USERNAME}-code
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -120,6 +122,34 @@ objects:
               matchLabels:
                 network.openshift.io/policy-group: codeready-workspaces
     podSelector: {}
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-dev-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-stage-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_dev.yaml
@@ -112,7 +112,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-code-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-dev
   spec:
     ingress:
@@ -120,17 +120,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-stage-namespace
-    namespace: ${USERNAME}-dev
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_dev.yaml
@@ -10,6 +10,8 @@ objects:
       openshift.io/description: ${USERNAME}-dev
       openshift.io/display-name: ${USERNAME}-dev
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-dev
     name: ${USERNAME}-dev
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -107,6 +109,34 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-code-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-code
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-stage-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
+    policyTypes:
+      - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_dev.yaml
@@ -115,12 +115,12 @@ objects:
     name: allow-from-code-namespace
     namespace: ${USERNAME}-dev
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -129,12 +129,12 @@ objects:
     name: allow-from-stage-namespace
     namespace: ${USERNAME}-dev
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
@@ -10,6 +10,8 @@ objects:
       openshift.io/description: ${USERNAME}-stage
       openshift.io/display-name: ${USERNAME}-stage
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-stage
     name: ${USERNAME}-stage
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -107,6 +109,34 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-code-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-code
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-dev-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+    policyTypes:
+      - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
@@ -112,7 +112,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-code-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-stage
   spec:
     ingress:
@@ -120,17 +120,6 @@ objects:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
-    podSelector: {}
-    policyTypes:
-      - Ingress
-- apiVersion: networking.k8s.io/v1
-  kind: NetworkPolicy
-  metadata:
-    name: allow-from-dev-namespace
-    namespace: ${USERNAME}-stage
-  spec:
-    ingress:
-      - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
@@ -115,12 +115,12 @@ objects:
     name: allow-from-code-namespace
     namespace: ${USERNAME}-stage
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-code
+    podSelector: {}
     policyTypes:
       - Ingress
 - apiVersion: networking.k8s.io/v1
@@ -129,12 +129,12 @@ objects:
     name: allow-from-dev-namespace
     namespace: ${USERNAME}-stage
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_dev.yaml
@@ -115,12 +115,12 @@ objects:
     name: allow-from-stage-namespace
     namespace: ${USERNAME}-dev
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-stage
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_dev.yaml
@@ -10,6 +10,8 @@ objects:
       openshift.io/description: ${USERNAME}-dev
       openshift.io/display-name: ${USERNAME}-dev
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-dev
     name: ${USERNAME}-dev
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -107,6 +109,20 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-stage-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
+    policyTypes:
+      - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_dev.yaml
@@ -112,7 +112,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-stage-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-dev
   spec:
     ingress:

--- a/deploy/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_stage.yaml
@@ -10,6 +10,8 @@ objects:
       openshift.io/description: ${USERNAME}-stage
       openshift.io/display-name: ${USERNAME}-stage
       openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-stage
     name: ${USERNAME}-stage
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -107,6 +109,20 @@ objects:
     podSelector: {}
     policyTypes:
     - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-dev-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+    policyTypes:
+      - Ingress
 parameters:
 - name: USERNAME
   required: true

--- a/deploy/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_stage.yaml
@@ -115,12 +115,12 @@ objects:
     name: allow-from-dev-namespace
     namespace: ${USERNAME}-stage
   spec:
-    podSelector: {}
     ingress:
       - from:
         - namespaceSelector:
             matchLabels:
               name: ${USERNAME}-dev
+    podSelector: {}
     policyTypes:
       - Ingress
 parameters:

--- a/deploy/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/team/ns_stage.yaml
@@ -112,7 +112,7 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
-    name: allow-from-dev-namespace
+    name: allow-from-other-user-namespaces
     namespace: ${USERNAME}-stage
   spec:
     ingress:

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -413,14 +413,17 @@ func assertNamespaceTemplate(t *testing.T, decoder runtime.Decoder, actual templ
 	// Each template should have one Namespace, one RoleBinding, one LimitRange and a varying number of NetworkPolicy objects depending on the namespace kind
 
 	// Template objects count
-	if tier == "team" {
+	switch tier {
+	case "team":
 		require.Len(t, actual.Objects, 9)
-	} else {
+	case "basic", "basicdeactivationdisabled", "advanced":
 		if kind == "code" {
 			require.Len(t, actual.Objects, 11)
 		} else {
 			require.Len(t, actual.Objects, 10)
 		}
+	default:
+		require.Fail(t, "unexpected tier: '%s'", tier)
 	}
 
 	// Namespace

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -410,7 +410,7 @@ func assertNamespaceTemplate(t *testing.T, decoder runtime.Decoder, actual templ
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
 	// Assert expected objects in the template
-	// Each template should have one Namespace, one RoleBinding, one LimitRange and a verying number of NetworkPolicy objects depending on the namespace kind
+	// Each template should have one Namespace, one RoleBinding, one LimitRange and a varying number of NetworkPolicy objects depending on the namespace kind
 
 	// Template objects count
 	if tier == "team" {

--- a/test/templates/nstemplatetiers/advanced/ns_code.yaml
+++ b/test/templates/nstemplatetiers/advanced/ns_code.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-code
     name: ${USERNAME}-code
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/advanced/ns_dev.yaml
+++ b/test/templates/nstemplatetiers/advanced/ns_dev.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-dev
     name: ${USERNAME}-dev
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/advanced/ns_stage.yaml
+++ b/test/templates/nstemplatetiers/advanced/ns_stage.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-stage
     name: ${USERNAME}-stage
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/basic/ns_code.yaml
+++ b/test/templates/nstemplatetiers/basic/ns_code.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-code
     name: ${USERNAME}-code
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/basic/ns_dev.yaml
+++ b/test/templates/nstemplatetiers/basic/ns_dev.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-dev
     name: ${USERNAME}-dev
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/basic/ns_stage.yaml
+++ b/test/templates/nstemplatetiers/basic/ns_stage.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-stage
     name: ${USERNAME}-stage
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/nocluster/ns_code.yaml
+++ b/test/templates/nstemplatetiers/nocluster/ns_code.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-code
     name: ${USERNAME}-code
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/nocluster/ns_dev.yaml
+++ b/test/templates/nstemplatetiers/nocluster/ns_dev.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-dev
     name: ${USERNAME}-dev
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/nocluster/ns_stage.yaml
+++ b/test/templates/nstemplatetiers/nocluster/ns_stage.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-stage
     name: ${USERNAME}-stage
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/team/ns_dev.yaml
+++ b/test/templates/nstemplatetiers/team/ns_dev.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-dev
     name: ${USERNAME}-dev
 parameters:
 - name: USERNAME

--- a/test/templates/nstemplatetiers/team/ns_stage.yaml
+++ b/test/templates/nstemplatetiers/team/ns_stage.yaml
@@ -14,6 +14,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${USERNAME}-stage
     name: ${USERNAME}-stage
 parameters:
 - name: USERNAME


### PR DESCRIPTION
Adds network policies that allow connections between all namespaces belonging to a user but not from other user's namespaces.

- Adds a new `name` label for each user namespace that will be used for the network selector in the NetworkPolicy
- Adds a NetworkPolicy for each of the user namespaces to allow connections from each of the other namespaces belonging to the same user

Note: I manually verified connectivity between each of the namespace types and also verified other namespaces cannot access the user's namespace.

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/222

Related issue: https://issues.redhat.com/browse/CRT-819