### PR TITLE
Introducing Test tier

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/ns_stage.yaml
@@ -67,7 +67,7 @@ objects:
     - type: "Container"
       default:
         cpu: 500m
-        memory: 512Mi
+        memory: 750Mi
       defaultRequest:
         cpu: 10m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basic/ns_stage.yaml
@@ -67,7 +67,7 @@ objects:
     - type: "Container"
       default:
         cpu: 500m
-        memory: 512Mi
+        memory: 750Mi
       defaultRequest:
         cpu: 10m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/basicdeactivationdisabled/ns_stage.yaml
@@ -67,7 +67,7 @@ objects:
     - type: "Container"
       default:
         cpu: 500m
-        memory: 512Mi
+        memory: 750Mi
       defaultRequest:
         cpu: 10m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/test/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/test/cluster.yaml
@@ -1,0 +1,46 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: test-cluster-resources
+objects:
+- apiVersion: quota.openshift.io/v1
+  kind: ClusterResourceQuota
+  metadata:
+    name: for-${USERNAME}
+  spec:
+    quota:
+      hard:
+        limits.cpu: 10000m
+        limits.memory: 7Gi
+        limits.ephemeral-storage: 7Gi
+        requests.cpu: 1750m
+        requests.memory: 7Gi
+        requests.storage: 15Gi
+        requests.ephemeral-storage: 7Gi
+        count/pods: "50"
+        count/replicasets.apps: "30"
+    selector:
+      annotations:
+        openshift.io/requester: ${USERNAME}
+      labels: null
+- apiVersion: toolchain.dev.openshift.com/v1alpha1
+  kind: Idler
+  metadata:
+    name: ${USERNAME}-dev
+  spec:
+    timeoutSeconds: 28800 # 8 hours
+- apiVersion: toolchain.dev.openshift.com/v1alpha1
+  kind: Idler
+  metadata:
+    name: ${USERNAME}-code
+  spec:
+    timeoutSeconds: 28800 # 8 hours
+- apiVersion: toolchain.dev.openshift.com/v1alpha1
+  kind: Idler
+  metadata:
+    name: ${USERNAME}-stage
+  spec:
+    timeoutSeconds: 28800 # 8 hours
+parameters:
+- name: USERNAME
+  required: true

