### PR TITLE
Enhance logging for failed notification delivery

### DIFF
--- a/pkg/controller/notification/notification_context.go
+++ b/pkg/controller/notification/notification_context.go
@@ -2,6 +2,7 @@ package notification
 
 type Context interface {
 	DeliveryEmail() string
+	KeysAndValues() []interface{}
 }
 
 // AdminNotificationContext is used to generate a notification for sending to an admin mailing list
@@ -21,4 +22,10 @@ func NewAdminNotificationContext(adminEmail string) *AdminNotificationContext {
 
 func (c *AdminNotificationContext) DeliveryEmail() string {
 	return c.AdminEmail
+}
+
+func (c *AdminNotificationContext) KeysAndValues() []interface{} {
+	return []interface{}{
+		"DeliveryEmail", c.DeliveryEmail(),
+	}
 }

--- a/pkg/controller/notification/notification_controller.go
+++ b/pkg/controller/notification/notification_controller.go
@@ -112,6 +112,10 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		// Send the notification via the configured delivery service
 		err = r.deliveryService.Send(notCtx, notification)
 		if err != nil {
+			reqLogger.Error(err, "delivery service failed to send notification",
+				notCtx.KeysAndValues()...,
+			)
+
 			return reconcile.Result{}, r.wrapErrorWithStatusUpdate(reqLogger, notification,
 				r.setStatusNotificationDeliveryError, err, "failed to send notification")
 		}

--- a/pkg/controller/notification/user_notification_context.go
+++ b/pkg/controller/notification/user_notification_context.go
@@ -63,3 +63,15 @@ func (c *UserNotificationContext) DeliveryEmail() string {
 		c.LastName,
 		c.UserEmail)
 }
+
+func (c *UserNotificationContext) KeysAndValues() []interface{} {
+	return []interface{}{
+		"UserID", c.UserID,
+		"UserEmail", c.UserEmail,
+		"DeliveryEmail", c.DeliveryEmail(),
+		"FirstName", c.FirstName,
+		"LastName", c.LastName,
+		"CompanyName", c.CompanyName,
+		"RegistrationURL", c.RegistrationURL,
+	}
+}


### PR DESCRIPTION
Initial diagnostic code for https://issues.redhat.com/browse/CRT-1104.  This PR will capture additional notification context state in our logs in order to determine cause of delivery errors.