### PR TITLE
Refactored UserSignup to use states for deactivated flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20210429025708-2d7ac2edb6d8
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210413083628-a2981455c932
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20210503221502-8d45017725b0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/codeready-toolchain/api v0.0.0-20210429025708-2d7ac2edb6d8 h1:w1SeAP9
 github.com/codeready-toolchain/api v0.0.0-20210429025708-2d7ac2edb6d8/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210413083628-a2981455c932 h1:Es/8fAJzJ4l+ynWqkhskRpV2QCd/6D9Cfu2g1d+wpwM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210413083628-a2981455c932/go.mod h1:174YTzyQ21yeNsnnG08RR5VExGBsoH9KDBRRNiy/ahM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210503221502-8d45017725b0 h1:t7awU15V4rbA5W7flBrmsvk0pxMVpZPwg8i5X9okgIk=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20210503221502-8d45017725b0/go.mod h1:174YTzyQ21yeNsnnG08RR5VExGBsoH9KDBRRNiy/ahM=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/go.sum
+++ b/go.sum
@@ -140,12 +140,8 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20210413031854-81652586fd90/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/api v0.0.0-20210426074636-2f2696f1a944 h1:D8wRcU0yJYD+asg10cHlJg5M+/1viZR26bLc1WNnDBc=
-github.com/codeready-toolchain/api v0.0.0-20210426074636-2f2696f1a944/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/codeready-toolchain/api v0.0.0-20210429025708-2d7ac2edb6d8 h1:w1SeAP9MeSByKnujv6IevlUDzi6PaZCNZV/VVSMEXGs=
 github.com/codeready-toolchain/api v0.0.0-20210429025708-2d7ac2edb6d8/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210413083628-a2981455c932 h1:Es/8fAJzJ4l+ynWqkhskRpV2QCd/6D9Cfu2g1d+wpwM=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210413083628-a2981455c932/go.mod h1:174YTzyQ21yeNsnnG08RR5VExGBsoH9KDBRRNiy/ahM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210503221502-8d45017725b0 h1:t7awU15V4rbA5W7flBrmsvk0pxMVpZPwg8i5X9okgIk=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210503221502-8d45017725b0/go.mod h1:174YTzyQ21yeNsnnG08RR5VExGBsoH9KDBRRNiy/ahM=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -127,6 +127,11 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
