### PR TITLE
update usersignup retention to 180 days

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -122,7 +122,7 @@ const (
 	// gathering user metrics before removing the resources from the cluster.
 	varUserSignupDeactivatedRetentionDays = "usersignup.deactivated.retention.days"
 
-	defaultUserSignupDeactivatedRetentionDays = 90
+	defaultUserSignupDeactivatedRetentionDays = 180
 )
 
 // Config encapsulates the Viper configuration registry which stores the

--- a/pkg/controller/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/pkg/controller/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -3,6 +3,9 @@ package usersignupcleanup
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
@@ -14,8 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"testing"
-	"time"
 
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -64,10 +65,10 @@ func TestUserCleanup(t *testing.T) {
 		require.NotNil(t, userSignup)
 		require.True(t, res.Requeue)
 
-		// We expect the requeue duration to be approximately equal to the default retention time of 90 days. Let's
-		// accept any value here between the range of 89 days and 91 days
-		durLower := time.Duration(89 * time.Hour * 24)
-		durUpper := time.Duration(91 * time.Hour * 24)
+		// We expect the requeue duration to be approximately equal to the default retention time of 180 days. Let's
+		// accept any value here between the range of 179 days and 181 days
+		durLower := time.Duration(179 * time.Hour * 24)
+		durUpper := time.Duration(181 * time.Hour * 24)
 
 		require.Greater(t, res.RequeueAfter, durLower)
 		require.Less(t, res.RequeueAfter, durUpper)


### PR DESCRIPTION
deactivated usersignup resources will be retained for a longer
period, so we can keep track of returning users even later

fixes https://issues.redhat.com/browse/CRT-1021

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
