### PR TITLE
feat: add Proxy URL to ToolchainStatus CR

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
@@ -143,6 +143,49 @@ spec:
                 - revision
                 - version
                 type: object
+              hostRoutes:
+                description: HostRoutes/URLs of the host cluster, such as Proxy URL
+                properties:
+                  conditions:
+                    description: 'Conditions is an array of current member operator
+                      status conditions Supported condition types: ConditionReady'
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transit from one status
+                            to another.
+                          format: date-time
+                          type: string
+                        lastUpdatedTime:
+                          description: Last time the condition was updated
+                          format: date-time
+                          type: string
+                        message:
+                          description: Human readable message indicating details about
+                            last transition.
+                          type: string
+                        reason:
+                          description: (brief) reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False,
+                            Unknown.
+                          type: string
+                        type:
+                          description: Type of condition
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  proxyURL:
+                    description: ProxyURL is the Proxy URL of the cluster
+                    type: string
+                type: object
               members:
                 description: Members is an array of member status objects
                 items:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go v0.60.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20211201162254-338ce55976be
+	github.com/codeready-toolchain/api v0.0.0-20211206130419-fedaada130c4
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20211129155533-e8c160fca78f
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
@@ -30,7 +30,5 @@ require (
 	k8s.io/kubectl v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20211206093415-e32605ed165f
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20211206093415-e32605ed165f
+
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,9 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/codeready-toolchain/api v0.0.0-20211123132956-238f2adf05c8/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20211206130419-fedaada130c4 h1:wq0Q52DGfR6I0oeAvBW3FD93z41cxKNohnjSfnDY79M=
+github.com/codeready-toolchain/api v0.0.0-20211206130419-fedaada130c4/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211129155533-e8c160fca78f h1:Gp6fERZmfJUl0RVtzzJak2kz7p36dsYG78VandUDWco=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211129155533-e8c160fca78f/go.mod h1:uLIbmzVFTx7w7AR3RrGTeD2MRqrhD+zlEsa+8t9Yh6Q=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -402,8 +405,6 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/matousjobanek/api v0.0.0-20211206093415-e32605ed165f h1:CGToCS0vSw9hnY1j83T6quxNZzJ13WegZ2EneEDD55M=
-github.com/matousjobanek/api v0.0.0-20211206093415-e32605ed165f/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/go.sum
+++ b/go.sum
@@ -113,9 +113,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20211123132956-238f2adf05c8/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20211201162254-338ce55976be h1:gw4jUbLh18sE5YbaP2gF4SvFxeuNgiC4n4+UP0zeHa4=
-github.com/codeready-toolchain/api v0.0.0-20211201162254-338ce55976be/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211129155533-e8c160fca78f h1:Gp6fERZmfJUl0RVtzzJak2kz7p36dsYG78VandUDWco=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211129155533-e8c160fca78f/go.mod h1:uLIbmzVFTx7w7AR3RrGTeD2MRqrhD+zlEsa+8t9Yh6Q=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -405,6 +402,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/matousjobanek/api v0.0.0-20211206093415-e32605ed165f h1:CGToCS0vSw9hnY1j83T6quxNZzJ13WegZ2EneEDD55M=
+github.com/matousjobanek/api v0.0.0-20211206093415-e32605ed165f/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/main.go
+++ b/main.go
@@ -243,6 +243,7 @@ func main() {
 		Scheme:         mgr.GetScheme(),
 		HTTPClientImpl: &http.Client{},
 		GetMembersFunc: cluster.GetMemberClusters,
+		Namespace:      namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ToolchainStatus")
 	}

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -2,6 +2,7 @@ package apis
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
 	templatev1 "github.com/openshift/api/template/v1"
 
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -10,6 +11,6 @@ import (
 
 // AddToScheme adds all Resources to the Scheme
 func AddToScheme(s *runtime.Scheme) error {
-	addToSchemes := append(runtime.SchemeBuilder{}, toolchainv1alpha1.AddToScheme, extensionsv1.AddToScheme, templatev1.Install)
+	addToSchemes := append(runtime.SchemeBuilder{}, toolchainv1alpha1.AddToScheme, extensionsv1.AddToScheme, templatev1.Install, routev1.Install)
 	return addToSchemes.AddToScheme(s)
 }

--- a/pkg/templates/registrationservice/template.go
+++ b/pkg/templates/registrationservice/template.go
@@ -9,6 +9,9 @@ import (
 // ResourceName is the name used for the registration service resource
 const ResourceName = "registration-service"
 
+// ProxyRouteName is the name used for the Proxy route resource
+const ProxyRouteName = "api"
+
 func GetDeploymentTemplate() (*v1.Template, error) {
 	deployment, err := Asset("registration-service.yaml")
 	if err != nil {

--- a/pkg/templates/registrationservice/template_test.go
+++ b/pkg/templates/registrationservice/template_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	routev1 "github.com/openshift/api/route/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
@@ -35,6 +36,7 @@ func TestDeploymentAssetContainsAllNecessaryInformation(t *testing.T) {
 	saFound := false
 	roleFound := false
 	roleBindingFound := false
+	apiRouteFound := false
 	for _, toolchainObject := range toolchainObjects {
 		assert.Equal(t, "my-namespace", toolchainObject.GetNamespace())
 		gvk, err := apiutil.GVKForObject(toolchainObject, s)
@@ -53,13 +55,17 @@ func TestDeploymentAssetContainsAllNecessaryInformation(t *testing.T) {
 			roleFound = true
 		case rbacv1.SchemeGroupVersion.WithKind("RoleBinding"):
 			roleBindingFound = true
-
+		case routev1.GroupVersion.WithKind("Route"):
+			if toolchainObject.GetName() == ProxyRouteName {
+				apiRouteFound = true
+			}
 		}
 	}
 	assert.True(t, deploymentFound, "a Deployment wasn't found")
 	assert.True(t, saFound, "a ServiceAccount wasn't found")
 	assert.True(t, roleFound, "a Role wasn't found")
 	assert.True(t, roleBindingFound, "a RoleBinding wasn't found")
+	assert.True(t, apiRouteFound, "a proxy route with the name 'api' wasn't found")
 }
 
 func getVars(namespace, image, replicas string) map[string]string {

--- a/test/toolchainstatus_assertions.go
+++ b/test/toolchainstatus_assertions.go
@@ -120,6 +120,14 @@ func (a *ToolchainStatusAssertion) HasRegistrationServiceStatus(expected toolcha
 	return a
 }
 
+func (a *ToolchainStatusAssertion) HasHostRoutesStatus(proxyURL string, expCondition toolchainv1alpha1.Condition) *ToolchainStatusAssertion {
+	err := a.loadToolchainStatus()
+	require.NoError(a.t, err)
+	require.Equal(a.t, proxyURL, a.toolchainStatus.Status.HostRoutes.ProxyURL)
+	test.AssertConditionsMatch(a.t, a.toolchainStatus.Status.HostRoutes.Conditions, expCondition)
+	return a
+}
+
 func (a *ToolchainStatusAssertion) ReadyConditionLastTransitionTimeEqual(expected metav1.Time) *ToolchainStatusAssertion {
 	return a.readyConditionLastTransitionTimeEqual(expected, true)
 }


### PR DESCRIPTION
This PR:
1. gets Proxy URL from the Proxy route
2. adds the Proxy URL to the ToolchainStatus CR
3. if the proxy route is not found, then it sets the condition as "unavailable"

The URL will be then used by reg-service to show the Proxy URL to AppStudio developers.

Paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/418