### PR TITLE
refactor: add MasterUserRecord.Spec.TierName field (only)

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
@@ -28,7 +28,7 @@ spec:
     - jsonPath: .spec.userAccounts[].targetCluster
       name: Cluster
       type: string
-    - jsonPath: .spec.userAccounts[].spec.nsTemplateSet.tierName
+    - jsonPath: .spec.tierName
       name: Tier
       type: string
     - jsonPath: .spec.banned
@@ -77,6 +77,13 @@ spec:
                 description: OriginalSub is an optional property temporarily introduced
                   for the purpose of migrating the users to a new IdP provider client,
                   and contains the user's "original-sub" claim
+                type: string
+              tierName:
+                description: TierName is an optional property introduced to retain
+                  the name of the tier for which the Dev Sandbox user is provisioned,
+                  so we can still deal with deactivation once the NSTemplateSet field
+                  has been removed from `[]spec.UserAccounts` temporarily marked as
+                  optional until the migration took place (CRT-1321)
                 type: string
               userAccounts:
                 description: The list of user accounts in the member clusters which

--- a/config/manifests/bases/host-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/host-operator.clusterserviceversion.yaml
@@ -60,7 +60,8 @@ spec:
       kind: ToolchainConfig
       name: toolchainconfigs.toolchain.dev.openshift.com
       version: v1alpha1
-    - description: ToolchainEvent is used to allow users to sign up to events such as workshops or training
+    - description: ToolchainEvent is used to allow users to sign up to events such
+        as workshops or training
       displayName: CodeReady Toolchain Event
       kind: ToolchainEvent
       name: toolchainevents.toolchain.dev.openshift.com

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go v0.60.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2
+	github.com/codeready-toolchain/api v0.0.0-20211123132956-238f2adf05c8
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
@@ -30,7 +30,5 @@ require (
 	k8s.io/kubectl v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211123080725-72e8d12f0de1
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211123080725-72e8d12f0de1
+
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2 h1:MJ6aUUWVuNqku9um4NAVHReKP5y/tq1wXbgBNfphL0c=
-github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb h1:EhSrGxwUJA3+rOl7B7tfqiJN6r3OXqLecLhZGRrTQeA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -560,6 +558,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/xcoulon/api v0.0.0-20211123080725-72e8d12f0de1 h1:6LVhSBtlZLZ5cCdhmwclf2r1mYAY15eGt1iNk2iawzQ=
+github.com/xcoulon/api v0.0.0-20211123080725-72e8d12f0de1/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,9 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/codeready-toolchain/api v0.0.0-20211116140337-1aaf7ef57cc2/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20211123132956-238f2adf05c8 h1:lJjMhrTdaIzZ2FQ39ohCFLP3RPkQ1MRAWwJ5VUZ5xjY=
+github.com/codeready-toolchain/api v0.0.0-20211123132956-238f2adf05c8/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb h1:EhSrGxwUJA3+rOl7B7tfqiJN6r3OXqLecLhZGRrTQeA=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211116140718-3ae87ec76ddb/go.mod h1:DJVsWbbiNJ6XB5DekM5duSoqrUXjjKG6dDArFZsGSDY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -558,8 +561,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/xcoulon/api v0.0.0-20211123080725-72e8d12f0de1 h1:6LVhSBtlZLZ5cCdhmwclf2r1mYAY15eGt1iNk2iawzQ=
-github.com/xcoulon/api v0.0.0-20211123080725-72e8d12f0de1/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Just a module update with the new field in `MasterUserRecord.Spec`,
but no change in the business logic.
Applying the same module update on both host-operator and member-operator
so that when the business logic is applied, both operators can use the
new field.

This is a workaround the limitations of e2e test pairing.
See [discussion](https://github.com/codeready-toolchain/host-operator/pull/539#issuecomment-975630203)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
