### PR TITLE
feat: watch member clusters directly

### DIFF
--- a/controllers/masteruserrecord/sync_test.go
+++ b/controllers/masteruserrecord/sync_test.go
@@ -739,12 +739,14 @@ func verifySyncMurStatusWithUserAccountStatus(t *testing.T, memberClient, hostCl
 
 func newMemberCluster(cl client.Client) *cluster.CachedToolchainCluster {
 	return &cluster.CachedToolchainCluster{
-		Name:              test.MemberClusterName,
-		APIEndpoint:       fmt.Sprintf("https://api.%s:6433", test.MemberClusterName),
-		Client:            cl,
-		Type:              cluster.Member,
-		OperatorNamespace: test.HostOperatorNs,
-		OwnerClusterName:  test.HostClusterName,
+		Config: &cluster.Config{
+			Name:              test.MemberClusterName,
+			APIEndpoint:       fmt.Sprintf("https://api.%s:6433", test.MemberClusterName),
+			Type:              cluster.Member,
+			OperatorNamespace: test.HostOperatorNs,
+			OwnerClusterName:  test.HostClusterName,
+		},
+		Client: cl,
 		ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
 			Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
 				Type:   toolchainv1alpha1.ToolchainClusterReady,

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1377,12 +1377,14 @@ func newDeploymentWithConditions(deploymentName string, deploymentConditions ...
 
 func cachedToolchainCluster(cl client.Client, name string, status corev1.ConditionStatus, lastProbeTime metav1.Time) *cluster.CachedToolchainCluster {
 	return &cluster.CachedToolchainCluster{
-		Name:              name,
-		Client:            cl,
-		Type:              cluster.Host,
-		OperatorNamespace: test.MemberOperatorNs,
-		OwnerClusterName:  test.MemberClusterName,
-		APIEndpoint:       "http://api.devcluster.openshift.com",
+		Config: &cluster.Config{
+			Name:              name,
+			Type:              cluster.Host,
+			OperatorNamespace: test.MemberOperatorNs,
+			OwnerClusterName:  test.MemberClusterName,
+			APIEndpoint:       "http://api.devcluster.openshift.com",
+		},
+		Client: cl,
 		ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
 			Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
 				Type:          toolchainv1alpha1.ToolchainClusterReady,

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/MatousJobanek/toolchain-common v0.0.0-20211119160239-6df56eb6f7e0
+
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/MatousJobanek/toolchain-common v0.0.0-20211119160239-6df56eb6f7e0
+replace github.com/codeready-toolchain/toolchain-common => github.com/MatousJobanek/toolchain-common v0.0.0-20211123084829-ae1da04c8b89
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvo
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.1.0 h1:j7GpgZ7PdFqNsmncycTHsLmVPf5/3wJtlgW9TNDYD9Y=
 github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZE/rU8pmrbihA=
+github.com/MatousJobanek/toolchain-common v0.0.0-20211119160239-6df56eb6f7e0 h1:kJUfjC6KH1mpmdiiKqOeThznz4ReRWWhzbvWOqVHCdI=
+github.com/MatousJobanek/toolchain-common v0.0.0-20211119160239-6df56eb6f7e0/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -115,8 +117,6 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2 h1:MJ6aUUWVuNqku9um4NAVHReKP5y/tq1wXbgBNfphL0c=
 github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb h1:EhSrGxwUJA3+rOl7B7tfqiJN6r3OXqLecLhZGRrTQeA=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvo
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.1.0 h1:j7GpgZ7PdFqNsmncycTHsLmVPf5/3wJtlgW9TNDYD9Y=
 github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZE/rU8pmrbihA=
-github.com/MatousJobanek/toolchain-common v0.0.0-20211119160239-6df56eb6f7e0 h1:kJUfjC6KH1mpmdiiKqOeThznz4ReRWWhzbvWOqVHCdI=
-github.com/MatousJobanek/toolchain-common v0.0.0-20211119160239-6df56eb6f7e0/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
+github.com/MatousJobanek/toolchain-common v0.0.0-20211123084829-ae1da04c8b89 h1:aX/pJlAc3Sa/n2Cd5rqA+qhAxKPM+h/HfVk9x7dvo+c=
+github.com/MatousJobanek/toolchain-common v0.0.0-20211123084829-ae1da04c8b89/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func addMemberClusters(mgr ctrl.Manager, cl client.Client, namespace string) ([]
 	for _, memberConfig := range memberConfigs {
 		setupLog.Info("adding cluster for a member", "name", memberConfig.Name, "apiEndpoint", memberConfig.APIEndpoint)
 
-		memberCluster, err := runtimecluster.New(memberConfig.Config, func(options *runtimecluster.Options) {
+		memberCluster, err := runtimecluster.New(memberConfig.RestConfig, func(options *runtimecluster.Options) {
 			options.Scheme = scheme
 			options.Namespace = memberConfig.OperatorNamespace
 		})

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -62,11 +62,13 @@ func NewGetMemberCluster(ok bool, status v1.ConditionStatus) GetMemberClusterFun
 				return nil, false
 			}
 			return &cluster.CachedToolchainCluster{
-				Client:            cl,
-				Name:              name,
-				Type:              cluster.Member,
-				OperatorNamespace: test.MemberOperatorNs,
-				OwnerClusterName:  test.HostClusterName,
+				Config: &cluster.Config{
+					Name:              name,
+					Type:              cluster.Member,
+					OperatorNamespace: test.MemberOperatorNs,
+					OwnerClusterName:  test.HostClusterName,
+				},
+				Client: cl,
 				ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
 					Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
 						Type:   toolchainv1alpha1.ToolchainClusterReady,


### PR DESCRIPTION
This PR brings a code that will be used in the following tasks:
* https://issues.redhat.com/browse/CRT-1310
* https://issues.redhat.com/browse/CRT-1306

It let us watch the member clusters directly. It uses this https://github.com/kubernetes-sigs/controller-runtime/blob/master/designs/move-cluster-specific-code-out-of-manager.md)
related PR: https://github.com/codeready-toolchain/toolchain-common/pull/217