### PR TITLE
Rename Deactivating reason to DeactivationInProgress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go v0.60.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20210527231005-3bb0f668e644
+	github.com/codeready-toolchain/api v0.0.0-20210528134715-13373a2ab54a
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20210528140854-e36fca9e7edf
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codeready-toolchain/api v0.0.0-20210527231005-3bb0f668e644 h1:A/p5oS6ACSSNEXt7BTL7OaLoaKK575+7bi0WbDG1BPw=
 github.com/codeready-toolchain/api v0.0.0-20210527231005-3bb0f668e644/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
+github.com/codeready-toolchain/api v0.0.0-20210528134715-13373a2ab54a h1:vgAmn8t5F0+9PIeYpooMLwj9rjPqFDw4RNUhGZFP1S4=
+github.com/codeready-toolchain/api v0.0.0-20210528134715-13373a2ab54a/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210528140854-e36fca9e7edf h1:sQhalyiXRkQbcN9kY2OF1ytDfueDOd0DYkG3dZPjf/s=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210528140854-e36fca9e7edf/go.mod h1:xYj5K9tJRqoYP/+TPaUXELd81hK9XTdlk9A6kCIFWCg=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/pkg/controller/usersignup/status.go
+++ b/pkg/controller/usersignup/status.go
@@ -138,13 +138,13 @@ func (u *StatusUpdater) setStatusBanned(userSignup *toolchainv1alpha1.UserSignup
 		})
 }
 
-func (u *StatusUpdater) setStatusDeactivating(userSignup *toolchainv1alpha1.UserSignup, message string) error {
+func (u *StatusUpdater) setStatusDeactivationInProgress(userSignup *toolchainv1alpha1.UserSignup, message string) error {
 	return u.updateStatusConditions(
 		userSignup,
 		toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
 			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUserDeactivatingReason,
+			Reason:  toolchainv1alpha1.UserSignupDeactivationInProgressReason,
 			Message: message,
 		})
 }

--- a/pkg/controller/usersignup/usersignup_controller.go
+++ b/pkg/controller/usersignup/usersignup_controller.go
@@ -303,10 +303,10 @@ func (r *Reconciler) checkIfMurAlreadyExists(reqLogger logr.Logger, userSignup *
 			if err := r.setStateLabel(reqLogger, userSignup, toolchainv1alpha1.UserSignupStateLabelValueDeactivated); err != nil {
 				return true, err
 			}
-			// We set the inProgressStatusUpdater parameter here to setStatusDeactivating, as a temporary status before
+			// We set the inProgressStatusUpdater parameter here to setStatusDeactivationInProgress, as a temporary status before
 			// the main reconcile function completes the deactivation process
 			reqLogger.Info("deleting MasterUserRecord since user has been deactivated")
-			return true, r.DeleteMasterUserRecord(mur, userSignup, reqLogger, r.setStatusDeactivating, r.setStatusFailedToDeleteMUR)
+			return true, r.DeleteMasterUserRecord(mur, userSignup, reqLogger, r.setStatusDeactivationInProgress, r.setStatusFailedToDeleteMUR)
 		}
 
 		// if the UserSignup doesn't have the state=approved label set, then update it

--- a/pkg/controller/usersignup/usersignup_controller_test.go
+++ b/pkg/controller/usersignup/usersignup_controller_test.go
@@ -1604,7 +1604,7 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
 				Status: v1.ConditionFalse,
-				Reason: "Deactivating",
+				Reason: "DeactivationInProgress",
 			})
 
 		murs := &toolchainv1alpha1.MasterUserRecordList{}
@@ -2110,7 +2110,7 @@ func TestUserSignupDeactivatedWhenMURExists(t *testing.T) {
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupComplete,
 					Status: v1.ConditionFalse,
-					Reason: "Deactivating",
+					Reason: "DeactivationInProgress",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,


### PR DESCRIPTION
This PR changes the "Deactivating" reason to "DeactivationInProgress" in order to remove ambiguity between the state where the user is currently in the process of being deactivated, as opposed to the user being within the pre-deactivation period before their account is deactivated.