### PR TITLE
chore: configure klog and klog/v2 output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	k8s.io/apiextensions-apiserver v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
+	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.8.0
 	k8s.io/kubectl v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )


### PR DESCRIPTION
configure the underlying logger so we also have valid JSON
logs for the underlying modules, and have those logs injested
by Loki.

for example, something like:

```
I1025 14:29:07.669111       1 request.go:655] Throttling request took 1.029351794s, request: GET:https://172.30.0.1:443/apis/network.openshift.io/v1?timeout=32s

```

becomes:

```
{"level":"info","ts":"2021-10-25T15:23:40.829Z","msg":"Throttling request took 1.038356681s, request: GET:https://172.30.0.1:443/apis/console.openshift.io/v1?timeout=32s\n"}
```

(taking 2 different examples, so don't pay attention to the timestamp values!)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
