### PR TITLE
refactor metrics

### DIFF
--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -169,7 +169,7 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
-	metrics.UserSignupAutoDeactivatedTotal.Increment()
+	metrics.UserSignupAutoDeactivatedTotal.Inc()
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -258,7 +258,7 @@ func TestReconcile(t *testing.T) {
 }
 
 func prepareReconcile(t *testing.T, name string, initObjs ...runtime.Object) (reconcile.Reconciler, reconcile.Request, *test.FakeClient) {
-	metrics.ResetCounters()
+	metrics.Reset()
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)

--- a/pkg/controller/toolchainstatus/toolchainstatus_controller.go
+++ b/pkg/controller/toolchainstatus/toolchainstatus_controller.go
@@ -9,9 +9,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/ghodss/yaml"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	crtCfg "github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/host-operator/pkg/controller/registrationservice"
@@ -20,6 +17,8 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
+
+	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	errs "github.com/pkg/errors"
@@ -30,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/pkg/controller/usersignup/masteruserrecord.go
+++ b/pkg/controller/usersignup/masteruserrecord.go
@@ -3,6 +3,7 @@ package usersignup
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/controller/nstemplatetier"
+	
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/counter/cache.go
+++ b/pkg/counter/cache.go
@@ -9,7 +9,10 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var log = logf.Log.WithName("counter_cache")
 
 var cachedCounts = cache{
 	Counts: Counts{
@@ -53,6 +56,7 @@ func reset() {
 func IncrementMasterUserRecordCount() {
 	write(func() {
 		cachedCounts.MasterUserRecordCount++
+		log.Info("incrementing MasterUserRecordGauge", "value", cachedCounts.MasterUserRecordCount)
 		metrics.MasterUserRecordGauge.Set(float64(cachedCounts.MasterUserRecordCount))
 	})
 }
@@ -66,6 +70,7 @@ func DecrementMasterUserRecordCount(log logr.Logger) {
 			log.Error(fmt.Errorf("the count of MasterUserRecords is zero"),
 				"unable to decrement the number of MasterUserRecords")
 		}
+		log.Info("decrementing MasterUserRecordGauge", "value", cachedCounts.MasterUserRecordCount)
 		metrics.MasterUserRecordGauge.Set(float64(cachedCounts.MasterUserRecordCount))
 	})
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -11,28 +11,24 @@ import (
 
 func TestInitCounter(t *testing.T) {
 	// given
-	m := initCounter("test_counter", "test counter description")
+	m := newCounter("test_counter", "test counter description")
 
 	// when
-	m.Increment()
+	m.Inc()
 
 	// then
-	assert.Equal(t, "sandbox_test_counter", m.name)
-	assert.Equal(t, "test counter description", m.help)
-	assert.Equal(t, float64(1), promtestutil.ToFloat64(m.prometheusCounter))
+	assert.Equal(t, float64(1), promtestutil.ToFloat64(m))
 }
 
 func TestInitGauge(t *testing.T) {
 	// given
-	m := initGauge("test_gauge", "test gauge description")
+	m := newGauge("test_gauge", "test gauge description")
 
 	// when
 	m.Set(22)
 
 	// then
-	assert.Equal(t, "sandbox_test_gauge", m.name)
-	assert.Equal(t, "test gauge description", m.help)
-	assert.Equal(t, float64(22), promtestutil.ToFloat64(m.prometheusGauge))
+	assert.Equal(t, float64(22), promtestutil.ToFloat64(m))
 }
 
 func TestRegisterCustomMetrics(t *testing.T) {
@@ -42,25 +38,26 @@ func TestRegisterCustomMetrics(t *testing.T) {
 	// then
 	// verify all metrics were registered successfully
 	for _, m := range allCounters {
-		assert.True(t, k8smetrics.Registry.Unregister(m.prometheusCounter))
+		assert.True(t, k8smetrics.Registry.Unregister(m))
 	}
 
 	for _, m := range allGauges {
-		assert.True(t, k8smetrics.Registry.Unregister(m.prometheusGauge))
+		assert.True(t, k8smetrics.Registry.Unregister(m))
 	}
+
+	// for _, m := range allGaugeVecs {
+	// 	assert.True(t, k8smetrics.Registry.Unregister(m))
+	// }
 }
 
-func TestResetCounters(t *testing.T) {
-	// given
-	c := initCounter("test_counter", "test counter description")
-	g := initGauge("test_gauge", "test gauge description")
+func TestResetMetrics(t *testing.T) {
 
 	// when
-	c.Increment()
-	g.Set(22)
-	ResetCounters()
+	UserSignupUniqueTotal.Inc()
+	MasterUserRecordGauge.Set(22)
+	Reset()
 
 	// then
-	assert.Equal(t, float64(0), promtestutil.ToFloat64(c.prometheusCounter))
-	assert.Equal(t, float64(22), promtestutil.ToFloat64(g.prometheusGauge))
+	assert.Equal(t, float64(0), promtestutil.ToFloat64(UserSignupUniqueTotal))
+	assert.Equal(t, float64(0), promtestutil.ToFloat64(MasterUserRecordGauge))
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -44,10 +44,6 @@ func TestRegisterCustomMetrics(t *testing.T) {
 	for _, m := range allGauges {
 		assert.True(t, k8smetrics.Registry.Unregister(m))
 	}
-
-	// for _, m := range allGaugeVecs {
-	// 	assert.True(t, k8smetrics.Registry.Unregister(m))
-	// }
 }
 
 func TestResetMetrics(t *testing.T) {

--- a/test/counter.go
+++ b/test/counter.go
@@ -9,6 +9,8 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +34,7 @@ func AssertThatUninitializedCounterHas(t *testing.T, numberOfMurs int, numberOfU
 func AssertThatCounterHas(t *testing.T, numberOfMurs int, numberOfUasPerCluster ...ExpectedNumberOfUserAccounts) {
 	AssertMetricsGaugeEquals(t, numberOfMurs, metrics.MasterUserRecordGauge)
 	counts, err := counter.GetCounts()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	verifyCounts(t, counts, numberOfMurs, numberOfUasPerCluster...)
 }
 
@@ -89,5 +91,6 @@ func initializeCounter(t *testing.T, cl *test.FakeClient, numberOfMurs int, numb
 
 	err := counter.Synchronize(cl, toolchainStatus)
 	require.NoError(t, err)
+	t.Logf("MasterUserRecordGauge=%.0f", promtestutil.ToFloat64(metrics.MasterUserRecordGauge))
 	return toolchainStatus
 }

--- a/test/metric.go
+++ b/test/metric.go
@@ -3,16 +3,15 @@ package test
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/host-operator/pkg/metrics"
-
+	"github.com/prometheus/client_golang/prometheus"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func AssertMetricsCounterEquals(t *testing.T, expected int, counter *metrics.Counter) {
-	assert.Equal(t, float64(expected), promtestutil.ToFloat64(counter.Collector()))
+func AssertMetricsCounterEquals(t *testing.T, expected int, counter prometheus.Counter) {
+	assert.Equal(t, float64(expected), promtestutil.ToFloat64(counter))
 }
 
-func AssertMetricsGaugeEquals(t *testing.T, expected int, gauge *metrics.Gauge) {
-	assert.Equal(t, float64(expected), promtestutil.ToFloat64(gauge.Collector()))
+func AssertMetricsGaugeEquals(t *testing.T, expected int, gauge prometheus.Gauge) {
+	assert.Equal(t, float64(expected), promtestutil.ToFloat64(gauge))
 }


### PR DESCRIPTION
remove the wrappers, refactor the init/reset
and update the tests accordingly: ince the `Reset()` func
now resets all metrics including the gauge(s), it's important
to set the initial values after preparing the reconciler and
resetting the metrics

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
