### PR TITLE
Crt 913 move generateusername to common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff => ../toolchain-common
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff => github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff => ../toolchain-common
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"

--- a/go.sum
+++ b/go.sum
@@ -139,13 +139,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20201014170554-ba7a98533167/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20210115184740-77f08aa35c87 h1:jUqvvFYZYeD6Hcs4zEv5+oppXaxeIgGQn3YJd1DQDg0=
-github.com/codeready-toolchain/api v0.0.0-20210115184740-77f08aa35c87/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101 h1:oKHlw3jQXcMX8AbAlCdzn8ZS58jnGtjT7ItG5oaistM=
 github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff h1:vBNOeBFLOFJm8Eb3KTGNUqMHUPF/TBPF6ZT2y+izHTs=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20201208090743-91c4f9716eff/go.mod h1:TC5Q5FtNUwzpHNMLAkJXaxkifHwPJlZtrvnTWKIY+2M=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/go.sum
+++ b/go.sum
@@ -884,6 +884,8 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e h1:2IokO8z9TzRUbeCKwJpZC9NiakEcj0B1DufVv63jiGg=
+github.com/tinakurian/toolchain-common v0.0.0-20210216182308-9a7445b1611e/go.mod h1:2MIk76M6c61igSzapDQr0iyNTB24jOsuCyt7MjnjeZc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/pkg/controller/registrationservice/creation.go
+++ b/pkg/controller/registrationservice/creation.go
@@ -28,7 +28,7 @@ func CreateOrUpdateResources(client client.Client, s *runtime.Scheme, namespace 
 		Spec: v1alpha1.RegistrationServiceSpec{
 			EnvironmentVariables: envs,
 		}}
-	commonclient := commonclient.NewApplyClient(client, s)
-	_, err := commonclient.CreateOrUpdateObject(regService, false, nil)
+	commoncl := commonclient.NewApplyClient(client, s)
+	_, err := commoncl.ApplyObject(regService, commonclient.ForceUpdate(false))
 	return err
 }

--- a/pkg/controller/registrationservice/creation_test.go
+++ b/pkg/controller/registrationservice/creation_test.go
@@ -61,7 +61,7 @@ func TestCreateOrUpdateResources(t *testing.T) {
 			},
 		}
 		client := commonclient.NewApplyClient(cl, s)
