### PR TITLE
refactor: decouple UserAccounts from NSTemplateSets

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
@@ -139,7 +139,6 @@ spec:
                           type: object
                       required:
                       - nsLimit
-                      - nsTemplateSet
                       type: object
                     syncIndex:
                       description: SyncIndex is to be updated by UserAccount Controller

--- a/controllers/changetierrequest/changetierrequest_controller.go
+++ b/controllers/changetierrequest/changetierrequest_controller.go
@@ -159,6 +159,10 @@ func (r *Reconciler) changeTier(logger logr.Logger, changeTierRequest *toolchain
 	changed := false
 
 	for i, ua := range mur.Spec.UserAccounts {
+		// skip if no NSTemplateSet defined for the UserAccount
+		if ua.Spec.NSTemplateSet == nil {
+			continue
+		}
 		if changeTierRequest.Spec.TargetCluster != "" {
 			if ua.TargetCluster == changeTierRequest.Spec.TargetCluster {
 				// here we remove the template hash label since it was change for one or all target clusters
@@ -186,6 +190,10 @@ func (r *Reconciler) changeTier(logger logr.Logger, changeTierRequest *toolchain
 	}
 	// then we compute again *all* hashes, in case we removed the entry for a single target cluster, but others still "use" it.
 	for _, ua := range mur.Spec.UserAccounts {
+		// skip if no NSTemplateSet defined for the UserAccount
+		if ua.Spec.NSTemplateSet == nil {
+			continue
+		}
 		hash, err := nstemplatetier.ComputeHashForNSTemplateSetSpec(*ua.Spec.NSTemplateSet)
 		if err != nil {
 			return r.wrapErrorWithStatusUpdate(logger, changeTierRequest, r.setStatusChangeFailed, err, "unable to compute hash for NSTemplateTier with name '%s'", nsTemplateTier.Name)

--- a/controllers/changetierrequest/changetierrequest_controller.go
+++ b/controllers/changetierrequest/changetierrequest_controller.go
@@ -186,13 +186,11 @@ func (r *Reconciler) changeTier(logger logr.Logger, changeTierRequest *toolchain
 	}
 	// then we compute again *all* hashes, in case we removed the entry for a single target cluster, but others still "use" it.
 	for _, ua := range mur.Spec.UserAccounts {
-		if ua.Spec.NSTemplateSet != nil {
-			hash, err := nstemplatetier.ComputeHashForNSTemplateSetSpec(*ua.Spec.NSTemplateSet)
-			if err != nil {
-				return r.wrapErrorWithStatusUpdate(logger, changeTierRequest, r.setStatusChangeFailed, err, "unable to compute hash for NSTemplateTier with name '%s'", nsTemplateTier.Name)
-			}
-			mur.Labels[nstemplatetier.TemplateTierHashLabelKey(ua.Spec.NSTemplateSet.TierName)] = hash
+		hash, err := nstemplatetier.ComputeHashForNSTemplateSetSpec(*ua.Spec.NSTemplateSet)
+		if err != nil {
+			return r.wrapErrorWithStatusUpdate(logger, changeTierRequest, r.setStatusChangeFailed, err, "unable to compute hash for NSTemplateTier with name '%s'", nsTemplateTier.Name)
 		}
+		mur.Labels[nstemplatetier.TemplateTierHashLabelKey(ua.Spec.NSTemplateSet.TierName)] = hash
 	}
 	if err := r.Client.Update(context.TODO(), mur); err != nil {
 		return r.wrapErrorWithStatusUpdate(logger, changeTierRequest, r.setStatusChangeFailed, err, "unable to change tier in MasterUserRecord %s", changeTierRequest.Spec.MurName)

--- a/controllers/changetierrequest/changetierrequest_controller_test.go
+++ b/controllers/changetierrequest/changetierrequest_controller_test.go
@@ -54,7 +54,7 @@ func TestChangeTierSuccess(t *testing.T) {
 		require.NoError(t, err)
 		murtest.AssertThatMasterUserRecord(t, "john", cl).
 			AllUserAccountsHaveTier(*teamTier).
-			DoesNotHaveLabel(nstemplatetier.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTier.Name))
+			DoesNotHaveLabel(nstemplatetier.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 	})
 
@@ -70,7 +70,7 @@ func TestChangeTierSuccess(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).AllUserAccountsHaveTier(*teamTier).
-			DoesNotHaveLabel(nstemplatetier.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTier.Name))
+			DoesNotHaveLabel(nstemplatetier.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 	})
 
@@ -87,7 +87,7 @@ func TestChangeTierSuccess(t *testing.T) {
 		require.NoError(t, err)
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
 			UserAccountHasTier("another-cluster", *teamTier).
-			UserAccountHasTier(test.MemberClusterName, murtest.DefaultNSTemplateTier)
+			UserAccountHasTier(test.MemberClusterName, murtest.DefaultNSTemplateTier())
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 	})
 
@@ -107,7 +107,7 @@ func TestChangeTierSuccess(t *testing.T) {
 		assert.True(t, result.RequeueAfter < cast.ToDuration("10s"))
 		assert.True(t, result.RequeueAfter > cast.ToDuration("1s"))
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
-			AllUserAccountsHaveTier(murtest.DefaultNSTemplateTier)
+			AllUserAccountsHaveTier(murtest.DefaultNSTemplateTier())
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 	})
 
@@ -126,7 +126,7 @@ func TestChangeTierSuccess(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, result.Requeue)
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
-			AllUserAccountsHaveTier(murtest.DefaultNSTemplateTier)
+			AllUserAccountsHaveTier(murtest.DefaultNSTemplateTier())
 		AssertThatChangeTierRequestIsDeleted(t, cl, changeTierRequest.Name)
 	})
 
@@ -199,7 +199,7 @@ func TestChangeTierFailure(t *testing.T) {
 		// then
 		require.EqualError(t, err, "unable to change tier in MasterUserRecord johny: the MasterUserRecord 'johny' doesn't contain UserAccount with cluster 'some-other-cluster' whose tier should be changed")
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
-			AllUserAccountsHaveTier(murtest.DefaultNSTemplateTier)
+			AllUserAccountsHaveTier(murtest.DefaultNSTemplateTier())
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name,
 			toBeNotComplete("the MasterUserRecord 'johny' doesn't contain UserAccount with cluster 'some-other-cluster' whose tier should be changed"))
 	})
