### PR TITLE
Populate UserSignup.Spec.UserID, and use to create MUR

### DIFF
--- a/pkg/controller/usersignup/masteruserrecord.go
+++ b/pkg/controller/usersignup/masteruserrecord.go
@@ -39,7 +39,8 @@ func migrateOrFixMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, nstempl
 	return changed, nil
 }
 
-func newMasterUserRecord(nstemplateTier *toolchainv1alpha1.NSTemplateTier, name, namespace, targetCluster, userSignupName string) (*toolchainv1alpha1.MasterUserRecord, error) {
+func newMasterUserRecord(nstemplateTier *toolchainv1alpha1.NSTemplateTier, name, namespace, targetCluster,
+	userSignupName, userID string) (*toolchainv1alpha1.MasterUserRecord, error) {
 	userAccounts := []toolchainv1alpha1.UserAccountEmbedded{
 		{
 			TargetCluster: targetCluster,
@@ -68,7 +69,7 @@ func newMasterUserRecord(nstemplateTier *toolchainv1alpha1.NSTemplateTier, name,
 		},
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
 			UserAccounts: userAccounts,
-			UserID:       userSignupName,
+			UserID:       userID,
 		},
 	}
 	return mur, nil

--- a/pkg/controller/usersignup/masteruserrecord_test.go
+++ b/pkg/controller/usersignup/masteruserrecord_test.go
@@ -18,7 +18,8 @@ func TestNewMasterUserRecord(t *testing.T) {
 		nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
 
 		// when
-		mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
+		mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName,
+			"123456789", "UserID123")
 
 		// then
 		require.NoError(t, err)
@@ -31,7 +32,8 @@ func TestNewMasterUserRecord(t *testing.T) {
 		nsTemplateTier.Spec.ClusterResources = nil
 
 		// when
-		mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
+		mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName,
+			"123456789", "UserID123")
 
 		// then
 		require.NoError(t, err)
@@ -75,7 +77,8 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when mur is the same", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName,
+				"123456789", "UserID123")
 			require.NoError(t, err)
 
 			// when
@@ -90,7 +93,8 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when one namespace is missing and one is extra, but rest is fine, then doesn't change", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName,
+				"123456789", "UserID123")
 			require.NoError(t, err)
 			mur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces[0].TemplateRef = "advanced-cicd-123abc1"
 			providedMur := mur.DeepCopy()
@@ -110,7 +114,8 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when mur is missing NsLimit", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName,
+				"123456789", "UserID123")
 			require.NoError(t, err)
 			mur.Spec.UserAccounts[0].Spec.NSLimit = ""
 
@@ -126,7 +131,8 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when whole NSTemplateSet is missing", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName,
+				"123456789", "UserID123")
 			require.NoError(t, err)
 			mur.Spec.UserAccounts[0].Spec.NSTemplateSet = v1alpha1.NSTemplateSetSpec{}
 
@@ -142,7 +148,8 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 		t.Run("when tier labels are missing", func(t *testing.T) {
 			// given
 			nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
-			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName, "123456789")
+			mur, err := newMasterUserRecord(nsTemplateTier, "johny", test.HostOperatorNs, test.MemberClusterName,
+				"123456789", "UserID123")
 			delete(mur.Labels, "toolchain.dev.openshift.com/advanced-tier-hash") // removed for the purpose of this test
 			require.NoError(t, err)
 
@@ -190,7 +197,7 @@ func newExpectedMur(tier v1alpha1.NSTemplateTier) v1alpha1.MasterUserRecord {
 			},
 		},
 		Spec: v1alpha1.MasterUserRecordSpec{
-			UserID:        "123456789",
+			UserID:        "UserID123",
 			Banned:        false,
 			Disabled:      false,
 			Deprovisioned: false,

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -1267,6 +1267,7 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "john.doe@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
+			UserID:      "UserID123",
 			Username:    "john.doe@redhat.com",
 			Deactivated: true,
 		},
@@ -1297,7 +1298,8 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 		// given
 		InitializeCounter(t, 2)
 		defer counter.Reset()
-		r, req, cl := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), basicNSTemplateTier)
+		r, req, cl := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup,
+			NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), basicNSTemplateTier)
 
 		cl.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 			switch obj.(type) {
@@ -1355,6 +1357,7 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "john.doe@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
+			UserID:      "UserID123",
 			Username:    "john.doe@redhat.com",
 			Deactivated: false,
 		},
@@ -1511,6 +1514,7 @@ func TestUserSignupDeactivatingWhenMURExists(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "edward.jones@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
+			UserID:      "UserID123",
 			Username:    "edward.jones@redhat.com",
 			Deactivated: true,
 		},
@@ -1848,6 +1852,7 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "alice.mayweather.doe@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
+			UserID:      "UserID123",
 			Username:    "alice.mayweather.doe@redhat.com",
 			Deactivated: true,
 		},
@@ -2320,7 +2325,8 @@ func TestMigrateMur(t *testing.T) {
 	InitializeCounter(t, 0)
 	defer counter.Reset()
 	userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
-	mur, err := newMasterUserRecord(basicNSTemplateTier, "foo", test.HostOperatorNs, "east", userSignup.Name)
+	mur, err := newMasterUserRecord(basicNSTemplateTier, "foo", test.HostOperatorNs, "east",
+		userSignup.Name, userSignup.Spec.UserID)
 	require.NoError(t, err)
 
 	// set NSLimit and NSTemplateSet to be empty

--- a/test/usersignup.go
+++ b/test/usersignup.go
@@ -61,6 +61,7 @@ func NewUserSignup(modifiers ...UserSignupModifier) *v1alpha1.UserSignup {
 	signup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "foo@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
+			UserID:   "UserID123",
 			Username: "foo@redhat.com",
 		},
 	}


### PR DESCRIPTION
This PR is step 3 of the changes required for CRT-915.  It populates the UserSignup.Spec.UserID property from the UserSignup.Name, and uses this new property value when creating new MasterUserRecord instances

Fixes https://issues.redhat.com/browse/CRT-915