-		_, err := client.CreateOrUpdateObject(regService, false, nil)
+		_, err := client.ApplyObject(regService, commonclient.ForceUpdate(false))
 		require.NoError(t, err)
 		restore := SetEnvVarsAndRestore(t,
 			Env("REGISTRATION_SERVICE_IMAGE", "quay.io/rh/registration-service:v0.1"),

--- a/pkg/controller/registrationservice/registrationservice_controller.go
+++ b/pkg/controller/registrationservice/registrationservice_controller.go
@@ -141,7 +141,7 @@ func (r *ReconcileRegistrationService) Reconcile(request reconcile.Request) (rec
 	// create all objects that are within the template, and update only when the object has changed.
 	var updated []string
 	for _, toolchainObject := range toolchainObjects {
-		createdOrUpdated, err := cl.CreateOrUpdateObject(toolchainObject.GetRuntimeObject(), false, regService)
+		createdOrUpdated, err := cl.ApplyObject(toolchainObject.GetRuntimeObject(), applycl.ForceUpdate(false), applycl.SetOwner(regService))
 		if err != nil {
 			return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, regService, r.setStatusFailed(toolchainv1alpha1.RegistrationServiceDeployingFailedReason), err, "cannot deploy registration service template")
 		}

--- a/pkg/controller/registrationservice/registrationservice_controller_test.go
+++ b/pkg/controller/registrationservice/registrationservice_controller_test.go
@@ -66,9 +66,9 @@ func TestReconcileRegistrationService(t *testing.T) {
 		// given
 		service, request := prepareServiceAndRequest(t, s, decoder, reqService)
 		cclient := commonclient.NewApplyClient(service.client, service.scheme)
-		_, err := cclient.CreateOrUpdateObject(objs[0].GetRuntimeObject().DeepCopyObject(), false, nil)
+		_, err := cclient.ApplyObject(objs[0].GetRuntimeObject().DeepCopyObject(), commonclient.ForceUpdate(false))
 		require.NoError(t, err)
-		_, err = cclient.CreateOrUpdateObject(objs[1].GetRuntimeObject().DeepCopyObject(), false, nil)
+		_, err = cclient.ApplyObject(objs[1].GetRuntimeObject().DeepCopyObject(), commonclient.ForceUpdate(false))
 		require.NoError(t, err)
 		fakeClient := service.client.(*test.FakeClient)
 		fakeClient.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
@@ -98,12 +98,12 @@ func TestReconcileRegistrationService(t *testing.T) {
 		// given
 		service, request := prepareServiceAndRequest(t, s, decoder)
 		client := commonclient.NewApplyClient(service.client, service.scheme)
-		_, err := client.CreateOrUpdateObject(objs[0].GetRuntimeObject().DeepCopyObject(), false, nil)
+		_, err := client.ApplyObject(objs[0].GetRuntimeObject().DeepCopyObject(), commonclient.ForceUpdate(false))
 		require.NoError(t, err)
-		_, err = client.CreateOrUpdateObject(objs[1].GetRuntimeObject().DeepCopyObject(), false, nil)
+		_, err = client.ApplyObject(objs[1].GetRuntimeObject().DeepCopyObject(), commonclient.ForceUpdate(false))
 		require.NoError(t, err)
 		reqService := newRegistrationService(test.HostOperatorNs, "quay.io/rh/registration-service:v0.1", "", 1)
-		_, err = client.CreateOrUpdateObject(reqService, false, nil)
+		_, err = client.ApplyObject(reqService, commonclient.ForceUpdate(false))
 		require.NoError(t, err)
 
 		// when

--- a/pkg/controller/toolchainstatus/creation.go
+++ b/pkg/controller/toolchainstatus/creation.go
@@ -19,6 +19,6 @@ func CreateOrUpdateResources(client client.Client, s *runtime.Scheme, namespace,
 		Spec: v1alpha1.ToolchainStatusSpec{},
 	}
 	cl := commonclient.NewApplyClient(client, s)
-	_, err := cl.CreateOrUpdateObject(toolchainStatus, false, nil)
+	_, err := cl.ApplyObject(toolchainStatus, commonclient.ForceUpdate(false))
 	return err
 }

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -5,8 +5,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"regexp"
-	"strings"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	crtCfg "github.com/codeready-toolchain/host-operator/pkg/configuration"
@@ -16,12 +14,13 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/templates/notificationtemplates"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
+
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -33,11 +32,6 @@ import (
 )
 
 var log = logf.Log.WithName("controller_usersignup")
-
-var (
-	specialCharRegexp = regexp.MustCompile("[^A-Za-z0-9]")
-	onlyNumbers       = regexp.MustCompile("^[0-9]*$")
-)
 
 type StatusUpdater func(userAcc *toolchainv1alpha1.UserSignup, message string) error
 
@@ -413,70 +407,6 @@ func getNsTemplateTier(cl client.Client, tierName, namespace string) (*toolchain
 	return nstemplateTier, err
 }
 
-func (r *ReconcileUserSignup) generateCompliantUsername(instance *toolchainv1alpha1.UserSignup) (string, error) {
-	replaced := transformUsername(instance.Spec.Username)
-
-	// Check for any forbidden prefixes
-	for _, prefix := range r.crtConfig.GetForbiddenUsernamePrefixes() {
-		if strings.HasPrefix(replaced, prefix) {
-			replaced = fmt.Sprintf("%s%s", "crt-", replaced)
-			break
-		}
-	}
-
-	validationErrors := validation.IsQualifiedName(replaced)
-	if len(validationErrors) > 0 {
-		return "", fmt.Errorf(fmt.Sprintf("transformed username [%s] is invalid", replaced))
-	}
-
-	transformed := replaced
-
-	for i := 2; i < 101; i++ { // No more than 100 attempts to find a vacant name
-		mur := &toolchainv1alpha1.MasterUserRecord{}
-		// Check if a MasterUserRecord exists with the same transformed name
-		namespacedMurName := types.NamespacedName{Namespace: instance.Namespace, Name: transformed}
-		err := r.client.Get(context.TODO(), namespacedMurName, mur)
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				return "", err
-			}
-			// If there was a NotFound error looking up the mur, it means we found an available name
-			return transformed, nil
-		} else if mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] == instance.Name {
-			// If the found MUR has the same UserID as the UserSignup, then *it* is the correct MUR -
-			// Return an error here and allow the reconcile() function to pick it up on the next loop
-			return "", fmt.Errorf(fmt.Sprintf("INFO: could not generate compliant username as MasterUserRecord with the same name [%s] and user id [%s] already exists. The next reconcile loop will pick it up.", mur.Name, instance.Name))
-		}
-
-		transformed = fmt.Sprintf("%s-%d", replaced, i)
-	}
-
-	return "", fmt.Errorf(fmt.Sprintf("unable to transform username [%s] even after 100 attempts", instance.Spec.Username))
-}
-
-func transformUsername(username string) string {
-	newUsername := specialCharRegexp.ReplaceAllString(strings.Split(username, "@")[0], "-")
-	if len(newUsername) == 0 {
-		newUsername = strings.ReplaceAll(username, "@", "at-")
-	}
-	newUsername = specialCharRegexp.ReplaceAllString(newUsername, "-")
-
-	matched := onlyNumbers.MatchString(newUsername)
-	if matched {
-		newUsername = "crt-" + newUsername
-	}
-	for strings.Contains(newUsername, "--") {
-		newUsername = strings.ReplaceAll(newUsername, "--", "-")
-	}
-	if strings.HasPrefix(newUsername, "-") {
-		newUsername = "crt" + newUsername
-	}
-	if strings.HasSuffix(newUsername, "-") {
-		newUsername = newUsername + "crt"
-	}
-	return newUsername
-}
-
 // provisionMasterUserRecord does the work of provisioning the MasterUserRecord
 func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1alpha1.UserSignup, targetCluster string,
 	nstemplateTier *toolchainv1alpha1.NSTemplateTier, logger logr.Logger) error {
@@ -484,7 +414,7 @@ func (r *ReconcileUserSignup) provisionMasterUserRecord(userSignup *toolchainv1a
 	// TODO Update the MasterUserRecord with NSTemplateTier values
 	// SEE https://jira.coreos.com/browse/CRT-74
 
-	compliantUsername, err := r.generateCompliantUsername(userSignup)
+	compliantUsername, err := usersignup.GenerateCompliantUsername(userSignup, r.client, r.crtConfig.GetForbiddenUsernamePrefixes())
 	if err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, userSignup, r.setStatusFailedToCreateMUR, err,
 			"Error generating compliant username for %s", userSignup.Spec.Username)

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/host-operator/pkg/templates/nstemplatetiers"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-	//"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 
 	. "github.com/codeready-toolchain/host-operator/test"
 	ntest "github.com/codeready-toolchain/host-operator/test/notification"

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/host-operator/pkg/templates/nstemplatetiers"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 
 	. "github.com/codeready-toolchain/host-operator/test"
 	ntest "github.com/codeready-toolchain/host-operator/test/notification"
@@ -2183,8 +2184,8 @@ func TestTransformUsername(t *testing.T) {
 var dnsRegExp = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
 
 func assertName(t *testing.T, expected, username string) {
-	assert.Regexp(t, dnsRegExp, transformUsername(username))
-	assert.Equal(t, expected, transformUsername(username))
+	assert.Regexp(t, dnsRegExp, usersignup.TransformUsername(username))
+	assert.Equal(t, expected, usersignup.TransformUsername(username))
 }
 
 func TestUsernameWithForbiddenPrefix(t *testing.T) {

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/host-operator/pkg/templates/nstemplatetiers"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-	"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
+	//"github.com/codeready-toolchain/toolchain-common/pkg/usersignup"
 
 	. "github.com/codeready-toolchain/host-operator/test"
 	ntest "github.com/codeready-toolchain/host-operator/test/notification"
@@ -2152,40 +2152,6 @@ func newReconcileRequest(name string) reconcile.Request {
 			Namespace: test.HostOperatorNs,
 		},
 	}
-}
-
-func TestTransformUsername(t *testing.T) {
-	assertName(t, "some", "some@email.com")
-	assertName(t, "so-me", "so-me@email.com")
-	assertName(t, "at-email-com", "@email.com")
-	assertName(t, "at-crt", "@")
-	assertName(t, "some", "some")
-	assertName(t, "so-me", "so-me")
-	assertName(t, "so-me", "so-----me")
-	assertName(t, "so-me", "so_me")
-	assertName(t, "so-me", "so me")
-	assertName(t, "so-me", "so me@email.com")
-	assertName(t, "so-me", "so.me")
-	assertName(t, "so-me", "so?me")
-	assertName(t, "so-me", "so:me")
-	assertName(t, "so-me", "so:#$%!$%^&me")
-	assertName(t, "crt-crt", ":#$%!$%^&")
-	assertName(t, "some1", "some1")
-	assertName(t, "so1me1", "so1me1")
-	assertName(t, "crt-me", "-me")
-	assertName(t, "crt-me", "_me")
-	assertName(t, "me-crt", "me-")
-	assertName(t, "me-crt", "me_")
-	assertName(t, "crt-me-crt", "_me_")
-	assertName(t, "crt-me-crt", "-me-")
-	assertName(t, "crt-12345", "12345")
-}
-
-var dnsRegExp = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-
-func assertName(t *testing.T, expected, username string) {
-	assert.Regexp(t, dnsRegExp, usersignup.TransformUsername(username))
-	assert.Equal(t, expected, usersignup.TransformUsername(username))
 }
 
 func TestUsernameWithForbiddenPrefix(t *testing.T) {

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
@@ -304,7 +304,7 @@ func (t *tierGenerator) createNSTemplateTiers() error {
 		}
 		labels[toolchainv1alpha1.ProviderLabelKey] = toolchainv1alpha1.ProviderLabelValue
 
-		updated, err := applyCl.ApplyObject(tier)
+		updated, err := applyCl.ApplyObject(tier, commonclient.ForceUpdate(true))
 		if err != nil {
 			return errors.Wrapf(err, "unable to create or update the '%s' NSTemplateTier", tierName)
 		}

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
@@ -304,7 +304,7 @@ func (t *tierGenerator) createNSTemplateTiers() error {
 		}
 		labels[toolchainv1alpha1.ProviderLabelKey] = toolchainv1alpha1.ProviderLabelValue
 
-		updated, err := applyCl.CreateOrUpdateObject(tier, true, nil)
+		updated, err := applyCl.ApplyObject(tier)
 		if err != nil {
 			return errors.Wrapf(err, "unable to create or update the '%s' NSTemplateTier", tierName)
 		}


### PR DESCRIPTION
Moving GenerateCompliantUsername and TransofmrUsername functions to common. GenerateCompliantUsername can then be used in registration-service when checking for crtadmin users.

This work is related to CRT-913: preventing usersignups for usernames that have the crtadmin suffix. 

Related PRs: https://github.com/codeready-toolchain/toolchain-e2e/pull/237, https://github.com/codeready-toolchain/toolchain-common/pull/151, 
https://github.com/codeready-toolchain/registration-service/pull/170

Jira: https://issues.redhat.com/browse/CRT-913