+	// If the usersignup is already deactivated then there's nothing else to do
+	if states.Deactivated(usersignup) {
+		return reconcile.Result{}, nil
+	}
+
 	// Check the domain exclusion list, if the user's email matches then they cannot be automatically deactivated
 	if emailLbl, exists := usersignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey]; exists {
 		for _, domain := range r.config.GetDeactivationDomainsExcludedList() {

--- a/pkg/controller/deactivation/deactivation_controller.go
+++ b/pkg/controller/deactivation/deactivation_controller.go
@@ -225,11 +225,11 @@ func (r *ReconcileDeactivation) Reconcile(request reconcile.Request) (reconcile.
 	}
 
 	// Deactivate the user
-	if usersignup.Spec.Deactivated {
+	if states.Deactivated(usersignup) {
 		// The UserSignup is already set for deactivation, nothing left to do
 		return reconcile.Result{}, nil
 	}
-	usersignup.Spec.Deactivated = true
+	states.SetDeactivated(usersignup, true)
 
 	if err := r.client.Update(context.TODO(), usersignup); err != nil {
 		logger.Error(err, "failed to update usersignup")

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -197,7 +197,7 @@ func TestReconcile(t *testing.T) {
 				t.Run("usersignup requeued after deactivating notification created for user", func(t *testing.T) {
 					// Set the notification status condition as sent
 					userSignupFoobar.Status.Conditions = []toolchainv1alpha1.Condition{
-						toolchainv1alpha1.Condition{
+						{
 							Type:               toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
 							Status:             v1.ConditionTrue,
 							LastTransitionTime: metav1.Time{Time: time.Now()},
@@ -227,7 +227,7 @@ func TestReconcile(t *testing.T) {
 					t.Run("usersignup should be deactivated", func(t *testing.T) {
 						// Set the notification status condition as sent, but this time 3 days in the past
 						userSignupFoobar.Status.Conditions = []toolchainv1alpha1.Condition{
-							toolchainv1alpha1.Condition{
+							{
 								Type:               toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
 								Status:             v1.ConditionTrue,
 								LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Duration(-3) * time.Hour * 24)},

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -174,7 +174,7 @@ func TestReconcile(t *testing.T) {
 			// Reload the userSignup
 			require.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: userSignupFoobar.Name, Namespace: operatorNamespace}, userSignupFoobar))
 			require.True(t, states.Deactivating(userSignupFoobar))
-			require.False(t, userSignupFoobar.Spec.Deactivated)
+			require.False(t, states.Deactivated(userSignupFoobar))
 
 			t.Run("reconciliation should be requeued when notification not yet sent", func(t *testing.T) {
 				r, req, cl := prepareReconcile(t, mur.Name, basicTier, mur, userSignupFoobar, config)
@@ -192,7 +192,7 @@ func TestReconcile(t *testing.T) {
 				require.True(t, states.Deactivating(userSignupFoobar))
 
 				// deactivated state should still be false
-				require.False(t, userSignupFoobar.Spec.Deactivated)
+				require.False(t, states.Deactivated(userSignupFoobar))
 
 				t.Run("usersignup requeued after deactivating notification created for user", func(t *testing.T) {
 					// Set the notification status condition as sent
@@ -222,7 +222,7 @@ func TestReconcile(t *testing.T) {
 					require.True(t, states.Deactivating(userSignupFoobar))
 
 					// deactivated state should still be false
-					require.False(t, userSignupFoobar.Spec.Deactivated)
+					require.False(t, states.Deactivated(userSignupFoobar))
 
 					t.Run("usersignup should be deactivated", func(t *testing.T) {
 						// Set the notification status condition as sent, but this time 3 days in the past
@@ -250,7 +250,7 @@ func TestReconcile(t *testing.T) {
 						require.True(t, states.Deactivating(userSignupFoobar))
 
 						// deactivated state should now be true also
-						require.True(t, userSignupFoobar.Spec.Deactivated)
+						require.True(t, states.Deactivated(userSignupFoobar))
 
 						t.Run("usersignup already deactivated", func(t *testing.T) {
 							// additional reconciles should find the usersignup is already deactivated
@@ -267,7 +267,7 @@ func TestReconcile(t *testing.T) {
 
 		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'other' tier
 		t.Run("usersignup should be deactivated - other tier (60 days)", func(t *testing.T) {
-			userSignupFoobar.Spec.Deactivated = false
+			states.SetDeactivated(userSignupFoobar, false)
 			// given
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutOtherTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *otherTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))
@@ -416,7 +416,7 @@ func assertThatUserSignupDeactivated(t *testing.T, cl *test.FakeClient, name str
 	userSignup := &toolchainv1alpha1.UserSignup{}
 	err := cl.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: operatorNamespace}, userSignup)
 	require.NoError(t, err)
-	require.Equal(t, expected, userSignup.Spec.Deactivated)
+	require.Equal(t, expected, states.Deactivated(userSignup))
 }
 
 func newHostOperatorConfigWithReset(t *testing.T, options ...test.HostOperatorConfigOption) *toolchainv1alpha1.HostOperatorConfig {

--- a/pkg/controller/deactivation/deactivation_controller_test.go
+++ b/pkg/controller/deactivation/deactivation_controller_test.go
@@ -246,10 +246,10 @@ func TestReconcile(t *testing.T) {
 						// Reload the userSignup
 						require.NoError(t, cl.Get(context.TODO(), types.NamespacedName{Name: userSignupFoobar.Name, Namespace: operatorNamespace}, userSignupFoobar))
 
-						// deactivating state should still be true
-						require.True(t, states.Deactivating(userSignupFoobar))
+						// deactivating state should now be false
+						require.False(t, states.Deactivating(userSignupFoobar))
 
-						// deactivated state should now be true also
+						// deactivated state should now be true
 						require.True(t, states.Deactivated(userSignupFoobar))
 
 						t.Run("usersignup already deactivated", func(t *testing.T) {
@@ -267,7 +267,7 @@ func TestReconcile(t *testing.T) {
 
 		// the time since the mur was provisioned exceeds the deactivation timeout period for the 'other' tier
 		t.Run("usersignup should be deactivated - other tier (60 days)", func(t *testing.T) {
-			states.SetDeactivated(userSignupFoobar, false)
+			states.SetDeactivating(userSignupFoobar, true)
 			// given
 			murProvisionedTime := &metav1.Time{Time: time.Now().Add(-time.Duration(expectedDeactivationTimeoutOtherTier*24) * time.Hour)}
 			mur := murtest.NewMasterUserRecord(t, username, murtest.Account("cluster1", *otherTier), murtest.ProvisionedMur(murProvisionedTime), murtest.UserIDFromUserSignup(userSignupFoobar))

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -156,6 +156,8 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 		if err := r.client.Update(context.TODO(), userSignup); err != nil {
 			return reconcile.Result{}, err
 		}
+		// Requeue the reconciliation if the UserSignup was migrated
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	if userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] == "" {

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -211,7 +211,7 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 	}
 
-	if states.Deactivating(userSignup) && !states.Deactivated(userSignup) && condition.IsNotTrue(userSignup.Status.Conditions,
+	if states.Deactivating(userSignup) && condition.IsNotTrue(userSignup.Status.Conditions,
 		toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated) {
 
 		if err := r.sendDeactivatingNotification(logger, userSignup); err != nil {

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -146,9 +146,20 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 	logger = logger.WithValues("username", userSignup.Spec.Username)
 
+	// ###################################################################################
+	//
+	// TODO Migration code - remove this after all UserSignup instances have been migrated
+	//
+	// ###################################################################################
+	if userSignup.Spec.Deactivated && !states.Deactivated(userSignup) {
+		states.SetDeactivated(userSignup, true)
+		if err := r.client.Update(context.TODO(), userSignup); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	if userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] == "" {
 		if err := r.setStateLabel(logger, userSignup, toolchainv1alpha1.UserSignupStateLabelValueNotReady); err != nil {
-
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -157,7 +157,7 @@ func (r *ReconcileUserSignup) Reconcile(request reconcile.Request) (reconcile.Re
 			return reconcile.Result{}, err
 		}
 		// Requeue the reconciliation if the UserSignup was migrated
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{}, nil
 	}
 
 	if userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] == "" {

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -1381,7 +1381,8 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 		mur := murtest.NewMasterUserRecord(t, "john-doe", murtest.MetaNamespace(test.HostOperatorNs))
 		mur.Labels = map[string]string{v1alpha1.MasterUserRecordOwnerLabelKey: userSignup.Name}
 
-		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, mur, NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), baseNSTemplateTier)
+		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, mur,
+			NewHostOperatorConfigWithReset(t, test.AutomaticApproval().Enabled()), baseNSTemplateTier)
 		InitializeCounters(t, NewToolchainStatus(WithHost(WithMasterUserRecordCount(1))))
 
 		// when
@@ -1477,9 +1478,9 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "john.doe@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:      "UserID123",
-			Username:    "john.doe@redhat.com",
-			Deactivated: true,
+			UserID:   "UserID123",
+			Username: "john.doe@redhat.com",
+			States:   []v1alpha1.UserSignupState{v1alpha1.UserSignupStateDeactivated},
 		},
 		Status: v1alpha1.UserSignupStatus{
 			Conditions: []v1alpha1.Condition{
@@ -1566,9 +1567,8 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "john.doe@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:      "UserID123",
-			Username:    "john.doe@redhat.com",
-			Deactivated: false,
+			UserID:   "UserID123",
+			Username: "john.doe@redhat.com",
 		},
 		Status: v1alpha1.UserSignupStatus{
 			CompliantUsername: "john-doe",
@@ -1736,9 +1736,9 @@ func TestUserSignupDeactivatedWhenMURExists(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "edward.jones@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:      "UserID123",
-			Username:    "edward.jones@redhat.com",
-			Deactivated: true,
+			UserID:   "UserID123",
+			Username: "edward.jones@redhat.com",
+			States:   []v1alpha1.UserSignupState{v1alpha1.UserSignupStateDeactivated},
 		},
 		Status: v1alpha1.UserSignupStatus{
 			Conditions: []v1alpha1.Condition{
@@ -2150,9 +2150,9 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 	userSignup := &v1alpha1.UserSignup{
 		ObjectMeta: NewUserSignupObjectMeta("", "alice.mayweather.doe@redhat.com"),
 		Spec: v1alpha1.UserSignupSpec{
-			UserID:      "UserID123",
-			Username:    "alice.mayweather.doe@redhat.com",
-			Deactivated: true,
+			UserID:   "UserID123",
+			Username: "alice.mayweather.doe@redhat.com",
+			States:   []v1alpha1.UserSignupState{v1alpha1.UserSignupStateDeactivated},
 		},
 		Status: v1alpha1.UserSignupStatus{
 			Conditions: []v1alpha1.Condition{

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
@@ -56,6 +58,27 @@ func newNsTemplateTier(tierName string, nsTypes ...string) *v1alpha1.NSTemplateT
 }
 
 var baseNSTemplateTier = newNsTemplateTier("base", "dev", "stage")
+
+// TODO remove this test once the migration code is removed
+func TestMigration(t *testing.T) {
+	// given
+	userSignup := NewUserSignup()
+	userSignup.Spec.Deactivated = true
+	r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup)
+
+	// when
+	res, err := r.Reconcile(req)
+	require.NoError(t, err)
+
+	// Verify that the UserSignup was migrated correctly, and the result is set to requeue
+	require.True(t, res.Requeue)
+
+	// Reload the UserSignup
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)
+	require.NoError(t, err)
+
+	require.True(t, states.Deactivated(userSignup))
+}
 
 func TestUserSignupCreateMUROk(t *testing.T) {
 

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -67,11 +67,8 @@ func TestMigration(t *testing.T) {
 	r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup)
 
 	// when
-	res, err := r.Reconcile(req)
+	_, err := r.Reconcile(req)
 	require.NoError(t, err)
-
-	// Verify that the UserSignup was migrated correctly, and the result is set to requeue
-	require.True(t, res.Requeue)
 
 	// Reload the UserSignup
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, userSignup)

--- a/pkg/controller/usersignupcleanup/usersignup_cleanup_controller.go
+++ b/pkg/controller/usersignupcleanup/usersignup_cleanup_controller.go
@@ -2,9 +2,12 @@ package usersignupcleanup
 
 import (
 	"context"
+	"time"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
 	crtCfg "github.com/codeready-toolchain/host-operator/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	"github.com/go-logr/logr"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -16,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
 )
 
 var log = logf.Log.WithName("controller_usercleanup")
@@ -111,7 +113,7 @@ func (r *ReconcileUserSignupCleanup) Reconcile(request reconcile.Request) (recon
 		}, nil
 	}
 
-	if instance.Spec.Deactivated {
+	if states.Deactivated(instance) {
 		// Find the UserSignupComplete condition
 		cond, found := condition.FindConditionByType(instance.Status.Conditions, toolchainv1alpha1.UserSignupComplete)
 

--- a/test/usersignup.go
+++ b/test/usersignup.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"time"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
@@ -42,13 +44,13 @@ func ApprovedAutomatically() UserSignupModifier {
 
 func Deactivated() UserSignupModifier {
 	return func(userSignup *v1alpha1.UserSignup) {
-		userSignup.Spec.Deactivated = true
+		states.SetDeactivated(userSignup, true)
 	}
 }
 
 func DeactivatedWithLastTransitionTime(before time.Duration) UserSignupModifier {
 	return func(userSignup *v1alpha1.UserSignup) {
-		userSignup.Spec.Deactivated = true
+		states.SetDeactivated(userSignup, true)
 
 		deactivatedCondition := toolchainv1alpha1.Condition{
 			Type:               v1alpha1.UserSignupComplete,


### PR DESCRIPTION
This PR refactored the host operator to use the `UserSignup.Spec.States` property to record the deactivated state, instead of `UserSignup.Spec.Deactivated`.

Fixes https://issues.redhat.com/browse/CRT-1006

Related toolchain-common PR: https://github.com/codeready-toolchain/toolchain-common/pull/162

Related sandbox-sre PR: https://github.com/codeready-toolchain/sandbox-sre/pull/213