### PR TITLE
Member user limit

### DIFF
--- a/pkg/controller/usersignup/approval.go
+++ b/pkg/controller/usersignup/approval.go
@@ -67,7 +67,7 @@ func hasNotReachedMaxNumberOfUsersThreshold(config toolchainv1alpha1.HostOperato
 		}
 		numberOfUserAccounts := counts.UserAccountsPerClusterCounts[cluster.Name]
 		threshold := config.AutomaticApproval.MaxNumberOfUsers.SpecificPerMemberCluster[cluster.Name]
-		return threshold == 0 || numberOfUserAccounts <= threshold
+		return threshold == 0 || numberOfUserAccounts < threshold
 	}
 }
 

--- a/pkg/controller/usersignup/approval_test.go
+++ b/pkg/controller/usersignup/approval_test.go
@@ -90,8 +90,8 @@ func TestGetClusterIfApproved(t *testing.T) {
 		hostOperatorConfig := NewHostOperatorConfigWithReset(t,
 			AutomaticApproval().
 				Enabled().
-				MaxUsersNumber(2000, PerMemberCluster("member1", 6000), PerMemberCluster("member2", 1000)).
-				ResourceCapThreshold(80, PerMemberCluster("member1", 60), PerMemberCluster("member2", 75)))
+				MaxUsersNumber(2000, PerMemberCluster("member1", 800), PerMemberCluster("member2", 1000)).
+				ResourceCapThreshold(80, PerMemberCluster("member1", 90), PerMemberCluster("member2", 95)))
 		fakeClient := NewFakeClient(t, toolchainStatus, hostOperatorConfig)
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
 


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-949

While updating the e2e tests for automatic approval to test multiple members, I discovered that the automatic approval was actually allowing 1 more user than the specified limit. For example, if you configure the HostOperatorConfig for a member to have a user limit of 1 then 2 users would be approved to be provisioned on the cluster. This is because in the `hasNotReachedMaxNumberOfUsersThreshold` func `numberOfUserAccounts <= threshold` will cause it to return true if the number of user accounts has reached the specified limit when it should really be returning false.

Also found that the unit test for the case 'two clusters where the first one reaches max number of UserAccounts' was misleading because it was actually hitting the resource limit, instead of the user limit. So I updated that test as well by setting the max user limit for member1 to `800` which is equal to the initialized counter for member1.