### PR TITLE
chore: add publish-operator-for-e2e-tests worflow

### DIFF
--- a/.github/workflows/publish-operator-for-e2e-tests.yml
+++ b/.github/workflows/publish-operator-for-e2e-tests.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   GOPATH: /tmp/go
-  GO_VERSION: 1.15.x
+  GO_VERSION: 1.16.x
 
 jobs:
   binary:

--- a/.github/workflows/publish-operator-for-e2e-tests.yml
+++ b/.github/workflows/publish-operator-for-e2e-tests.yml
@@ -1,0 +1,60 @@
+name: publish-operator-for-e2e-tests
+on:
+  pull_request_target
+
+env:
+  GOPATH: /tmp/go
+  GO_VERSION: 1.15.x
+
+jobs:
+  binary:
+    name: Build & push operator bundle for e2e tests
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles ('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Prepare tools
+      #      uses: codeready-toolchain/toolchain-cicd/prepare-tools-action@master
+      uses: MatousJobanek/toolchain-cicd/prepare-tools-action@master
+
+    - name: Login to quay
+      shell: bash
+      run: |
+        set -e
+        mkdir -p  ~/.docker || true
+        echo "{
+                      \"auths\": {
+                              \"quay.io\": {
+                                      \"auth\": \"${{ secrets.TEST_QUAY_TOKEN }}\"
+                              }
+                      }
+              }"> ~/.docker/config.json
+
+        podman login quay.io  --authfile=~/.docker/config.json
+
+    - name: Publish current bundle for e2e tests
+      shell: bash
+      run: |
+        make publish-current-bundle-for-e2e QUAY_NAMESPACE=codeready-toolchain-test IMAGE_BUILDER=podman || true


### PR DESCRIPTION
This is a workflow that will publish bundle of host operator for every PR
This is needed for the migration to operator-sdk 1.8.0
Since it uses `pull_request_target` to be able to access secrets, I need to have it in master branch so it is executed by GH actions