### PR TITLE
Add validation for recipient when creating a new NotificationBuilder

### DIFF
--- a/controllers/notification/notification_builder.go
+++ b/controllers/notification/notification_builder.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -12,6 +13,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+var emailRegex = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
 type Option = func(notification *toolchainv1alpha1.Notification) error
 
@@ -41,6 +44,10 @@ type notificationBuilderImpl struct {
 }
 
 func (b *notificationBuilderImpl) Create(recipient string) (*toolchainv1alpha1.Notification, error) {
+
+	if !emailRegex.MatchString(recipient) {
+		return nil, fmt.Errorf("The specified recipient [%s] is not a valid email address", recipient)
+	}
 
 	notification := &toolchainv1alpha1.Notification{
 		ObjectMeta: v1.ObjectMeta{

--- a/controllers/notification/notification_builder_test.go
+++ b/controllers/notification/notification_builder_test.go
@@ -43,6 +43,21 @@ func TestNotificationBuilder(t *testing.T) {
 		require.Equal(t, "The specified recipient [foo] is not a valid email address", err.Error())
 	})
 
+	t.Run("test ok with multiple valid email addresses", func(t *testing.T) {
+		emailsToTest := []string{
+			"john.wick@subdomain.domain.com",
+			"john-Wick@domain.com",
+		}
+
+		// when
+		for _, email := range emailsToTest {
+			_, err := NewNotificationBuilder(client, test.HostOperatorNs).Create(email)
+
+			// then
+			require.NoError(t, err)
+		}
+	})
+
 	t.Run("test notification builder with user context", func(t *testing.T) {
 		// when
 		userSignup := test2.NewUserSignup()

--- a/controllers/notification/notification_builder_test.go
+++ b/controllers/notification/notification_builder_test.go
@@ -25,6 +25,24 @@ func TestNotificationBuilder(t *testing.T) {
 		require.Equal(t, "foo@acme.com", notification.Spec.Recipient)
 	})
 
+	t.Run("test create fails with empty email address", func(t *testing.T) {
+		// when
+		_, err := NewNotificationBuilder(client, test.HostOperatorNs).Create("")
+
+		// then
+		require.Error(t, err)
+		require.Equal(t, "The specified recipient [] is not a valid email address", err.Error())
+	})
+
+	t.Run("test create fails with invalid email address", func(t *testing.T) {
+		// when
+		_, err := NewNotificationBuilder(client, test.HostOperatorNs).Create("foo")
+
+		// then
+		require.Error(t, err)
+		require.Equal(t, "The specified recipient [foo] is not a valid email address", err.Error())
+	})
+
 	t.Run("test notification builder with user context", func(t *testing.T) {
 		// when
 		userSignup := test2.NewUserSignup()

--- a/controllers/notification/notification_controller_test.go
+++ b/controllers/notification/notification_controller_test.go
@@ -52,7 +52,7 @@ func TestNotificationSuccess(t *testing.T) {
 		ds, _ := mockDeliveryService(defaultTemplateLoader())
 		controller, cl := newController(t, ds, toolchainConfig)
 
-		notification, err := NewNotificationBuilder(cl, test.HostOperatorNs).Create("jane")
+		notification, err := NewNotificationBuilder(cl, test.HostOperatorNs).Create("jane@acme.com")
 		require.NoError(t, err)
 		notification.Status.Conditions = []toolchainv1alpha1.Condition{sentCond()}
 		require.NoError(t, cl.Update(context.TODO(), notification))
@@ -74,7 +74,7 @@ func TestNotificationSuccess(t *testing.T) {
 		ds, _ := mockDeliveryService(defaultTemplateLoader())
 		controller, cl := newController(t, ds, toolchainConfig)
 
-		notification, err := NewNotificationBuilder(cl, test.HostOperatorNs).Create("jane")
+		notification, err := NewNotificationBuilder(cl, test.HostOperatorNs).Create("jane@acme.com")
 		require.NoError(t, err)
 		notification.Status.Conditions = []toolchainv1alpha1.Condition{sentCond()}
 		notification.Status.Conditions[0].LastTransitionTime = v1.Time{Time: time.Now().Add(-cast.ToDuration("10s"))}
@@ -250,7 +250,7 @@ func TestNotificationDelivery(t *testing.T) {
 		controller, client := newController(t, nil, userSignup, toolchainConfig)
 
 		notification, err := NewNotificationBuilder(client, test.HostOperatorNs).
-			Create("abc123")
+			Create("jane@redhat.com")
 		require.NoError(t, err)
 
 		// when
@@ -288,7 +288,7 @@ func TestNotificationDelivery(t *testing.T) {
 		controller, client := newController(t, mds, userSignup)
 
 		notification, err := NewNotificationBuilder(client, test.HostOperatorNs).
-			Create("abc123")
+			Create("foo@redhat.com")
 		require.NoError(t, err)
 
 		// when


### PR DESCRIPTION
This PR adds validation that enforces the notification recipient to be a valid email address.

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/375

Fixes https://issues.redhat.com/browse/CRT-1219