### PR TITLE
improve ToolchainStatus notifications

### DIFF
--- a/pkg/controller/toolchainstatus/toolchainstatus_controller.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller.go
@@ -355,7 +355,8 @@ func (r *ReconcileToolchainStatus) sendToolchainStatusUnreadyNotification(logger
 		return errs.New(fmt.Sprintf("cannot create notification due to configuration error - admin.email [%s] is invalid or not set",
 			r.config.GetAdminEmail()))
 	}
-
+	toolchainStatus = toolchainStatus.DeepCopy()
+	toolchainStatus.ManagedFields = nil // we don't need these managed fields in the notification
 	statusYaml, err := yaml.Marshal(toolchainStatus)
 	if err != nil {
 		return err
@@ -371,7 +372,7 @@ func (r *ReconcileToolchainStatus) sendToolchainStatusUnreadyNotification(logger
 		Spec: toolchainv1alpha1.NotificationSpec{
 			Recipient: r.config.GetAdminEmail(),
 			Subject:   adminUnreadyNotificationSubject,
-			Content:   string(statusYaml),
+			Content:   "<div><pre><code>" + string(statusYaml) + "</code></pre></div>", // wrap with div/pre/code tags so the formatting remains intact in the delivered mail
 		},
 	}
 

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller_test.go
@@ -924,11 +924,12 @@ func TestToolchainStatusNotifications(t *testing.T) {
 						notification := assertToolchainStatusNotificationCreated(t, fakeClient)
 						require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-unready-"))
 						require.Len(t, notification.ObjectMeta.Name, 38)
-
 						require.NotNil(t, notification)
-						require.Equal(t, notification.Spec.Subject, "ToolchainStatus has been in an unready status for an extended period")
-						require.Equal(t, notification.Spec.Recipient, "admin@dev.sandbox.com")
-
+						assert.Equal(t, notification.Spec.Subject, "ToolchainStatus has been in an unready status for an extended period")
+						assert.Equal(t, notification.Spec.Recipient, "admin@dev.sandbox.com")
+						assert.True(t, strings.HasPrefix(notification.Spec.Content, "<div><pre><code>"))
+						assert.True(t, strings.HasSuffix(notification.Spec.Content, "</code></pre></div>"))
+						assert.NotContains(t, notification.Spec.Content, "managedFields")
 					})
 				})
 			})


### PR DESCRIPTION
- remove the unnecessary `metadata.managedFields` portion
- wrap the unmarshalled YAML into `<div><pre><code>` tags in order
  to keep the formatting in the received mails

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
