### PR TITLE
chore: prevent from creating sandbox* users

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -98,7 +98,7 @@ const (
 	// username has a forbidden prefix, then the username compliance prefix is added to the username
 	varForbiddenUsernamePrefixes = "username.forbidden.prefixes"
 
-	DefaultForbiddenUsernamePrefixes = "openshift,kube,default,redhat"
+	DefaultForbiddenUsernamePrefixes = "openshift,kube,default,redhat,sandbox"
 )
 
 // Config encapsulates the Viper configuration registry which stores the

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -294,9 +294,10 @@ func TestForbiddenUsernamePrefixesHaveCorrectDefaults(t *testing.T) {
 	defer restore()
 
 	config := getDefaultConfiguration(t)
-	require.Len(t, config.GetForbiddenUsernamePrefixes(), 4)
+	require.Len(t, config.GetForbiddenUsernamePrefixes(), 5)
 	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "openshift")
 	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "kube")
 	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "default")
 	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "redhat")
+	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "sandbox")
 }

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -186,7 +186,7 @@ func (s *Synchronizer) alignReadiness() (bool, error) {
 		notification := &toolchainv1alpha1.Notification{
 			ObjectMeta: v1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-%s-", s.record.Name, toolchainv1alpha1.NotificationTypeProvisioned),
-				Namespace: s.record.Namespace,
+				Namespace:    s.record.Namespace,
 				Labels: map[string]string{
 					// NotificationUserNameLabelKey is only used for easy lookup for debugging and e2e tests
 					toolchainv1alpha1.NotificationUserNameLabelKey: s.record.Name,

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -2197,8 +2197,8 @@ func TestUsernameWithForbiddenPrefix(t *testing.T) {
 	defer counter.Reset()
 
 	// Confirm we have 3 forbidden prefixes by default
-	require.Len(t, config.GetForbiddenUsernamePrefixes(), 4)
-	names := []string{"-Bob", "-Dave", "Linda", ""}
+	require.Len(t, config.GetForbiddenUsernamePrefixes(), 5)
+	names := []string{"-Bob", "-Dave", "Linda", "admin", ""}
 
 	for _, prefix := range config.GetForbiddenUsernamePrefixes() {
 		userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))


### PR DESCRIPTION
Since we have dedicated admin users with `sandbox-` prefix, we need to prevent from creating such users via provisioning flow.

paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/230