### PR TITLE
Cleanup temporary code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210115184740-77f08aa35c87
+	github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/api v0.0.0-20210115184740-77f08aa35c87 h1:jUqvvFYZYeD6Hcs4zEv5+oppXaxeIgGQn3YJd1DQDg0=
 github.com/codeready-toolchain/api v0.0.0-20210115184740-77f08aa35c87/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101 h1:oKHlw3jQXcMX8AbAlCdzn8ZS58jnGtjT7ItG5oaistM=
+github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff h1:vBNOeBFLOFJm8Eb3KTGNUqMHUPF/TBPF6ZT2y+izHTs=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff/go.mod h1:TC5Q5FtNUwzpHNMLAkJXaxkifHwPJlZtrvnTWKIY+2M=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -103,7 +103,7 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 	usersignup := &toolchainv1alpha1.UserSignup{}
 	if err := r.client.Get(context.TODO(), types.NamespacedName{
 		Namespace: mur.Namespace,
-		Name:      mur.Spec.UserID,
+		Name:      mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey],
 	}, usersignup); err != nil {
 		// Error getting usersignup - requeue the request.
 		return reconcile.Result{}, err

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -56,6 +56,7 @@ func TestReconcile(t *testing.T) {
 			// given
 			murProvisionedTime := metav1.Now()
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(&murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupFoobar.Name
 			r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupFoobar)
 			// when
 			timeSinceProvisioned := time.Since(murProvisionedTime.Time)
@@ -74,6 +75,7 @@ func TestReconcile(t *testing.T) {
 			// given
 			murProvisionedTime := metav1.Now()
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *otherTier), murtest.ProvisionedMur(&murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupFoobar.Name
 			r, req, cl := prepareReconcile(t, mur.Name, otherTier, mur, userSignupFoobar)
 			// when
 			timeSinceProvisioned := time.Since(murProvisionedTime.Time)
@@ -92,6 +94,7 @@ func TestReconcile(t *testing.T) {
 			// given
 			murProvisionedTime := metav1.Now()
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *noDeactivationTier), murtest.ProvisionedMur(&murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupFoobar.Name
 			r, req, cl := prepareReconcile(t, mur.Name, noDeactivationTier, mur, userSignupFoobar)
 			// when
 			res, err := r.Reconcile(req)
@@ -123,6 +126,7 @@ func TestReconcile(t *testing.T) {
 			defer restore()
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutBasicTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupRedhat))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupRedhat.Name
 			r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupRedhat)
 			// when
 			res, err := r.Reconcile(req)
@@ -141,6 +145,7 @@ func TestReconcile(t *testing.T) {
 			// given
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutBasicTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupFoobar.Name
 			r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupFoobar)
 			// when
 			res, err := r.Reconcile(req)
@@ -166,6 +171,7 @@ func TestReconcile(t *testing.T) {
 			// given
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutOtherTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *otherTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupFoobar.Name
 			r, req, cl := prepareReconcile(t, mur.Name, otherTier, mur, userSignupFoobar)
 			// when
 			res, err := r.Reconcile(req)
@@ -186,6 +192,7 @@ func TestReconcile(t *testing.T) {
 			// given
 			murProvisionedTime := metav1.Now()
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(&murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupFoobar.Name
 			r, req, cl := prepareReconcile(t, mur.Name, mur, userSignupFoobar)
 			// when
 			_, err := r.Reconcile(req)
@@ -200,6 +207,7 @@ func TestReconcile(t *testing.T) {
 			// given
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutBasicTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupFoobar.Name
 			r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupFoobar)
 			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
 				_, ok := obj.(*toolchainv1alpha1.UserSignup)
@@ -227,6 +235,7 @@ func TestReconcile(t *testing.T) {
 			// given
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutBasicTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *basicTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
+			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignupFoobar.Name
 			r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupFoobar)
 			cl.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 				_, ok := obj.(*toolchainv1alpha1.UserSignup)
@@ -294,6 +303,7 @@ func userSignupWithEmail(username, email string) *toolchainv1alpha1.UserSignup {
 			Username:      email,
 			Approved:      true,
 			TargetCluster: "east",
+			UserID:        username,
 		},
 	}
 }

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -195,7 +195,7 @@ func (s *Synchronizer) alignReadiness() (bool, error) {
 				},
 			},
 			Spec: toolchainv1alpha1.NotificationSpec{
-				UserID:   s.record.Spec.UserID,
+				UserID:   s.record.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey],
 				Template: notificationtemplates.UserProvisioned.Name,
 			},
 		}

--- a/pkg/controller/masteruserrecord/sync.go
+++ b/pkg/controller/masteruserrecord/sync.go
@@ -195,6 +195,8 @@ func (s *Synchronizer) alignReadiness() (bool, error) {
 				},
 			},
 			Spec: toolchainv1alpha1.NotificationSpec{
+				// The UserID property actually refers to the UserSignup resource name.  This will be renamed
+				// (or removed) in a future PR
 				UserID:   s.record.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey],
 				Template: notificationtemplates.UserProvisioned.Name,
 			},

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -442,8 +442,7 @@ func (r *ReconcileUserSignup) generateCompliantUsername(instance *toolchainv1alp
 			}
 			// If there was a NotFound error looking up the mur, it means we found an available name
 			return transformed, nil
-		} else if mur.Labels[toolchainv1alpha1.MasterUserRecordUserIDLabelKey] == instance.Name ||
-			mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] == instance.Name {
+		} else if mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] == instance.Name {
 			// If the found MUR has the same UserID as the UserSignup, then *it* is the correct MUR -
 			// Return an error here and allow the reconcile() function to pick it up on the next loop
 			return "", fmt.Errorf(fmt.Sprintf("INFO: could not generate compliant username as MasterUserRecord with the same name [%s] and user id [%s] already exists. The next reconcile loop will pick it up.", mur.Name, instance.Name))


### PR DESCRIPTION
This PR removes the temporary code that was required as part of https://issues.redhat.com/browse/CRT-915.  This is a work in progress, and is first waiting upon https://github.com/codeready-toolchain/api/pull/213.