### PR TITLE
feat: prevent from creating users with specific suffixes

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -103,6 +103,12 @@ const (
 
 	DefaultForbiddenUsernamePrefixes = "openshift,kube,default,redhat,sandbox"
 
+	// varForbiddenUsernameSuffixes defines the suffixes that a username may not have when signing up.  If a
+	// username has a forbidden suffix, then the username compliance suffix is added to the username
+	varForbiddenUsernameSuffixes = "username.forbidden.suffixes"
+
+	DefaultForbiddenUsernameSuffixes = "admin"
+
 	// varUserSignupUnverifiedRetentionDays is used to configure how many days we should keep unverified (i.e. the user
 	// hasn't completed the user verification process via the registration service) UserSignup resources before deleting
 	// them.  It is intended for this parameter to define an aggressive cleanup schedule for unverified user signups,
@@ -186,6 +192,9 @@ func (c *Config) setConfigDefaults() {
 	c.host.SetDefault(varMasterUserRecordUpdateFailureThreshold, 2) // allow 1 failure, try again and then give up if failed again
 	c.host.SetDefault(varToolchainStatusRefreshTime, defaultToolchainStatusRefreshTime)
 	c.host.SetDefault(varForbiddenUsernamePrefixes, strings.FieldsFunc(DefaultForbiddenUsernamePrefixes, func(c rune) bool {
+		return c == ','
+	}))
+	c.host.SetDefault(varForbiddenUsernameSuffixes, strings.FieldsFunc(DefaultForbiddenUsernameSuffixes, func(c rune) bool {
 		return c == ','
 	}))
 	c.host.SetDefault(varUserSignupUnverifiedRetentionDays, defaultUserSignupUnverifiedRetentionDays)
@@ -287,6 +296,10 @@ func (c *Config) GetDeactivationDomainsExcludedList() []string {
 
 func (c *Config) GetForbiddenUsernamePrefixes() []string {
 	return c.host.GetStringSlice(varForbiddenUsernamePrefixes)
+}
+
+func (c *Config) GetForbiddenUsernameSuffixes() []string {
+	return c.host.GetStringSlice(varForbiddenUsernameSuffixes)
 }
 
 func (c *Config) GetUserSignupUnverifiedRetentionDays() int {

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -301,3 +301,12 @@ func TestForbiddenUsernamePrefixesHaveCorrectDefaults(t *testing.T) {
 	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "redhat")
 	require.Contains(t, config.GetForbiddenUsernamePrefixes(), "sandbox")
 }
+
+func TestForbiddenUsernameSuffixesHaveCorrectDefaults(t *testing.T) {
+	restore := test.SetEnvVarAndRestore(t, "WATCH_NAMESPACE", "toolchain-host-operator")
+	defer restore()
+
+	config := getDefaultConfiguration(t)
+	require.Len(t, config.GetForbiddenUsernameSuffixes(), 1)
+	require.Contains(t, config.GetForbiddenUsernameSuffixes(), "admin")
+}

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -427,6 +427,14 @@ func (r *ReconcileUserSignup) generateCompliantUsername(instance *toolchainv1alp
 		}
 	}
 
+	// Check for any forbidden suffixes
+	for _, suffix := range r.crtConfig.GetForbiddenUsernameSuffixes() {
+		if strings.HasSuffix(replaced, suffix) {
+			replaced = fmt.Sprintf("%s%s", replaced, "-crt")
+			break
+		}
+	}
+
 	validationErrors := validation.IsQualifiedName(replaced)
 	if len(validationErrors) > 0 {
 		return "", fmt.Errorf(fmt.Sprintf("transformed username [%s] is invalid", replaced))

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -2162,9 +2162,9 @@ func TestUsernameWithForbiddenPrefix(t *testing.T) {
 
 	defer counter.Reset()
 
-	// Confirm we have 3 forbidden prefixes by default
+	// Confirm we have 5 forbidden prefixes by default
 	require.Len(t, config.GetForbiddenUsernamePrefixes(), 5)
-	names := []string{"-Bob", "-Dave", "Linda", "admin", ""}
+	names := []string{"-Bob", "-Dave", "Linda", ""}
 
 	for _, prefix := range config.GetForbiddenUsernamePrefixes() {
 		userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
@@ -2192,6 +2192,48 @@ func TestUsernameWithForbiddenPrefix(t *testing.T) {
 			mur := murs.Items[0]
 			require.Equal(t, userSignup.Name, mur.Labels[v1alpha1.MasterUserRecordOwnerLabelKey])
 			require.Equal(t, fmt.Sprintf("crt-%s%s", prefix, name), mur.Name)
+		}
+
+	}
+}
+
+func TestUsernameWithForbiddenSuffixes(t *testing.T) {
+	// given
+	fakeClient := test.NewFakeClient(t)
+	config, err := configuration.LoadConfig(fakeClient)
+	require.NoError(t, err)
+
+	defer counter.Reset()
+
+	require.Len(t, config.GetForbiddenUsernameSuffixes(), 1)
+	names := []string{"dedicated-", "cluster-", "bob", ""}
+
+	for _, suffix := range config.GetForbiddenUsernameSuffixes() {
+		userSignup := NewUserSignup(Approved(), WithTargetCluster("east"))
+		userSignup.Labels[v1alpha1.UserSignupStateLabelKey] = "not-ready"
+
+		for _, name := range names {
+			userSignup.Spec.Username = fmt.Sprintf("%s%s", name, suffix)
+
+			r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
+			InitializeCounter(t, 1)
+
+			// when
+			_, err := r.Reconcile(req)
+			require.NoError(t, err)
+
+			// then verify that the username has been suffixed - first lookup the UserSignup again
+			err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
+			require.NoError(t, err)
+
+			// Lookup the MUR
+			murs := &v1alpha1.MasterUserRecordList{}
+			err = r.client.List(context.TODO(), murs, client.InNamespace(test.HostOperatorNs))
+			require.NoError(t, err)
+			require.Len(t, murs.Items, 1)
+			mur := murs.Items[0]
+			require.Equal(t, userSignup.Name, mur.Labels[v1alpha1.MasterUserRecordOwnerLabelKey])
+			require.Equal(t, fmt.Sprintf("%s%s-crt", name, suffix), mur.Name)
 		}
 
 	}

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -2216,7 +2216,7 @@ func TestUsernameWithForbiddenSuffixes(t *testing.T) {
 			userSignup.Spec.Username = fmt.Sprintf("%s%s", name, suffix)
 
 			r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
-			InitializeCounter(t, 1)
+			InitializeCounter(t, MasterUserRecords(1))
 
 			// when
 			_, err := r.Reconcile(req)


### PR DESCRIPTION
In the production cluster, there has been created a new user with cluster-admin privileges - that user has a suffix "admin" and some dedicated admin users have the same suffix as well. So I added a logic & configuration that prevents from creating users with the `admin` suffix.

paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/272