@@ -244,7 +244,7 @@ func TestChangeTierFailure(t *testing.T) {
 		// then
 		require.EqualError(t, err, "failed to delete changeTierRequest: unable to delete ChangeTierRequest object 'request-name': error")
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
-			AllUserAccountsHaveTier(murtest.DefaultNSTemplateTier)
+			AllUserAccountsHaveTier(murtest.DefaultNSTemplateTier())
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete(), toBeDeletionError("unable to delete ChangeTierRequest object 'request-name': error"))
 	})
 

--- a/controllers/masteruserrecord/sync_test.go
+++ b/controllers/masteruserrecord/sync_test.go
@@ -85,7 +85,7 @@ func TestIsSynchronized(t *testing.T) {
 func setupSynchronizerItems() (toolchainv1alpha1.MasterUserRecord, toolchainv1alpha1.UserAccountEmbedded, toolchainv1alpha1.UserAccount) {
 	base := toolchainv1alpha1.UserAccountSpecBase{
 		NSLimit: "limit",
-		NSTemplateSet: toolchainv1alpha1.NSTemplateSetSpec{
+		NSTemplateSet: &toolchainv1alpha1.NSTemplateSetSpec{
 			TierName: "basic",
 			ClusterResources: &toolchainv1alpha1.NSTemplateSetClusterResources{
 				TemplateRef: "basic-clusterresources-654321a",

--- a/controllers/templateupdaterequest/templateupdaterequest_controller.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller.go
@@ -183,11 +183,13 @@ func (r Reconciler) updateTemplateRefs(logger logr.Logger, tur toolchainv1alpha1
 			}
 			mur.Spec.UserAccounts[i] = ua
 			// also, update the tier template hash label
-			hash, err := nstemplatetier.ComputeHashForNSTemplateSetSpec(ua.Spec.NSTemplateSet)
-			if err != nil {
-				return err
+			if ua.Spec.NSTemplateSet != nil {
+				hash, err := nstemplatetier.ComputeHashForNSTemplateSetSpec(*ua.Spec.NSTemplateSet)
+				if err != nil {
+					return err
+				}
+				mur.Labels[nstemplatetier.TemplateTierHashLabelKey(tur.Spec.TierName)] = hash
 			}
-			mur.Labels[nstemplatetier.TemplateTierHashLabelKey(tur.Spec.TierName)] = hash
 		}
 	}
 	logger.Info("updating the MUR")

--- a/controllers/templateupdaterequest/templateupdaterequest_controller.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller.go
@@ -141,49 +141,49 @@ func maxUpdateFailuresReached(tur toolchainv1alpha1.TemplateUpdateRequest, thres
 func (r Reconciler) updateTemplateRefs(logger logr.Logger, tur toolchainv1alpha1.TemplateUpdateRequest, mur *toolchainv1alpha1.MasterUserRecord) error {
 	// update MasterUserRecord accounts whose tier matches the TemplateUpdateRequest
 	for i, ua := range mur.Spec.UserAccounts {
-		if ua.Spec.NSTemplateSet.TierName == tur.Spec.TierName {
-			logger.Info("updating templaterefs", "tier", tur.Spec.TierName, "target_cluster", ua.TargetCluster)
-			// reset the new templateRefs, only retain those with a custom template in use
-			namespaces := make(map[string]toolchainv1alpha1.NSTemplateSetNamespace, len(ua.Spec.NSTemplateSet.Namespaces))
-			for _, ns := range ua.Spec.NSTemplateSet.Namespaces {
-				if ns.Template != "" {
+		if ua.Spec.NSTemplateSet != nil {
+			if ua.Spec.NSTemplateSet.TierName == tur.Spec.TierName {
+				logger.Info("updating templaterefs", "tier", tur.Spec.TierName, "target_cluster", ua.TargetCluster)
+				// reset the new templateRefs, only retain those with a custom template in use
+				namespaces := make(map[string]toolchainv1alpha1.NSTemplateSetNamespace, len(ua.Spec.NSTemplateSet.Namespaces))
+				for _, ns := range ua.Spec.NSTemplateSet.Namespaces {
+					if ns.Template != "" {
+						t := namespaceType(ns.TemplateRef)
+						logger.Info("retainining the custom namespace template", "type", t)
+						namespaces[t] = ns
+					}
+				}
+				// now, add the new templateRefs, unless there's a custom template in use
+				for _, ns := range tur.Spec.Namespaces {
 					t := namespaceType(ns.TemplateRef)
-					logger.Info("retainining the custom namespace template", "type", t)
-					namespaces[t] = ns
+					// don't override the custom template
+					namespaces[t] = toolchainv1alpha1.NSTemplateSetNamespace{
+						TemplateRef: ns.TemplateRef,
+						Template:    namespaces[t].Template, // empty unless there was something before
+					}
 				}
-			}
-			// now, add the new templateRefs, unless there's a custom template in use
-			for _, ns := range tur.Spec.Namespaces {
-				t := namespaceType(ns.TemplateRef)
-				// don't override the custom template
-				namespaces[t] = toolchainv1alpha1.NSTemplateSetNamespace{
-					TemplateRef: ns.TemplateRef,
-					Template:    namespaces[t].Template, // empty unless there was something before
+				// finally, set the new namespace templates in the user account
+				ua.Spec.NSTemplateSet.Namespaces = []toolchainv1alpha1.NSTemplateSetNamespace{}
+				for _, ns := range namespaces {
+					ua.Spec.NSTemplateSet.Namespaces = append(ua.Spec.NSTemplateSet.Namespaces, ns)
 				}
-			}
-			// finally, set the new namespace templates in the user account
-			ua.Spec.NSTemplateSet.Namespaces = []toolchainv1alpha1.NSTemplateSetNamespace{}
-			for _, ns := range namespaces {
-				ua.Spec.NSTemplateSet.Namespaces = append(ua.Spec.NSTemplateSet.Namespaces, ns)
-			}
-			// now, let's take care about the cluster resources
-			if ua.Spec.NSTemplateSet.ClusterResources != nil && ua.Spec.NSTemplateSet.ClusterResources.Template != "" {
-				// retain the custom template even if the TemplateUpdateRequest has no clusterresources templateref
-				if tur.Spec.ClusterResources != nil {
-					ua.Spec.NSTemplateSet.ClusterResources.TemplateRef = tur.Spec.ClusterResources.TemplateRef
+				// now, let's take care about the cluster resources
+				if ua.Spec.NSTemplateSet.ClusterResources != nil && ua.Spec.NSTemplateSet.ClusterResources.Template != "" {
+					// retain the custom template even if the TemplateUpdateRequest has no clusterresources templateref
+					if tur.Spec.ClusterResources != nil {
+						ua.Spec.NSTemplateSet.ClusterResources.TemplateRef = tur.Spec.ClusterResources.TemplateRef
+					} else {
+						ua.Spec.NSTemplateSet.ClusterResources.TemplateRef = ""
+					}
+				} else if tur.Spec.ClusterResources != nil {
+					ua.Spec.NSTemplateSet.ClusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
+						TemplateRef: tur.Spec.ClusterResources.TemplateRef,
+					}
 				} else {
-					ua.Spec.NSTemplateSet.ClusterResources.TemplateRef = ""
+					ua.Spec.NSTemplateSet.ClusterResources = nil
 				}
-			} else if tur.Spec.ClusterResources != nil {
-				ua.Spec.NSTemplateSet.ClusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
-					TemplateRef: tur.Spec.ClusterResources.TemplateRef,
-				}
-			} else {
-				ua.Spec.NSTemplateSet.ClusterResources = nil
-			}
-			mur.Spec.UserAccounts[i] = ua
-			// also, update the tier template hash label
-			if ua.Spec.NSTemplateSet != nil {
+				mur.Spec.UserAccounts[i] = ua
+				// also, update the tier template hash label
 				hash, err := nstemplatetier.ComputeHashForNSTemplateSetSpec(*ua.Spec.NSTemplateSet)
 				if err != nil {
 					return err

--- a/controllers/usersignup/masteruserrecord.go
+++ b/controllers/usersignup/masteruserrecord.go
@@ -37,17 +37,15 @@ func migrateOrFixMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, nstempl
 		tierName := ua.Spec.NSTemplateSet.TierName
 		// only set the label if it is missing.
 		if _, ok := mur.Labels[nstemplatetier.TemplateTierHashLabelKey(tierName)]; !ok {
-			if ua.Spec.NSTemplateSet != nil {
-				hash, err := nstemplatetier.ComputeHashForNSTemplateSetSpec(*ua.Spec.NSTemplateSet)
-				if err != nil {
-					return false, err
-				}
-				if mur.Labels == nil {
-					mur.Labels = map[string]string{}
-				}
-				mur.Labels[nstemplatetier.TemplateTierHashLabelKey(tierName)] = hash
-				changed = true
+			hash, err := nstemplatetier.ComputeHashForNSTemplateSetSpec(*ua.Spec.NSTemplateSet)
+			if err != nil {
+				return false, err
 			}
+			if mur.Labels == nil {
+				mur.Labels = map[string]string{}
+			}
+			mur.Labels[nstemplatetier.TemplateTierHashLabelKey(tierName)] = hash
+			changed = true
 		}
 	}
 	// TODO: remove as part of CRT-1074

--- a/controllers/usersignup/masteruserrecord.go
+++ b/controllers/usersignup/masteruserrecord.go
@@ -22,7 +22,7 @@ func migrateOrFixMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, nstempl
 			changed = true
 		}
 		nsTemplateSet := userAccount.Spec.NSTemplateSet
-		if nsTemplateSet == nil || nsTemplateSet.TierName == "" {
+		if nsTemplateSet != nil && nsTemplateSet.TierName == "" {
 			mur.Spec.UserAccounts[uaIndex].Spec.NSTemplateSet = NewNSTemplateSetSpec(nstemplateTier)
 			changed = true
 		}
@@ -30,6 +30,10 @@ func migrateOrFixMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, nstempl
 	// also, ensure that the MUR has a label for each tier in use
 	// this label will be needed to select master user record that need to be updated when tier templates changed.
 	for _, ua := range mur.Spec.UserAccounts {
+		// skip if no NSTemplateSet defined on the UserAccount
+		if ua.Spec.NSTemplateSet == nil {
+			continue
+		}
 		tierName := ua.Spec.NSTemplateSet.TierName
 		// only set the label if it is missing.
 		if _, ok := mur.Labels[nstemplatetier.TemplateTierHashLabelKey(tierName)]; !ok {

--- a/controllers/usersignup/masteruserrecord.go
+++ b/controllers/usersignup/masteruserrecord.go
@@ -22,7 +22,7 @@ func migrateOrFixMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, nstempl
 			changed = true
 		}
 		nsTemplateSet := userAccount.Spec.NSTemplateSet
-		if nsTemplateSet.TierName == "" {
+		if nsTemplateSet == nil || nsTemplateSet.TierName == "" {
 			mur.Spec.UserAccounts[uaIndex].Spec.NSTemplateSet = NewNSTemplateSetSpec(nstemplateTier)
 			changed = true
 		}

--- a/controllers/usersignup/masteruserrecord_test.go
+++ b/controllers/usersignup/masteruserrecord_test.go
@@ -164,8 +164,10 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			assert.True(t, changed)
-			assert.Equal(t, newExpectedMur(nsTemplateTier, userSignup), mur)
+			assert.False(t, changed)
+			expectedMUR := newExpectedMur(nsTemplateTier, userSignup)
+			expectedMUR.Spec.UserAccounts[0].Spec.NSTemplateSet = nil
+			assert.Equal(t, expectedMUR, mur)
 		})
 
 		t.Run("when whole NSTemplateSet is empty", func(t *testing.T) {

--- a/controllers/usersignup/masteruserrecord_test.go
+++ b/controllers/usersignup/masteruserrecord_test.go
@@ -157,7 +157,7 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 			nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
 			mur, err := newMasterUserRecord(userSignup, test.MemberClusterName, nsTemplateTier, "johny")
 			require.NoError(t, err)
-			mur.Spec.UserAccounts[0].Spec.NSTemplateSet = toolchainv1alpha1.NSTemplateSetSpec{}
+			mur.Spec.UserAccounts[0].Spec.NSTemplateSet = &toolchainv1alpha1.NSTemplateSetSpec{}
 
 			// when
 			changed, err := migrateOrFixMurIfNecessary(mur, nsTemplateTier, userSignup)
@@ -207,8 +207,8 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 
 }
 
-func newExpectedNsTemplateSetSpec() toolchainv1alpha1.NSTemplateSetSpec {
-	return toolchainv1alpha1.NSTemplateSetSpec{
+func newExpectedNsTemplateSetSpec() *toolchainv1alpha1.NSTemplateSetSpec {
+	return &toolchainv1alpha1.NSTemplateSetSpec{
 		TierName: "advanced",
 		Namespaces: []toolchainv1alpha1.NSTemplateSetNamespace{
 			{

--- a/controllers/usersignup/masteruserrecord_test.go
+++ b/controllers/usersignup/masteruserrecord_test.go
@@ -157,6 +157,23 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 			nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
 			mur, err := newMasterUserRecord(userSignup, test.MemberClusterName, nsTemplateTier, "johny")
 			require.NoError(t, err)
+			mur.Spec.UserAccounts[0].Spec.NSTemplateSet = nil // here: "missing" == nil
+
+			// when
+			changed, err := migrateOrFixMurIfNecessary(mur, nsTemplateTier, userSignup)
+
+			// then
+			require.NoError(t, err)
+			assert.True(t, changed)
+			assert.Equal(t, newExpectedMur(nsTemplateTier, userSignup), mur)
+		})
+
+		t.Run("when whole NSTemplateSet is empty", func(t *testing.T) {
+			// given
+			userSignup := NewUserSignup()
+			nsTemplateTier := newNsTemplateTier("advanced", "dev", "stage", "extra")
+			mur, err := newMasterUserRecord(userSignup, test.MemberClusterName, nsTemplateTier, "johny")
+			require.NoError(t, err)
 			mur.Spec.UserAccounts[0].Spec.NSTemplateSet = &toolchainv1alpha1.NSTemplateSetSpec{}
 
 			// when

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -3416,7 +3416,7 @@ func TestMigrateMur(t *testing.T) {
 	require.NoError(t, err)
 
 	// set NSLimit and NSTemplateSet to be empty
-	mur.Spec.UserAccounts[0].Spec.NSTemplateSet = toolchainv1alpha1.NSTemplateSetSpec{}
+	mur.Spec.UserAccounts[0].Spec.NSTemplateSet = &toolchainv1alpha1.NSTemplateSetSpec{}
 	mur.Spec.UserAccounts[0].Spec.NSLimit = ""
 
 	expectedMur := mur.DeepCopy()

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go v0.60.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20211019160629-cc6228d73828
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20211015175119-b8c44c873137
+	github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.4.0
@@ -30,9 +30,5 @@ require (
 	k8s.io/kubectl v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211116101409-1abcc4e9a1a6
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 
 replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
 
-// replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42
-replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211116101409-1abcc4e9a1a6
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42
+
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 
 replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42
+// replace github.com/codeready-toolchain/toolchain-common => github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42
+replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -558,8 +558,6 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42 h1:LPlbmNMKwMTTYeCI1PSc8xbU6pAqD2lYy3uAsTabi3I=
-github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -558,6 +558,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
 github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/xcoulon/toolchain-common v0.0.0-20211116101409-1abcc4e9a1a6 h1:SSZO92BzgF2dESg1yJ7RGrkJ6/+knw3utRRtfaTjOOc=
+github.com/xcoulon/toolchain-common v0.0.0-20211116101409-1abcc4e9a1a6/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -113,11 +113,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20210930215026-da4da11421c7/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20211019160629-cc6228d73828 h1:eqaN5TqUBqMSvF9NC8Ct2kUEkPVkeXGzV/gXkiX6WOE=
-github.com/codeready-toolchain/api v0.0.0-20211019160629-cc6228d73828/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20211015175119-b8c44c873137 h1:gabUZoR94/nOMzcTCvaTFURrKcRoWxhhemPnj9ZPxIk=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20211015175119-b8c44c873137/go.mod h1:TtEDfGBOckQJJDFxjlOc7DooiS9hkoKJaTgFqiAnhyo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -561,6 +556,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
+github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42 h1:LPlbmNMKwMTTYeCI1PSc8xbU6pAqD2lYy3uAsTabi3I=
+github.com/xcoulon/toolchain-common v0.0.0-20211112102125-7cd9c79c4c42/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,10 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2 h1:MJ6aUUWVuNqku9um4NAVHReKP5y/tq1wXbgBNfphL0c=
+github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb h1:EhSrGxwUJA3+rOl7B7tfqiJN6r3OXqLecLhZGRrTQeA=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -556,10 +560,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073 h1:eMhfT9qzw3N0n28mfBf2iUqKZuWrepUbcxaAHnB9UZI=
-github.com/xcoulon/api v0.0.0-20211110143945-dec71f4e5073/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/xcoulon/toolchain-common v0.0.0-20211116101409-1abcc4e9a1a6 h1:SSZO92BzgF2dESg1yJ7RGrkJ6/+knw3utRRtfaTjOOc=
-github.com/xcoulon/toolchain-common v0.0.0-20211116101409-1abcc4e9a1a6/go.mod h1:8PNm+zdJzwfjqwKBi24hnAP7qbN+aOT3wLfcsPChsn8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/test/templateupdaterequest/assertion.go
+++ b/test/templateupdaterequest/assertion.go
@@ -72,6 +72,14 @@ func (a *SingleTemplateUpdateRequestAssertion) HasSyncIndexes(indexes map[string
 	return a
 }
 
+// HasNoSyncIndexes verifies that the TemplateUpdateRequest has the no sync indexes in its status
+func (a *SingleTemplateUpdateRequestAssertion) HasNoSyncIndexes() *SingleTemplateUpdateRequestAssertion {
+	err := a.loadResource()
+	require.NoError(a.t, err)
+	assert.Empty(a.t, a.templateUpdateRequest.Status.SyncIndexes)
+	return a
+}
+
 // Exists verifies that the TemplateUpdateRequest exists
 func (a *SingleTemplateUpdateRequestAssertion) Exists() *SingleTemplateUpdateRequestAssertion {
 	err := a.loadResource()


### PR DESCRIPTION
Apply changes after switching to a pointer for `UserAccount.Spec.NSTemplateSet` 

See also:
- https://github.com/codeready-toolchain/api/pull/263
- https://github.com/codeready-toolchain/toolchain-common/pull/216


Fixes Fixes https://issues.redhat.com/browse/CRT-1305

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
