### PR TITLE
fix: prevent redhat and default prefixes

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -98,7 +98,7 @@ const (
 	// username has a forbidden prefix, then the username compliance prefix is added to the username
 	varForbiddenUsernamePrefixes = "username.forbidden.prefixes"
 
-	DefaultForbiddenUsernamePrefixes = "openshift,kubernetes,kube-"
+	DefaultForbiddenUsernamePrefixes = "openshift,kube,default,redhat"
 )
 
 // Config encapsulates the Viper configuration registry which stores the

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -294,8 +294,9 @@ func TestForbiddenUsernamePrefixesHaveCorrectDefaults(t *testing.T) {
 	defer restore()
 
 	config := getDefaultConfiguration(t)
-	require.Len(t, config.GetForbiddenUsernamePrefixes(), 3)
+	require.Len(t, config.GetForbiddenUsernamePrefixes(), 4)
 	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "openshift")
-	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "kubernetes")
-	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "kube-")
+	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "kube")
+	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "default")
+	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "redhat")
 }

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -2184,33 +2184,35 @@ func TestUsernameWithForbiddenPrefix(t *testing.T) {
 	defer counter.Reset()
 
 	// Confirm we have 3 forbidden prefixes by default
-	require.Len(t, config.GetForbiddenUsernamePrefixes(), 3)
-	names := []string{"-Bob", "-Dave", "Linda"}
+	require.Len(t, config.GetForbiddenUsernamePrefixes(), 4)
+	names := []string{"-Bob", "-Dave", "Linda", ""}
 
-	for i, prefix := range config.GetForbiddenUsernamePrefixes() {
+	for _, prefix := range config.GetForbiddenUsernamePrefixes() {
 		userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
 		userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "not-ready"
 
-		userSignup.Spec.Username = fmt.Sprintf("%s%s", prefix, names[i])
+		for _, name := range names {
+			userSignup.Spec.Username = fmt.Sprintf("%s%s", prefix, name)
 
-		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
+			r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
 
-		// when
-		_, err := r.Reconcile(req)
-		require.NoError(t, err)
+			// when
+			_, err := r.Reconcile(req)
+			require.NoError(t, err)
 
-		// then verify that the username has been prefixed - first lookup the UserSignup again
-		err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
-		require.NoError(t, err)
+			// then verify that the username has been prefixed - first lookup the UserSignup again
+			err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
+			require.NoError(t, err)
 
-		// Lookup the MUR
-		murs := &v1alpha1.MasterUserRecordList{}
-		err = r.client.List(context.TODO(), murs, client.InNamespace(test.HostOperatorNs))
-		require.NoError(t, err)
-		require.Len(t, murs.Items, 1)
-		mur := murs.Items[0]
-		require.Equal(t, userSignup.Name, mur.Labels[v1alpha1.MasterUserRecordUserIDLabelKey])
-		require.Equal(t, fmt.Sprintf("crt-%s%s", prefix, names[i]), mur.Name)
+			// Lookup the MUR
+			murs := &v1alpha1.MasterUserRecordList{}
+			err = r.client.List(context.TODO(), murs, client.InNamespace(test.HostOperatorNs))
+			require.NoError(t, err)
+			require.Len(t, murs.Items, 1)
+			mur := murs.Items[0]
+			require.Equal(t, userSignup.Name, mur.Labels[v1alpha1.MasterUserRecordUserIDLabelKey])
+			require.Equal(t, fmt.Sprintf("crt-%s%s", prefix, name), mur.Name)
+		}
 
 	}
 }


### PR DESCRIPTION
prevent from creating `redhat` & `default` prefixes
```
Customer workloads should be placed in customer namespaces, and should not match this regular expression: (^kube.*|^openshift.*|^default$|^redhat.*)
```
I know that the `default` is not a prefix, but it's easier to implement and doesn't hurt us :-) 

paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/223