### PR TITLE
fix: use PR head from fork repo

### DIFF
--- a/.github/workflows/publish-operator-for-e2e-tests.yml
+++ b/.github/workflows/publish-operator-for-e2e-tests.yml
@@ -16,6 +16,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
       with:
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
         fetch-depth: 0
 
     - name: Install Go


### PR DESCRIPTION
by default when `pull_request_target` is used, then it uses code from master, but we need to checkout the PR head from forked repo