### PR TITLE
CRDs updated after adding a new property ClusterApiEndpoint to MemberStatusStatus

### DIFF
--- a/deploy/crds/toolchain_v1alpha1_toolchainstatus_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_toolchainstatus_crd.yaml
@@ -195,6 +195,10 @@ spec:
                               - type
                               x-kubernetes-list-type: map
                           type: object
+                        clusterApiEndpoint:
+                          description: ClusterApiEndpoint is the server API URL of
+                            the cluster
+                          type: string
                         conditions:
                           description: 'Conditions is an array of current toolchain
                             status conditions Supported condition types: ConditionReady'

--- a/deploy/crds/toolchain_v1alpha1_usersignup_crd.yaml
+++ b/deploy/crds/toolchain_v1alpha1_usersignup_crd.yaml
@@ -97,7 +97,7 @@ spec:
                 description: The cluster in which the user is provisioned in If not
                   set then the target cluster will be picked automatically
                 type: string
-              userid:
+              userID:
                 description: The user's user ID, obtained from the identity provider
                   from the 'sub' (subject) claim
                 type: string
@@ -112,7 +112,7 @@ spec:
                   passed the verification. Default value is false.
                 type: boolean
             required:
-            - userid
+            - userID
             - username
             type: object
           status:

--- a/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain_v1alpha1_toolchainstatus_crd.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain_v1alpha1_toolchainstatus_crd.yaml
@@ -195,6 +195,10 @@ spec:
                               - type
                               x-kubernetes-list-type: map
                           type: object
+                        clusterApiEndpoint:
+                          description: ClusterApiEndpoint is the server API URL of
+                            the cluster
+                          type: string
                         conditions:
                           description: 'Conditions is an array of current toolchain
                             status conditions Supported condition types: ConditionReady'

--- a/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain_v1alpha1_usersignup_crd.yaml
+++ b/deploy/olm-catalog/toolchain-host-operator/manifests/toolchain_v1alpha1_usersignup_crd.yaml
@@ -97,7 +97,7 @@ spec:
                 description: The cluster in which the user is provisioned in If not
                   set then the target cluster will be picked automatically
                 type: string
-              userid:
+              userID:
                 description: The user's user ID, obtained from the identity provider
                   from the 'sub' (subject) claim
                 type: string
@@ -112,7 +112,7 @@ spec:
                   passed the verification. Default value is false.
                 type: boolean
             required:
-            - userid
+            - userID
             - username
             type: object
           status:

--- a/hack/deploy_csv.yaml
+++ b/hack/deploy_csv.yaml
@@ -1523,6 +1523,10 @@ data:
                                     - type
                                     x-kubernetes-list-type: map
                                 type: object
+                              clusterApiEndpoint:
+                                description: ClusterApiEndpoint is the server API URL of
+                                  the cluster
+                                type: string
                               conditions:
                                 description: 'Conditions is an array of current toolchain
                                   status conditions Supported condition types: ConditionReady'
@@ -2049,7 +2053,7 @@ data:
                       description: The cluster in which the user is provisioned in If not
                         set then the target cluster will be picked automatically
                       type: string
-                    userid:
+                    userID:
                       description: The user's user ID, obtained from the identity provider
                         from the 'sub' (subject) claim
                       type: string
@@ -2064,7 +2068,7 @@ data:
                         passed the verification. Default value is false.
                       type: boolean
                   required:
-                  - userid
+                  - userID
                   - username
                   type: object
                 status:


### PR DESCRIPTION
CRDs updated by running `make generate` after adding new property ClusterApiEndpoint to MemberStatusStatus

Fixes related to: https://issues.redhat.com/browse/CRT-971