### PR TITLE
Change baseextendedidling tier to 144 hrs

### DIFF
--- a/deploy/templates/nstemplatetiers/baseextendedidling/based_on_tier.yaml
+++ b/deploy/templates/nstemplatetiers/baseextendedidling/based_on_tier.yaml
@@ -4,5 +4,5 @@ to:
   name: baseextendedidling
   parameters:
   - name: IDLER_TIMEOUT_SECONDS
-    # 24 hours
-    value: "86400"
+    # 144 hours
+    value: "518400"

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -479,7 +479,7 @@ func assertClusterResourcesTemplate(t *testing.T, decoder runtime.Decoder, actua
 	case "baselarge":
 		assertDefaultObjects(t, actual, "43200", "16Gi")
 	case "baseextendedidling":
-		assertDefaultObjects(t, actual, "86400", "7Gi")
+		assertDefaultObjects(t, actual, "518400", "7Gi")
 	case "advanced":
 		assertDefaultObjects(t, actual, "0", "7Gi")
 	default:


### PR DESCRIPTION
Updates the idler timeout to 144 hrs (518400 seconds)

Related PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/383