### PR TITLE
Adds serviceaccounts so that proxy can list them when mapping users

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -48,6 +48,7 @@ objects:
         resources:
           - secrets
           - configmaps
+          - serviceaccounts
         verbs:
           - get
           - list


### PR DESCRIPTION
Required so that the serviceaccount lookup will work here: https://github.com/codeready-toolchain/registration-service/blob/d9a98e513a7bb2170d8bbec14d30c2bc545081bb/pkg/proxy/service/cluster_service.go#L62-L67

I will add it to https://github.com/codeready-toolchain/registration-service/blob/d9a98e513a7bb2170d8bbec14d30c2bc545081bb/deploy/registration-service.yaml as well