### PR TITLE
chore: rename & update publish-operators-for-e2e-tests.yml to the latest

### DIFF
--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -1,4 +1,4 @@
-name: publish-operator-for-e2e-tests
+name: publish-operators-for-e2e-tests
 on:
   pull_request_target
 
@@ -8,7 +8,7 @@ env:
 
 jobs:
   binary:
-    name: Build & push operator bundle for e2e tests
+    name: Build & push operator bundles for e2e tests
 
     runs-on: ubuntu-18.04
 
@@ -38,25 +38,12 @@ jobs:
         python-version: '3.x'
 
     - name: Prepare tools
-      #      uses: codeready-toolchain/toolchain-cicd/prepare-tools-action@master
+      #uses: codeready-toolchain/toolchain-cicd/prepare-tools-action@master
       uses: MatousJobanek/toolchain-cicd/prepare-tools-action@master
 
-    - name: Login to quay
-      shell: bash
-      run: |
-        set -e
-        mkdir -p  ~/.docker || true
-        echo "{
-                      \"auths\": {
-                              \"quay.io\": {
-                                      \"auth\": \"${{ secrets.TEST_QUAY_TOKEN }}\"
-                              }
-                      }
-              }"> ~/.docker/config.json
-
-        podman login quay.io  --authfile=~/.docker/config.json
-
-    - name: Publish current bundle for e2e tests
-      shell: bash
-      run: |
-        make publish-current-bundle-for-e2e QUAY_NAMESPACE=codeready-toolchain-test IMAGE_BUILDER=podman || true
+    - name: Publish current operator bundles for host & member
+      #uses: codeready-toolchain/toolchain-cicd/publish-operators-for-e2e-tests@master
+      uses: MatousJobanek/toolchain-cicd/publish-operators-for-e2e-tests@master
+      with:
+        quay-token: ${{ secrets.TEST_QUAY_TOKEN }}
+        quay-namespace: codeready-toolchain-test


### PR DESCRIPTION
rename & update the publish-operators-for-e2e-tests.yml worflow to the latest working & verified version