### PR TITLE
Propagate OriginalSub from UserSignup to MasterUserRecord

### DIFF
--- a/controllers/usersignup/masteruserrecord.go
+++ b/controllers/usersignup/masteruserrecord.go
@@ -9,6 +9,13 @@ import (
 
 func migrateOrFixMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, nstemplateTier *toolchainv1alpha1.NSTemplateTier, userSignup *toolchainv1alpha1.UserSignup) (bool, error) {
 	changed := false
+
+	// TODO remove this after all users migrated to new SSO Provider client that does not modify the original subject
+	if mur.Spec.OriginalSub != userSignup.Spec.OriginalSub {
+		mur.Spec.OriginalSub = userSignup.Spec.OriginalSub
+		changed = true
+	}
+
 	for uaIndex, userAccount := range mur.Spec.UserAccounts {
 		if userAccount.Spec.NSLimit == "" {
 			mur.Spec.UserAccounts[uaIndex].Spec.NSLimit = "default"
@@ -82,6 +89,7 @@ func newMasterUserRecord(userSignup *toolchainv1alpha1.UserSignup, targetCluster
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
 			UserAccounts: userAccounts,
 			UserID:       userSignup.Spec.Userid,
+			OriginalSub:  userSignup.Spec.OriginalSub,
 		},
 	}
 	return mur, nil

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -64,9 +64,22 @@ func TestUserSignupCreateMUROk(t *testing.T) {
 	member := NewMemberCluster(t, "member1", v1.ConditionTrue)
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	for testname, userSignup := range map[string]*toolchainv1alpha1.UserSignup{
-		"with valid activation annotation":   NewUserSignup(Approved(), WithTargetCluster("member1"), WithStateLabel("not-ready"), WithAnnotation(toolchainv1alpha1.UserSignupActivationCounterAnnotationKey, "2")), // this is a returning user
-		"with invalid activation annotation": NewUserSignup(Approved(), WithTargetCluster("member1"), WithStateLabel("not-ready"), WithAnnotation(toolchainv1alpha1.UserSignupActivationCounterAnnotationKey, "?")), // annotation value is not an 'int'
-		"without activation annotation":      NewUserSignup(Approved(), WithTargetCluster("member1"), WithStateLabel("not-ready"), WithoutAnnotation(toolchainv1alpha1.UserSignupActivationCounterAnnotationKey)),   // no annotation on this user, so the value will not be incremented
+		"with valid activation annotation": NewUserSignup(
+			Approved(),
+			WithTargetCluster("member1"),
+			WithStateLabel("not-ready"),
+			WithAnnotation(toolchainv1alpha1.UserSignupActivationCounterAnnotationKey, "2"),
+			WithOriginalSub("original-sub-value:1234")), // this is a returning user
+		"with invalid activation annotation": NewUserSignup(
+			Approved(),
+			WithTargetCluster("member1"),
+			WithStateLabel("not-ready"),
+			WithAnnotation(toolchainv1alpha1.UserSignupActivationCounterAnnotationKey, "?")), // annotation value is not an 'int'
+		"without activation annotation": NewUserSignup(
+			Approved(),
+			WithTargetCluster("member1"),
+			WithStateLabel("not-ready"),
+			WithoutAnnotation(toolchainv1alpha1.UserSignupActivationCounterAnnotationKey)), // no annotation on this user, so the value will not be incremented
 	} {
 		t.Run(testname, func(t *testing.T) {
 			// given
@@ -96,6 +109,7 @@ func TestUserSignupCreateMUROk(t *testing.T) {
 			require.Equal(t, test.HostOperatorNs, mur.Namespace)
 			require.Equal(t, userSignup.Name, mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey])
 			require.Len(t, mur.Spec.UserAccounts, 1)
+			require.Equal(t, userSignup.Spec.OriginalSub, mur.Spec.OriginalSub)
 			assert.Equal(t, "base", mur.Spec.UserAccounts[0].Spec.NSTemplateSet.TierName)
 			assert.Equal(t, []toolchainv1alpha1.NSTemplateSetNamespace{
 				{
@@ -1499,8 +1513,9 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 		toolchainv1alpha1.UserSignupUserEmailHashLabelKey: "fd2addbd8d82f0d2dc088fa122377eaa",
 		"toolchain.dev.openshift.com/approved":            "true",
 	}
+	userSignup.Spec.OriginalSub = "original-sub:foo"
 
-	// Create a MUR with the same UserID
+	// Create a MUR with the same UserID but don't set the OriginalSub property
 	mur := &toolchainv1alpha1.MasterUserRecord{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -1527,6 +1542,25 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 
 	// when
 	_, err := r.Reconcile(context.TODO(), req)
+
+	// then
+	require.NoError(t, err)
+
+	// The first reconciliation will result in a change in the MUR.  We will load it here and confirm that the
+	// OriginalSub property has now been set
+	murInstance := &toolchainv1alpha1.MasterUserRecord{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: test.HostOperatorNs,
+		Name:      mur.Name,
+	}, murInstance)
+	require.NoError(t, err)
+	require.Equal(t, userSignup.Spec.OriginalSub, murInstance.Spec.OriginalSub)
+
+	// Then we will prepare the reconciliation request and execute it again, this time the UserSignup status should be updated
+	r, req, _ = prepareReconcile(t, userSignup.Name, ready, userSignup, murInstance,
+		commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier)
+
+	_, err = r.Reconcile(context.TODO(), req)
 
 	// then
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go v0.60.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20210908175442-8916777f147d
+	github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20210908175442-8916777f147d h1:rCqr7NnL0dXtCE7NI6kErEBeDxPyFWWDFLnofENYJr8=
-github.com/codeready-toolchain/api v0.0.0-20210908175442-8916777f147d/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7 h1:143gcNMuebi/2tECJ4ReyG5KLApHcDi/z92Y3iJAhAE=
+github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e h1:SuDK0YqGpQK0OxNFi59ltcwHJeJ5WvfbG+e2+ATEbH0=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e/go.mod h1:sfSHDs+ksRHzZbpbFsOXtSylQcvpQ6aaXa2TimVCCyI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -634,7 +634,6 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=

--- a/test/usersignup.go
+++ b/test/usersignup.go
@@ -22,6 +22,12 @@ func WithTargetCluster(targetCluster string) UserSignupModifier {
 	}
 }
 
+func WithOriginalSub(originalSub string) UserSignupModifier {
+	return func(userSignup *toolchainv1alpha1.UserSignup) {
+		userSignup.Spec.OriginalSub = originalSub
+	}
+}
+
 func Approved() UserSignupModifier {
 	return func(userSignup *toolchainv1alpha1.UserSignup) {
 		states.SetApproved(userSignup, true)


### PR DESCRIPTION
This PR modifies the UserSignup controller to copy the UserSignup's OriginalSub property value to MasterUserRecord.

Fixes https://issues.redhat.com/browse/CRT-1271