### PR TITLE
Use the base tier as the default for new approvals

### DIFF
--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -37,7 +37,7 @@ var log = logf.Log.WithName("controller_usersignup")
 
 type StatusUpdater func(userAcc *toolchainv1alpha1.UserSignup, message string) error
 
-const defaultTierName = "basic"
+const defaultTierName = "base"
 
 // Add creates a new UserSignup Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -295,7 +295,7 @@ func (r *ReconcileUserSignup) ensureMurIfAlreadyExists(reqLogger logr.Logger, us
 			return true, err
 		}
 
-		// look-up the `basic` NSTemplateTier to get the NS templates
+		// look-up the default NSTemplateTier to get the NS templates
 		nstemplateTier, err := getNsTemplateTier(r.client, defaultTierName, userSignup.Namespace)
 		if err != nil {
 			return true, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusNoTemplateTierAvailable, err, "")

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -2207,7 +2207,7 @@ func TestUsernameWithForbiddenSuffixes(t *testing.T) {
 		for _, name := range names {
 			userSignup.Spec.Username = fmt.Sprintf("%s%s", name, suffix)
 
-			r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, basicNSTemplateTier)
+			r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, baseNSTemplateTier)
 			InitializeCounter(t, MasterUserRecords(1))
 
 			// when


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-985

Updates the automatic approval to use the base tier by default

e2e-tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/277