### PR TITLE
feat: add Role & RoleBindings to grant crtadmins view & exec perms

### DIFF
--- a/deploy/templates/nstemplatetiers/base/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/base/ns_dev.yaml
@@ -57,6 +57,49 @@ objects:
   subjects:
   - kind: User
     name: ${USERNAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: exec-pods
+    namespace: ${USERNAME}-dev
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods/exec
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: crtadmin-view
+    namespace: ${USERNAME}-dev
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: crtadmin-users-view
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: crtadmin-pods
+    namespace: ${USERNAME}-dev
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: exec-pods
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: crtadmin-users-view
 - apiVersion: v1
   kind: LimitRange
   metadata:

--- a/deploy/templates/nstemplatetiers/base/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/base/ns_stage.yaml
@@ -57,6 +57,49 @@ objects:
   subjects:
   - kind: User
     name: ${USERNAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: exec-pods
+    namespace: ${USERNAME}-stage
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods/exec
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: crtadmin-view
+    namespace: ${USERNAME}-stage
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: crtadmin-users-view
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: crtadmin-pods
+    namespace: ${USERNAME}-stage
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: exec-pods
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: crtadmin-users-view
 - apiVersion: v1
   kind: LimitRange
   metadata:

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -227,7 +227,6 @@ func TestLoadTemplatesByTiers(t *testing.T) {
 						return append(testnstemplatetiers.AssetNames(), fmt.Sprintf("advanced/%s", tmplName))
 
 					}, func(path string) (bytes []byte, e error) {
-						fmt.Println(path)
 						if path == "advanced/"+tmplName {
 							return []byte(""), nil
 						}
@@ -525,9 +524,9 @@ func assertNamespaceTemplate(t *testing.T, decoder runtime.Decoder, actual templ
 	switch tier {
 	case "advanced", "base", "baseextended", "baseextendedidling", "basedeactivationdisabled":
 		if kind == "dev" {
-			require.Len(t, actual.Objects, 10) // dev namespace has CRW network policy
+			require.Len(t, actual.Objects, 13) // dev namespace has CRW network policy
 		} else {
-			require.Len(t, actual.Objects, 9)
+			require.Len(t, actual.Objects, 12)
 		}
 	case "test":
 		return // Don't care what objects are defined in the test tier
@@ -572,6 +571,11 @@ func assertNamespaceTemplate(t *testing.T, decoder runtime.Decoder, actual templ
 	// Role & RoleBinding with additional permissions to edit roles/rolebindings
 	containsObj(t, actual, rbacEditRoleObj(kind))
 	containsObj(t, actual, userRbacEditRoleBindingObj(kind))
+
+	// crtadmins related Role & RoleBindings
+	containsObj(t, actual, execPodsRoleObj(kind))
+	containsObj(t, actual, crtadminViewRoleBindingObj(kind))
+	containsObj(t, actual, crtadminPodsRoleBindingObj(kind))
 }
 
 func assertTestClusterResourcesTemplate(t *testing.T, decoder runtime.Decoder, actual templatev1.Template, tier string) {
@@ -710,6 +714,18 @@ func userRbacEditRoleBindingObj(kind string) string {
 
 func rbacEditRoleObj(kind string) string {
 	return fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"rbac-edit","namespace":"${USERNAME}-%s"},"rules":[{"apiGroups":["authorization.openshift.io","rbac.authorization.k8s.io"],"resources":["roles","rolebindings"],"verbs":["get","list","watch","create","update","patch","delete"]}]}`, kind)
+}
+
+func execPodsRoleObj(kind string) string {
+	return fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","metadata":{"name":"exec-pods","namespace":"${USERNAME}-%s"},"rules":[{"apiGroups":[""],"resources":["pods/exec"],"verbs":["get","list","watch","create","delete","update"]}]}`, kind)
+}
+
+func crtadminViewRoleBindingObj(kind string) string {
+	return fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"name":"crtadmin-view","namespace":"${USERNAME}-%s"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"view"},"subjects":[{"apiGroup":"rbac.authorization.k8s.io","kind":"Group","name":"crtadmin-users-view"}]}`, kind)
+}
+
+func crtadminPodsRoleBindingObj(kind string) string {
+	return fmt.Sprintf(`{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","metadata":{"name":"crtadmin-pods","namespace":"${USERNAME}-%s"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"exec-pods"},"subjects":[{"apiGroup":"rbac.authorization.k8s.io","kind":"Group","name":"crtadmin-users-view"}]}`, kind)
 }
 
 func allowFromOpenshiftMonitoringPolicyObj(kind string) string {


### PR DESCRIPTION
adds Role & RoleBindings which will grant crtadmins (that in `crtadmin-users-view` group) a view & exec permissions in all users namespaces.

This will still require some additional changes in sandbox-sre repo to create the Group and add specific crtadmin users there.

paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/381