### PR TITLE
Formatted email address to be more RFC2822 compliant

### DIFF
--- a/controllers/notification/mailgun_notification_delivery_service.go
+++ b/controllers/notification/mailgun_notification_delivery_service.go
@@ -3,8 +3,9 @@ package notification
 import (
 	"context"
 	"fmt"
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	"github.com/mailgun/mailgun-go/v4"
 )

--- a/controllers/notification/notification_controller_test.go
+++ b/controllers/notification/notification_controller_test.go
@@ -161,7 +161,7 @@ func TestNotificationDelivery(t *testing.T) {
 		e := events[0]
 		require.IsType(t, &events2.Accepted{}, e)
 		accepted := e.(*events2.Accepted)
-		require.Equal(t, "\"Foo Bar\"<foo@redhat.com>", accepted.Recipient)
+		require.Equal(t, "foo@redhat.com", accepted.Recipient)
 		require.Equal(t, "redhat.com", accepted.RecipientDomain)
 		require.Equal(t, "foo", accepted.Message.Headers.Subject)
 		require.Equal(t, "noreply@foo.com", accepted.Message.Headers.From)

--- a/controllers/notification/notification_controller_test.go
+++ b/controllers/notification/notification_controller_test.go
@@ -161,7 +161,7 @@ func TestNotificationDelivery(t *testing.T) {
 		e := events[0]
 		require.IsType(t, &events2.Accepted{}, e)
 		accepted := e.(*events2.Accepted)
-		require.Equal(t, "Foo Bar<foo@redhat.com>", accepted.Recipient)
+		require.Equal(t, "\"Foo Bar\"<foo@redhat.com>", accepted.Recipient)
 		require.Equal(t, "redhat.com", accepted.RecipientDomain)
 		require.Equal(t, "foo", accepted.Message.Headers.Subject)
 		require.Equal(t, "noreply@foo.com", accepted.Message.Headers.From)

--- a/controllers/notification/user_notification_context.go
+++ b/controllers/notification/user_notification_context.go
@@ -3,8 +3,6 @@ package notification
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strings"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
@@ -59,17 +57,13 @@ func NewUserNotificationContext(client client.Client, userID, namespace string, 
 }
 
 func (c *UserNotificationContext) DeliveryEmail() string {
-	return fmt.Sprintf("\"%s %s\"<%s>",
-		strings.Replace(c.FirstName, "\"", "", -1),
-		strings.Replace(c.LastName, "\"", "", -1),
-		c.UserEmail)
+	return c.UserEmail
 }
 
 func (c *UserNotificationContext) KeysAndValues() []interface{} {
 	return []interface{}{
 		"UserID", c.UserID,
 		"UserEmail", c.UserEmail,
-		"DeliveryEmail", c.DeliveryEmail(),
 		"FirstName", c.FirstName,
 		"LastName", c.LastName,
 		"CompanyName", c.CompanyName,

--- a/controllers/notification/user_notification_context.go
+++ b/controllers/notification/user_notification_context.go
@@ -58,7 +58,7 @@ func NewUserNotificationContext(client client.Client, userID, namespace string, 
 }
 
 func (c *UserNotificationContext) DeliveryEmail() string {
-	return fmt.Sprintf("%s %s<%s>",
+	return fmt.Sprintf("\"%s %s\"<%s>",
 		c.FirstName,
 		c.LastName,
 		c.UserEmail)

--- a/controllers/notification/user_notification_context.go
+++ b/controllers/notification/user_notification_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/configuration"
@@ -59,8 +60,8 @@ func NewUserNotificationContext(client client.Client, userID, namespace string, 
 
 func (c *UserNotificationContext) DeliveryEmail() string {
 	return fmt.Sprintf("\"%s %s\"<%s>",
-		c.FirstName,
-		c.LastName,
+		strings.Replace(c.FirstName, "\"", "", -1),
+		strings.Replace(c.LastName, "\"", "", -1),
 		c.UserEmail)
 }
 

--- a/controllers/notification/user_notification_context_test.go
+++ b/controllers/notification/user_notification_context_test.go
@@ -72,7 +72,7 @@ func TestNotificationContext(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		require.Equal(t, "John Smith<jsmith@redhat.com>", notificationCtx.DeliveryEmail())
+		require.Equal(t, "\"John Smith\"<jsmith@redhat.com>", notificationCtx.DeliveryEmail())
 	})
 
 	t.Run("no configuration provided", func(t *testing.T) {

--- a/controllers/notification/user_notification_context_test.go
+++ b/controllers/notification/user_notification_context_test.go
@@ -66,13 +66,13 @@ func TestNotificationContext(t *testing.T) {
 		require.Equal(t, "usersignups.toolchain.dev.openshift.com \"other\" not found", err.Error())
 	})
 
-	t.Run("full email address", func(t *testing.T) {
+	t.Run("email address correct", func(t *testing.T) {
 		// when
 		notificationCtx, err := NewUserNotificationContext(client, userSignup.Name, operatorNamespace, config)
 
 		// then
 		require.NoError(t, err)
-		require.Equal(t, "\"John Smith\"<jsmith@redhat.com>", notificationCtx.DeliveryEmail())
+		require.Equal(t, "jsmith@redhat.com", notificationCtx.DeliveryEmail())
 	})
 
 	t.Run("no configuration provided", func(t *testing.T) {
@@ -82,29 +82,6 @@ func TestNotificationContext(t *testing.T) {
 		// then
 		require.Error(t, err)
 		assert.Equal(t, "configuration was not provided", err.Error())
-	})
-
-	t.Run("email address corrected when user's first and last name contain quotes", func(t *testing.T) {
-
-		// given
-		userSignup2 := &toolchainv1alpha1.UserSignup{
-			ObjectMeta: newObjectMeta("jane", "jdoe@redhat.com"),
-			Spec: toolchainv1alpha1.UserSignupSpec{
-				Username:      "jdoe@redhat.com",
-				TargetCluster: "east",
-				FamilyName:    "\"Doe\"",
-				GivenName:     "\"Jane\"",
-			},
-		}
-
-		client := prepareReconcile(t, userSignup2)
-
-		// when
-		notificationCtx, err := NewUserNotificationContext(client, userSignup2.Name, operatorNamespace, config)
-
-		// then
-		require.NoError(t, err)
-		require.Equal(t, "\"Jane Doe\"<jdoe@redhat.com>", notificationCtx.DeliveryEmail())
 	})
 }
 

--- a/controllers/notification/user_notification_context_test.go
+++ b/controllers/notification/user_notification_context_test.go
@@ -83,6 +83,29 @@ func TestNotificationContext(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, "configuration was not provided", err.Error())
 	})
+
+	t.Run("email address corrected when user's first and last name contain quotes", func(t *testing.T) {
+
+		// given
+		userSignup2 := &toolchainv1alpha1.UserSignup{
+			ObjectMeta: newObjectMeta("jane", "jdoe@redhat.com"),
+			Spec: toolchainv1alpha1.UserSignupSpec{
+				Username:      "jdoe@redhat.com",
+				TargetCluster: "east",
+				FamilyName:    "\"Doe\"",
+				GivenName:     "\"Jane\"",
+			},
+		}
+
+		client := prepareReconcile(t, userSignup2)
+
+		// when
+		notificationCtx, err := NewUserNotificationContext(client, userSignup2.Name, operatorNamespace, config)
+
+		// then
+		require.NoError(t, err)
+		require.Equal(t, "\"Jane Doe\"<jdoe@redhat.com>", notificationCtx.DeliveryEmail())
+	})
 }
 
 func newObjectMeta(name, email string) metav1.ObjectMeta {


### PR DESCRIPTION
After much digging through the RFC2822 spec, it seems the simplest fix for countering invalid characters that users insert into their names is to just surround their name with double quotes, making it a `quoted-string` (see https://datatracker.ietf.org/doc/html/rfc2822#section-3.2.5)

Fixes https://issues.redhat.com/browse/CRT-1166