### PR TITLE
Propagated OriginalSub from MUR to UserAccount

### DIFF
--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -139,6 +139,10 @@ func (r *Reconciler) ensureUserAccount(logger logr.Logger, murAccount toolchainv
 		if errors.IsNotFound(err) {
 			// does not exist - should create
 			userAccount = newUserAccount(nsdName, murAccount.Spec, mur.Spec)
+
+			// Remove this after all users have been migrated to new IdP client
+			userAccount.Spec.OriginalSub = mur.Spec.OriginalSub
+
 			if err := memberCluster.Client.Create(context.TODO(), userAccount); err != nil {
 				return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
 					"failed to create UserAccount in the member cluster '%s'", murAccount.TargetCluster)

--- a/controllers/masteruserrecord/masteruserrecord_controller_test.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller_test.go
@@ -122,6 +122,8 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
 	mur := murtest.NewMasterUserRecord(t, "john")
+	mur.Spec.OriginalSub = "original-sub:12345"
+
 	require.NoError(t, murtest.Modify(mur, murtest.Finalizer("finalizer.toolchain.dev.openshift.com")))
 	memberClient := test.NewFakeClient(t)
 	hostClient := test.NewFakeClient(t, mur)

--- a/controllers/masteruserrecord/sync.go
+++ b/controllers/masteruserrecord/sync.go
@@ -43,7 +43,7 @@ type Synchronizer struct {
 	logger            logr.Logger
 }
 
-// synchronizeSpec synhronizes the useraccount in the MasterUserRecord with the corresponding UserAccount on the member cluster.
+// synchronizeSpec synchronizes the useraccount in the MasterUserRecord with the corresponding UserAccount on the member cluster.
 func (s *Synchronizer) synchronizeSpec() error {
 
 	if !s.isSynchronized() {
@@ -54,6 +54,7 @@ func (s *Synchronizer) synchronizeSpec() error {
 		s.memberUserAcc.Spec.UserAccountSpecBase = s.recordSpecUserAcc.Spec.UserAccountSpecBase
 		s.memberUserAcc.Spec.Disabled = s.record.Spec.Disabled
 		s.memberUserAcc.Spec.UserID = s.record.Spec.UserID
+		s.memberUserAcc.Spec.OriginalSub = s.record.Spec.OriginalSub
 
 		err := s.memberCluster.Client.Update(context.TODO(), s.memberUserAcc)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/host-operator
 require (
 	cloud.google.com/go v0.60.0 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20211007001400-46221aa6002c
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7 h1:143gcNM
 github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e h1:SuDK0YqGpQK0OxNFi59ltcwHJeJ5WvfbG+e2+ATEbH0=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e/go.mod h1:sfSHDs+ksRHzZbpbFsOXtSylQcvpQ6aaXa2TimVCCyI=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20211007001400-46221aa6002c h1:DLambKtgDLbAd3AbIa6bFgeFVwkpKr5+LMC/T6/X0v0=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20211007001400-46221aa6002c/go.mod h1:TtEDfGBOckQJJDFxjlOc7DooiS9hkoKJaTgFqiAnhyo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
@@ -63,7 +63,7 @@ type tierData struct {
 	name           string
 	rawTemplates   *templates
 	tierTemplates  []*toolchainv1alpha1.TierTemplate
-	nstmplTierObjs []commonclient.ToolchainObject
+	nstmplTierObjs []client.Object
 	basedOnTier    *BasedOnTier
 }
 
@@ -373,9 +373,9 @@ func (t *tierGenerator) createNSTemplateTiers() error {
 			return fmt.Errorf("there is an unexpected number of NSTemplateTier object to be applied for tier name '%s'; expected: 1; actual: %d", tierName, len(tierData.nstmplTierObjs))
 		}
 
-		unstructuredObj, ok := tierData.nstmplTierObjs[0].GetClientObject().(*unstructured.Unstructured)
+		unstructuredObj, ok := tierData.nstmplTierObjs[0].(*unstructured.Unstructured)
 		if !ok {
-			return fmt.Errorf("unable to cast NSTemplateTier '%s' to Unstructured object '%+v'", tierName, tierData.nstmplTierObjs[0].GetClientObject())
+			return fmt.Errorf("unable to cast NSTemplateTier '%s' to Unstructured object '%+v'", tierName, tierData.nstmplTierObjs[0])
 		}
 		tier := &toolchainv1alpha1.NSTemplateTier{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, tier); err != nil {
@@ -424,7 +424,7 @@ func (t *tierGenerator) createNSTemplateTiers() error {
 //     - templateRef: basic-dev-4d49fe0-4d49fe0
 //     - templateRef: basic-stage-4d49fe0-4d49fe0
 // ------
-func (t *tierGenerator) newNSTemplateTier(sourceTierName, tierName string, nsTemplateTier template, tierTemplates []*toolchainv1alpha1.TierTemplate, parameters []templatev1.Parameter) ([]commonclient.ToolchainObject, error) {
+func (t *tierGenerator) newNSTemplateTier(sourceTierName, tierName string, nsTemplateTier template, tierTemplates []*toolchainv1alpha1.TierTemplate, parameters []templatev1.Parameter) ([]client.Object, error) {
 	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer()
 	if reflect.DeepEqual(nsTemplateTier, template{}) {
 		return nil, fmt.Errorf("tier %s is missing a tier.yaml file", tierName)

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_whitebox_test.go
@@ -278,7 +278,7 @@ func TestNewNSTemplateTier(t *testing.T) {
 			for _, tierData := range tc.templatesByTier {
 
 				for _, nstmplTierObj := range tierData.nstmplTierObjs {
-					tierObj := nstmplTierObj.GetClientObject()
+					tierObj := nstmplTierObj
 
 					// verify tier configuration
 					nstmplTier := runtimeObjectToNSTemplateTier(t, s, tierObj)
@@ -337,7 +337,7 @@ func TestNewNSTemplateTier(t *testing.T) {
 					objects := tc.templatesByTier[tier].nstmplTierObjs
 					require.Len(t, objects, 1, "expected only 1 NSTemplateTier toolchain object")
 					// when
-					actual := runtimeObjectToNSTemplateTier(t, s, objects[0].GetClientObject())
+					actual := runtimeObjectToNSTemplateTier(t, s, objects[0])
 
 					// then
 					deactivationTimeout := 30
@@ -791,7 +791,7 @@ func TestNewNSTemplateTiers(t *testing.T) {
 			tierData, found := tc.templatesByTier[name]
 			tierObjs := tierData.nstmplTierObjs
 			require.Len(t, tierObjs, 1, "expected only 1 NSTemplateTier toolchain object")
-			tier := runtimeObjectToNSTemplateTier(t, s, tierObjs[0].GetClientObject())
+			tier := runtimeObjectToNSTemplateTier(t, s, tierObjs[0])
 
 			require.True(t, found)
 			assert.Equal(t, name, tier.ObjectMeta.Name)

--- a/pkg/templates/registrationservice/template_test.go
+++ b/pkg/templates/registrationservice/template_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	"github.com/stretchr/testify/assert"
@@ -35,13 +37,15 @@ func TestDeploymentAssetContainsAllNecessaryInformation(t *testing.T) {
 	roleBindingFound := false
 	for _, toolchainObject := range toolchainObjects {
 		assert.Equal(t, "my-namespace", toolchainObject.GetNamespace())
-		fmt.Println(toolchainObject.GetGvk())
+		gvk, err := apiutil.GVKForObject(toolchainObject, s)
+		require.NoError(t, err)
+		fmt.Println(gvk)
 		fmt.Println(appsv1.SchemeGroupVersion.WithKind("Deployment"))
 
-		switch toolchainObject.GetGvk() {
+		switch gvk {
 		case appsv1.SchemeGroupVersion.WithKind("Deployment"):
 			deploymentFound = true
-			deployment := fmt.Sprintf("%+v", toolchainObject.GetClientObject())
+			deployment := fmt.Sprintf("%+v", toolchainObject)
 			assert.Contains(t, deployment, "replicas:10")
 			assert.Contains(t, deployment, "image:quay.io/cr-t/registration-service:123")
 


### PR DESCRIPTION
This PR propagates the OriginalSub property value from MasterUserRecord.Spec to UserAccount.Spec.

Fixes https://issues.redhat.com/browse/CRT-1272