--- a/deploy/templates/nstemplatetiers/test/ns_code.yaml
+++ b/deploy/templates/nstemplatetiers/test/ns_code.yaml
@@ -1,0 +1,146 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: test-code
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      che.eclipse.org/openshift-username: ${USERNAME}
+      openshift.io/description: ${USERNAME}-code
+      openshift.io/display-name: ${USERNAME}-code
+      openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-code
+    name: ${USERNAME}-code
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: rbac-edit
+    namespace: ${USERNAME}-code
+  rules:
+    - apiGroups:
+        - authorization.openshift.io
+        - rbac.authorization.k8s.io
+      resources:
+        - roles
+        - rolebindings
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: user-rbac-edit
+    namespace: ${USERNAME}-code
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rbac-edit
+  subjects:
+    - kind: User
+      name: ${USERNAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: user-edit
+    namespace: ${USERNAME}-code
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: edit
+  subjects:
+  - kind: User
+    name: ${USERNAME}
+- apiVersion: v1
+  kind: LimitRange
+  metadata:
+    name: resource-limits
+    namespace: ${USERNAME}-code
+  spec:
+    limits:
+    - type: "Container"
+      default:
+        cpu: 500m
+        memory: 750Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-same-namespace
+    namespace: ${USERNAME}-code
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-code
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-code
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-codeready-workspaces-operator
+    namespace: ${USERNAME}-code
+  spec:
+    ingress:
+      - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: codeready-workspaces
+    podSelector: {}
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-other-user-namespaces
+    namespace: ${USERNAME}-code
+  spec:
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
+    podSelector: {}
+    policyTypes:
+      - Ingress
+parameters:
+- name: USERNAME
+  required: true

--- a/deploy/templates/nstemplatetiers/test/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/test/ns_dev.yaml
@@ -1,0 +1,131 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: test-dev
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      openshift.io/description: ${USERNAME}-dev
+      openshift.io/display-name: ${USERNAME}-dev
+      openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-dev
+    name: ${USERNAME}-dev
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: rbac-edit
+    namespace: ${USERNAME}-dev
+  rules:
+    - apiGroups:
+        - authorization.openshift.io
+        - rbac.authorization.k8s.io
+      resources:
+        - roles
+        - rolebindings
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: user-rbac-edit
+    namespace: ${USERNAME}-dev
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rbac-edit
+  subjects:
+    - kind: User
+      name: ${USERNAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: user-edit
+    namespace: ${USERNAME}-dev
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: edit
+  subjects:
+  - kind: User
+    name: ${USERNAME}
+- apiVersion: v1
+  kind: LimitRange
+  metadata:
+    name: resource-limits
+    namespace: ${USERNAME}-dev
+  spec:
+    limits:
+    - type: "Container"
+      default:
+        cpu: 500m
+        memory: 750Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-same-namespace
+    namespace: ${USERNAME}-dev
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-other-user-namespaces
+    namespace: ${USERNAME}-dev
+  spec:
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-code
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-stage
+    podSelector: {}
+    policyTypes:
+      - Ingress
+parameters:
+- name: USERNAME
+  required: true

--- a/deploy/templates/nstemplatetiers/test/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/test/ns_stage.yaml
@@ -67,7 +67,7 @@ objects:
     - type: "Container"
       default:
         cpu: 500m
-        memory: 512Mi
+        memory: 750Mi
       defaultRequest:
         cpu: 10m
         memory: 64Mi

--- a/deploy/templates/nstemplatetiers/test/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/test/ns_stage.yaml
@@ -1,0 +1,131 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: test-stage
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      openshift.io/description: ${USERNAME}-stage
+      openshift.io/display-name: ${USERNAME}-stage
+      openshift.io/requester: ${USERNAME}
+    labels:
+      name: ${USERNAME}-stage
+    name: ${USERNAME}-stage
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: rbac-edit
+    namespace: ${USERNAME}-stage
+  rules:
+    - apiGroups:
+        - authorization.openshift.io
+        - rbac.authorization.k8s.io
+      resources:
+        - roles
+        - rolebindings
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: user-rbac-edit
+    namespace: ${USERNAME}-stage
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rbac-edit
+  subjects:
+    - kind: User
+      name: ${USERNAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: user-edit
+    namespace: ${USERNAME}-stage
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: edit
+  subjects:
+  - kind: User
+    name: ${USERNAME}
+- apiVersion: v1
+  kind: LimitRange
+  metadata:
+    name: resource-limits
+    namespace: ${USERNAME}-stage
+  spec:
+    limits:
+    - type: "Container"
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 64Mi
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-same-namespace
+    namespace: ${USERNAME}-stage
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-ingress
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-monitoring
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-other-user-namespaces
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-code
+        - namespaceSelector:
+            matchLabels:
+              name: ${USERNAME}-dev
+    podSelector: {}
+    policyTypes:
+      - Ingress
+parameters:
+- name: USERNAME
+  required: true

--- a/deploy/templates/nstemplatetiers/test/tier.yaml
+++ b/deploy/templates/nstemplatetiers/test/tier.yaml
@@ -1,0 +1,24 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: test-tier
+objects:
+- kind: NSTemplateTier
+  apiVersion: toolchain.dev.openshift.com/v1alpha1
+  metadata:
+    name: test
+    namespace: ${NAMESPACE}
+  spec:
+    clusterResources:
+      templateRef: ${CLUSTER_TEMPL_REF}
+    deactivationTimeoutDays: 30
+    namespaces:
+      - templateRef: ${CODE_TEMPL_REF}
+      - templateRef: ${DEV_TEMPL_REF}
+      - templateRef: ${STAGE_TEMPL_REF}
+parameters:
+- name: NAMESPACE
+- name: CLUSTER_TEMPL_REF
+- name: CODE_TEMPL_REF
+- name: DEV_TEMPL_REF
+- name: STAGE_TEMPL_REF

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -435,18 +435,17 @@ func assertNamespaceTemplate(t *testing.T, decoder runtime.Decoder, actual templ
 
 	// LimitRange
 	cpuLimit := "500m"
-	memoryLimit := "512Mi"
+	memoryLimit := "750Mi"
 	memoryRequest := "64Mi"
 	cpuRequest := "10m"
 	if kind == "code" {
 		cpuLimit = "1000m"
 		cpuRequest = "60m"
 		memoryRequest = "307Mi"
+		memoryLimit = "512Mi"
 	}
 	if tier == "team" {
 		memoryLimit = "1Gi"
-	} else if kind == "dev" {
-		memoryLimit = "750Mi"
 	}
 	containsObj(t, actual, limitRangeObj(kind, cpuLimit, memoryLimit, cpuRequest, memoryRequest))
 

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -39,9 +39,9 @@ func TestLoadTemplatesByTiers(t *testing.T) {
 			require.NoError(t, err)
 			// then
 			require.NoError(t, err)
-			require.Len(t, tmpls, 4)
+			require.Len(t, tmpls, 5)
 			require.NotContains(t, "foo", tmpls) // make sure that the `foo: bar` entry was ignored
-			for _, tier := range []string{"advanced", "basic", "team", "basicdeactivationdisabled"} {
+			for _, tier := range []string{"advanced", "basic", "team", "basicdeactivationdisabled", "test"} {
 				t.Run(tier, func(t *testing.T) {
 					for _, kind := range []string{"code", "dev", "stage"} {
 						t.Run(kind, func(t *testing.T) {
@@ -186,6 +186,7 @@ func TestNewNSTemplateTier(t *testing.T) {
 				"basicdeactivationdisabled": 0,
 				"advanced":                  0,
 				"team":                      0,
+				"test":                      30,
 			}
 
 			// when
@@ -420,8 +421,10 @@ func assertNamespaceTemplate(t *testing.T, decoder runtime.Decoder, actual templ
 		} else {
 			require.Len(t, actual.Objects, 9)
 		}
+	case "test":
+		return // Don't care what objects are defined in the test tier
 	default:
-		require.Fail(t, "unexpected tier: '%s'", tier)
+		require.Fail(t, fmt.Sprintf("unexpected tier: %s", tier))
 	}
 
 	// Namespace


### PR DESCRIPTION
There is a need for the CRW team to test some different namespace settings for user namespaces. See https://issues.redhat.com/browse/CRT-940?focusedCommentId=15762779&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15762779 for details.
But I think it would be useful to have some `test` tier which we could use for such research/tests. Ideally we would want to have some ability to create temporal tiers directly in the cluster but it's not that easy right now.

So, for now let's have a permanent special tier we can use for that. If we need to test something else we just modify this test tier.
We do not care much about detailed unit tests for this tier content besides testing the the tier is present and parseible. Also I don't think we have to include it into our e2e tests.

For now this test tier is a copy of the basic tier but -code namespace has the same limit range as -dev and -stage.

**NOTE:** This PR also fixes -stage templates in all tiers to align the default memory limits with -dev namespaces.

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/236