### PR TITLE
Reset deactivating state when promoting users

### DIFF
--- a/controllers/changetierrequest/changetierrequest_controller.go
+++ b/controllers/changetierrequest/changetierrequest_controller.go
@@ -140,12 +140,12 @@ func (r *Reconciler) changeTier(logger logr.Logger, changeTierRequest *toolchain
 	}
 	userSignupToUpdate := &toolchainv1alpha1.UserSignup{}
 	if err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: userSignupName}, userSignupToUpdate); err != nil {
-		return err
+		return r.wrapErrorWithStatusUpdate(logger, changeTierRequest, r.setStatusChangeFailed, err, `failed to get UserSignup '%s'`, userSignupName)
 	}
 	if states.Deactivating(userSignupToUpdate) {
 		states.SetDeactivating(userSignupToUpdate, false)
 		if err := r.Client.Update(context.TODO(), userSignupToUpdate); err != nil {
-			return err
+			return r.wrapErrorWithStatusUpdate(logger, changeTierRequest, r.setStatusChangeFailed, err, `failed to reset deactivating state for UserSignup '%s'`, userSignupName)
 		}
 	}
 

--- a/controllers/changetierrequest/changetierrequest_controller.go
+++ b/controllers/changetierrequest/changetierrequest_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/controllers/usersignup"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -59,8 +60,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	// Fetch the ChangeTierRequest instance
 	changeTierRequest := &toolchainv1alpha1.ChangeTierRequest{}
-	err = r.Client.Get(context.TODO(), request.NamespacedName, changeTierRequest)
-	if err != nil {
+	if err = r.Client.Get(context.TODO(), request.NamespacedName, changeTierRequest); err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
@@ -87,14 +87,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}, nil
 	}
 
-	err = r.changeTier(reqLogger, changeTierRequest, request.Namespace)
-	if err != nil {
+	if err = r.changeTier(reqLogger, changeTierRequest, request.Namespace); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	reqLogger.Info("Change of the tier is completed")
-	err = r.setStatusChangeComplete(changeTierRequest)
-	if err != nil {
+	if err = r.setStatusChangeComplete(changeTierRequest); err != nil {
 		reqLogger.Error(err, "unable to set change complete status to ChangeTierRequest")
 		return reconcile.Result{}, err
 	}
@@ -132,6 +130,23 @@ func (r *Reconciler) changeTier(logger logr.Logger, changeTierRequest *toolchain
 	murName := types.NamespacedName{Namespace: namespace, Name: changeTierRequest.Spec.MurName}
 	if err := r.Client.Get(context.TODO(), murName, mur); err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, changeTierRequest, r.setStatusChangeFailed, err, "unable to get MasterUserRecord with name %s", changeTierRequest.Spec.MurName)
+	}
+
+	// get the corresponding UserSignup and set the deactivating state to false to prevent the user from being deactivated prematurely
+	userSignupName, found := mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey]
+	if !found || userSignupName == "" {
+		err := fmt.Errorf(`MasterUserRecord is missing label '%s'`, toolchainv1alpha1.MasterUserRecordOwnerLabelKey)
+		return r.wrapErrorWithStatusUpdate(logger, changeTierRequest, r.setStatusChangeFailed, err, `failed to get corresponding UserSignup for MasterUserRecord with name '%s'`, changeTierRequest.Spec.MurName)
+	}
+	userSignupToUpdate := &toolchainv1alpha1.UserSignup{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: userSignupName}, userSignupToUpdate); err != nil {
+		return err
+	}
+	if states.Deactivating(userSignupToUpdate) {
+		states.SetDeactivating(userSignupToUpdate, false)
+		if err := r.Client.Update(context.TODO(), userSignupToUpdate); err != nil {
+			return err
+		}
 	}
 
 	nsTemplateTier := &toolchainv1alpha1.NSTemplateTier{}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/host-operator
 require (
 	cloud.google.com/go v0.60.0 // indirect
 	github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20211007001400-46221aa6002c
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20211015175119-b8c44c873137
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.4.0
@@ -28,7 +28,5 @@ require (
 	k8s.io/kubectl v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20211014172518-89114c0a8a23
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20211014172518-89114c0a8a23
+
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -113,13 +113,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20210811194925-19aeb221d584/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7 h1:143gcNMuebi/2tECJ4ReyG5KLApHcDi/z92Y3iJAhAE=
 github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e h1:SuDK0YqGpQK0OxNFi59ltcwHJeJ5WvfbG+e2+ATEbH0=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20210816150728-75450e8d842e/go.mod h1:sfSHDs+ksRHzZbpbFsOXtSylQcvpQ6aaXa2TimVCCyI=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20211007001400-46221aa6002c h1:DLambKtgDLbAd3AbIa6bFgeFVwkpKr5+LMC/T6/X0v0=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20211007001400-46221aa6002c/go.mod h1:TtEDfGBOckQJJDFxjlOc7DooiS9hkoKJaTgFqiAnhyo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -511,6 +506,8 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/toolchain-common v0.0.0-20211014172518-89114c0a8a23 h1:r+YgGjDMq74IpyzpL1GCERolE6vrbEqi9Wgblx3dHcw=
+github.com/rajivnathan/toolchain-common v0.0.0-20211014172518-89114c0a8a23/go.mod h1:TtEDfGBOckQJJDFxjlOc7DooiS9hkoKJaTgFqiAnhyo=
 github.com/redhat-cop/operator-utils v1.1.3-0.20210602122509-2eaf121122d2 h1:m0IMqkR8PcFAXITvUZGHTte/NvyF/P4Qr3bw0eIw2+c=
 github.com/redhat-cop/operator-utils v1.1.3-0.20210602122509-2eaf121122d2/go.mod h1:Hu6OKop6iQfga0Hwrqv/03CQgpkcp55qwjMh9Gi0Iyk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7 h1:143gcNMuebi/2tECJ4ReyG5KLApHcDi/z92Y3iJAhAE=
 github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20211015175119-b8c44c873137 h1:gabUZoR94/nOMzcTCvaTFURrKcRoWxhhemPnj9ZPxIk=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20211015175119-b8c44c873137/go.mod h1:TtEDfGBOckQJJDFxjlOc7DooiS9hkoKJaTgFqiAnhyo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -506,8 +508,6 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/toolchain-common v0.0.0-20211014172518-89114c0a8a23 h1:r+YgGjDMq74IpyzpL1GCERolE6vrbEqi9Wgblx3dHcw=
-github.com/rajivnathan/toolchain-common v0.0.0-20211014172518-89114c0a8a23/go.mod h1:TtEDfGBOckQJJDFxjlOc7DooiS9hkoKJaTgFqiAnhyo=
 github.com/redhat-cop/operator-utils v1.1.3-0.20210602122509-2eaf121122d2 h1:m0IMqkR8PcFAXITvUZGHTte/NvyF/P4Qr3bw0eIw2+c=
 github.com/redhat-cop/operator-utils v1.1.3-0.20210602122509-2eaf121122d2/go.mod h1:Hu6OKop6iQfga0Hwrqv/03CQgpkcp55qwjMh9Gi0Iyk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1222

Related PRs:
https://github.com/codeready-toolchain/toolchain-common/pull/214
https://github.com/codeready-toolchain/toolchain-e2e/pull/393


Updates the ChangeTierRequest controller to look up the related UserSignup and reset its deactivating state