### PR TITLE
Add support for ReplyTo email address when sending notifications

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -75,6 +75,9 @@ const (
 	// varMailgunSenderEmail specifies the host operator mailgun senders email
 	varMailgunSenderEmail = "mailgun.sender.email"
 
+	// varMailgunReplyToEmail specifies the reply-to email address that will be set in sent notifications
+	varMailgunReplyToEmail = "mailgun.replyto.email"
+
 	// varEnvironment specifies the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc
 	varEnvironment = "environment"
 
@@ -220,6 +223,11 @@ func (c *Config) GetMailgunAPIKey() string {
 // GetMailgunSenderEmail returns the host operator mailgun sender's email address
 func (c *Config) GetMailgunSenderEmail() string {
 	return c.secretValues[varMailgunSenderEmail]
+}
+
+// GetMailgunReplyToEmail returns the (optional) reply-to email address to set in sent notifications
+func (c *Config) GetMailgunReplyToEmail() string {
+	return c.secretValues[varMailgunReplyToEmail]
 }
 
 // GetEnvironment returns the host-operator environment such as prod, stage, unit-tests, e2e-tests, dev, etc

--- a/pkg/controller/notification/mailgun_notification_delivery_service_test.go
+++ b/pkg/controller/notification/mailgun_notification_delivery_service_test.go
@@ -28,7 +28,8 @@ func TestMailgunNotificationDeliveryService(t *testing.T) {
 	mockServerOption := NewMailgunAPIBaseOption(mgs.URL())
 	invalidServerOption := NewMailgunAPIBaseOption("https://127.0.0.1:60000/v3")
 
-	config := NewNotificationDeliveryServiceFactoryConfig("mg.foo.com", "abcd12345", "noreply@foo.com", "mailgun")
+	config := NewNotificationDeliveryServiceFactoryConfig("mg.foo.com", "abcd12345",
+		"noreply@foo.com", "", "mailgun")
 	notCtx := &UserNotificationContext{
 		UserID:      "jsmith123",
 		FirstName:   "John",
@@ -126,5 +127,23 @@ func TestMailgunNotificationDeliveryService(t *testing.T) {
 		// then
 		require.Error(t, err)
 		require.Equal(t, "template: template:1: function \"invalid_expression\" not defined", err.Error())
+	})
+
+	t.Run("test mailgun notification delivery service send with reply-to address", func(t *testing.T) {
+		// when
+		config := NewNotificationDeliveryServiceFactoryConfig("mg.foo.com", "abcd12345",
+			"noreply@foo.com", "info@foo.com", "mailgun")
+
+		mgds := NewMailgunNotificationDeliveryService(config, templateLoader, mockServerOption)
+		err := mgds.Send(notCtx, &v1alpha1.Notification{
+			Spec: v1alpha1.NotificationSpec{
+				Subject: "test",
+				Content: "abc",
+			},
+		})
+
+		// then
+		require.NoError(t, err)
+
 	})
 }

--- a/pkg/controller/notification/notification_controller_test.go
+++ b/pkg/controller/notification/notification_controller_test.go
@@ -327,7 +327,7 @@ func mockDeliveryService(templateLoader TemplateLoader) (NotificationDeliverySer
 	mgs := mailgun.NewMockServer()
 	mockServerOption := NewMailgunAPIBaseOption(mgs.URL())
 
-	config := NewNotificationDeliveryServiceFactoryConfig("mg.foo.com", "abcd12345", "noreply@foo.com", "mailgun")
+	config := NewNotificationDeliveryServiceFactoryConfig("mg.foo.com", "abcd12345", "noreply@foo.com", "", "mailgun")
 
 	mgds := NewMailgunNotificationDeliveryService(config, templateLoader, mockServerOption)
 	return mgds, mgs

--- a/pkg/controller/notification/notification_delivery_service_test.go
+++ b/pkg/controller/notification/notification_delivery_service_test.go
@@ -23,9 +23,10 @@ func (c *MockNotificationDeliveryServiceFactoryConfig) GetNotificationDeliverySe
 }
 
 type MockMailgunConfiguration struct {
-	Domain      string
-	APIKey      string
-	SenderEmail string
+	Domain       string
+	APIKey       string
+	SenderEmail  string
+	ReplyToEmail string
 }
 
 func (c *MockNotificationDeliveryServiceFactoryConfig) GetMailgunDomain() string {
@@ -40,9 +41,18 @@ func (c *MockNotificationDeliveryServiceFactoryConfig) GetMailgunSenderEmail() s
 	return c.Mailgun.SenderEmail
 }
 
-func NewNotificationDeliveryServiceFactoryConfig(domain, apiKey, senderEmail, service string) NotificationDeliveryServiceFactoryConfig {
+func (c *MockNotificationDeliveryServiceFactoryConfig) GetMailgunReplyToEmail() string {
+	return c.Mailgun.ReplyToEmail
+}
+
+func NewNotificationDeliveryServiceFactoryConfig(domain, apiKey, senderEmail, replyToEmail, service string) NotificationDeliveryServiceFactoryConfig {
 	return &MockNotificationDeliveryServiceFactoryConfig{
-		Mailgun: MockMailgunConfiguration{Domain: domain, APIKey: apiKey, SenderEmail: senderEmail},
+		Mailgun: MockMailgunConfiguration{
+			Domain:       domain,
+			APIKey:       apiKey,
+			SenderEmail:  senderEmail,
+			ReplyToEmail: replyToEmail,
+		},
 		Service: MockNotificationDeliveryServiceConfig{service: service},
 	}
 
@@ -79,7 +89,8 @@ func TestNotificationDeliveryServiceFactory(t *testing.T) {
 
 	t.Run("factory configured with mailgun delivery service", func(t *testing.T) {
 		// when
-		factory := NewNotificationDeliveryServiceFactory(client, NewNotificationDeliveryServiceFactoryConfig("mg.foo.com", "abcd12345", "noreply@foo.com", "mailgun"))
+		factory := NewNotificationDeliveryServiceFactory(client, NewNotificationDeliveryServiceFactoryConfig(
+			"mg.foo.com", "abcd12345", "noreply@foo.com", "", "mailgun"))
 		svc, err := factory.CreateNotificationDeliveryService()
 
 		// then
@@ -91,7 +102,8 @@ func TestNotificationDeliveryServiceFactory(t *testing.T) {
 
 		// when
 		factory := NewNotificationDeliveryServiceFactory(client,
-			NewNotificationDeliveryServiceFactoryConfig("mg.foo.com", "abcd12345", "noreply@foo.com", ""))
+			NewNotificationDeliveryServiceFactoryConfig("mg.foo.com", "abcd12345",
+				"noreply@foo.com", "", ""))
 		_, err := factory.CreateNotificationDeliveryService()
 
 		// then


### PR DESCRIPTION
Repeat PR that adds support for ReplyTo email address, this time without our private Mailgun API key :)

Fixes https://issues.redhat.com/browse/CRT-910

Signed-off-by: sbryzak <sbryzak@gmail.com>