### PR TITLE
chore: formatting & flaky deactivation test

### DIFF
--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -65,7 +65,7 @@ func TestReconcile(t *testing.T) {
 			expectedTime := (time.Duration(expectedDeactivationTimeoutBasicTier*24) * time.Hour) - timeSinceProvisioned
 			actualTime := res.RequeueAfter
 			diff := expectedTime - actualTime
-			require.Truef(t, diff > 0 && diff < time.Second, "expectedTime: '%v' is not within 1 second of actualTime: '%v' diff: '%v'", expectedTime, actualTime, diff)
+			require.Truef(t, diff > 0 && diff < 2*time.Second, "expectedTime: '%v' is not within 2 seconds of actualTime: '%v' diff: '%v'", expectedTime, actualTime, diff)
 			assertThatUserSignupDeactivated(t, cl, username, false)
 		})
 
@@ -83,7 +83,7 @@ func TestReconcile(t *testing.T) {
 			expectedTime := (time.Duration(expectedDeactivationTimeoutOtherTier*24) * time.Hour) - timeSinceProvisioned
 			actualTime := res.RequeueAfter
 			diff := expectedTime - actualTime
-			require.Truef(t, diff > 0 && diff < time.Second, "expectedTime: '%v' is not within 1 second of actualTime: '%v' diff: '%v'", expectedTime, actualTime, diff)
+			require.Truef(t, diff > 0 && diff < 2*time.Second, "expectedTime: '%v' is not within 2 seconds of actualTime: '%v' diff: '%v'", expectedTime, actualTime, diff)
 			assertThatUserSignupDeactivated(t, cl, username, false)
 		})
 

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -186,7 +186,7 @@ func (s *Synchronizer) alignReadiness() (bool, error) {
 		notification := &toolchainv1alpha1.Notification{
 			ObjectMeta: v1.ObjectMeta{
 				GenerateName: fmt.Sprintf("%s-%s-", s.record.Name, toolchainv1alpha1.NotificationTypeProvisioned),
-				Namespace: s.record.Namespace,
+				Namespace:    s.record.Namespace,
 				Labels: map[string]string{
 					// NotificationUserNameLabelKey is only used for easy lookup for debugging and e2e tests
 					toolchainv1alpha1.NotificationUserNameLabelKey: s.record.Name,


### PR DESCRIPTION
fix formatting in `sync.go`
increase the time cushion in the deactivation test - it happened to me that it failed when running the test from that repo but without changing the logic. My PC is maybe just too slow :grimacing: 