### PR TITLE
fix: skip reconcile when UserSignup is being deleted

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -139,7 +139,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	logger = logger.WithValues("username", userSignup.Spec.Username)
 
 	if util.IsBeingDeleted(userSignup) {
-		logger.Error(err, "The UserSignup is being deleted")
+		logger.Info("The UserSignup is being deleted")
 		return reconcile.Result{}, nil
 	}
 

--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/controllers/usersignup/unapproved"
@@ -136,6 +137,11 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 	logger = logger.WithValues("username", userSignup.Spec.Username)
+
+	if util.IsBeingDeleted(userSignup) {
+		logger.Error(err, "The UserSignup is being deleted")
+		return reconcile.Result{}, nil
+	}
 
 	if userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] == "" {
 		if err := r.setStateLabel(logger, userSignup, toolchainv1alpha1.UserSignupStateLabelValueNotReady); err != nil {


### PR DESCRIPTION
When UserSignup is being deleted, then (in my opinion) we should not do anything in the reconcile. 
My guess is that the flakiness is caused by reconciliation that creates MUR just after their deletion - this is at least what it looks like from the logs. 
I can be wrong, but still - when the UserSignup is being deleted, we should just exit the reconcile.
I'm open to discussion ;-) 