### PR TITLE
Template update requests for Spaces

### DIFF
--- a/controllers/templateupdaterequest/templateupdaterequest_controller.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller.go
@@ -91,7 +91,7 @@ func (r *Reconciler) handleSpaceUpdate(logger logr.Logger, request ctrl.Request,
 		return reconcile.Result{}, errs.Wrap(err, "unable to get the Space associated with the TemplateUpdateRequest")
 	}
 
-	labelKey := TemplateTierHashLabelKey(space.Spec.TierName)
+	labelKey := tierutil.TemplateTierHashLabelKey(space.Spec.TierName)
 	// if the tier hash has changed and the Space is in ready state then the update is complete
 	if tur.Spec.CurrentTierHash != space.Labels[labelKey] && condition.IsTrue(space.Status.Conditions, toolchainv1alpha1.ConditionReady) {
 		// once the Space is up-to-date, we can delete this TemplateUpdateRequest
@@ -107,11 +107,6 @@ func (r *Reconciler) handleSpaceUpdate(logger logr.Logger, request ctrl.Request,
 	}
 	// no explicit requeue: expect new reconcile loop when Space changes
 	return reconcile.Result{}, nil
-}
-
-// TODO remove
-func TemplateTierHashLabelKey(tierName string) string {
-	return toolchainv1alpha1.LabelKeyPrefix + tierName + "-tier-hash"
 }
 
 func (r *Reconciler) handleMURUpdate(logger logr.Logger, request ctrl.Request, tur *toolchainv1alpha1.TemplateUpdateRequest) (ctrl.Result, error) {

--- a/controllers/templateupdaterequest/templateupdaterequest_controller.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller.go
@@ -101,6 +101,10 @@ func (r *Reconciler) handleSpaceUpdate(logger logr.Logger, request ctrl.Request,
 
 	// otherwise, we need to wait
 	logger.Info("Space still being updated...")
+	if err := r.addUpdatingStatusCondition(tur, map[string]string{}); err != nil {
+		logger.Error(err, "Unable to update the TemplateUpdateRequest status")
+		return reconcile.Result{}, errs.Wrap(err, "unable to update the TemplateUpdateRequest status")
+	}
 	// no explicit requeue: expect new reconcile loop when Space changes
 	return reconcile.Result{}, nil
 }

--- a/controllers/templateupdaterequest/templateupdaterequest_controller.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller.go
@@ -32,6 +32,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&toolchainv1alpha1.TemplateUpdateRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Kind{Type: &toolchainv1alpha1.Space{}}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }
 
@@ -69,6 +70,47 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, errs.Wrap(err, "unable to get the current TemplateUpdateRequest")
 	}
 
+	if tur.Spec.CurrentTierHash != "" {
+		return r.handleSpaceUpdate(logger, request, tur)
+	} else {
+		return r.handleMURUpdate(logger, request, tur)
+	}
+}
+
+func (r *Reconciler) handleSpaceUpdate(logger logr.Logger, request ctrl.Request, tur *toolchainv1alpha1.TemplateUpdateRequest) (ctrl.Result, error) {
+	// lookup the Space with the same name as the TemplateUpdateRequest tur
+	space := &toolchainv1alpha1.Space{}
+	if err := r.Client.Get(context.TODO(), request.NamespacedName, space); err != nil {
+		if errors.IsNotFound(err) {
+			// Space object not found, could have been deleted after reconcile request.
+			// Marking this TemplateUpdateRequest as failed
+			return reconcile.Result{}, r.addFailureStatusCondition(tur, err)
+		}
+		// Error reading the object - requeue the request.
+		logger.Error(err, "Unable to get the Space associated with the TemplateUpdateRequest")
+		return reconcile.Result{}, errs.Wrap(err, "unable to get the Space associated with the TemplateUpdateRequest")
+	}
+
+	labelKey := TemplateTierHashLabelKey(space.Spec.TierName)
+	// if the tier hash has changed and the Space is in ready state then the update is complete
+	if tur.Spec.CurrentTierHash != space.Labels[labelKey] && condition.IsTrue(space.Status.Conditions, toolchainv1alpha1.ConditionReady) {
+		// once the Space is up-to-date, we can delete this TemplateUpdateRequest
+		logger.Info("Space is up-to-date. Marking the TemplateUpdateRequest as complete")
+		return reconcile.Result{}, r.setCompleteStatusCondition(tur)
+	}
+
+	// otherwise, we need to wait
+	logger.Info("Space still being updated...")
+	// no explicit requeue: expect new reconcile loop when Space changes
+	return reconcile.Result{}, nil
+}
+
+// TODO remove
+func TemplateTierHashLabelKey(tierName string) string {
+	return toolchainv1alpha1.LabelKeyPrefix + tierName + "-tier-hash"
+}
+
+func (r *Reconciler) handleMURUpdate(logger logr.Logger, request ctrl.Request, tur *toolchainv1alpha1.TemplateUpdateRequest) (ctrl.Result, error) {
 	config, err := toolchainconfig.GetToolchainConfig(r.Client)
 	if err != nil {
 		return reconcile.Result{}, errs.Wrapf(err, "unable to get ToolchainConfig")
@@ -76,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	// lookup the MasterUserRecord with the same name as the TemplateUpdateRequest tur
 	mur := &toolchainv1alpha1.MasterUserRecord{}
-	if err = r.Client.Get(context.TODO(), request.NamespacedName, mur); err != nil {
+	if err := r.Client.Get(context.TODO(), request.NamespacedName, mur); err != nil {
 		if errors.IsNotFound(err) {
 			// MUR object not found, could have been deleted after reconcile request.
 			// Marking this TemplateUpdateRequest as failed
@@ -92,7 +134,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		// and retain its current syncIndexex in the status
 		// NOTE: indexes need to be "captured" before updating the MURs
 		syncIndexes := syncIndexes(tur.Spec.TierName, *mur)
-		if err = r.updateTemplateRefs(logger, *tur, mur); err != nil {
+		if err := r.updateTemplateRefs(logger, *tur, mur); err != nil {
 			// we want to give ourselves a few chances before marking this MasterUserRecord update as "failed":
 			logger.Error(err, "Unable to update the MasterUserRecord associated with the TemplateUpdateRequest")
 			err = errs.Wrap(err, "unable to update the MasterUserRecord associated with the TemplateUpdateRequest")

--- a/controllers/templateupdaterequest/templateupdaterequest_controller_test.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller_test.go
@@ -558,9 +558,7 @@ func TestReconcile(t *testing.T) {
 			t.Run("tier not found", func(t *testing.T) {
 				// given
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-				initObjs := []runtime.Object{basicTier}
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier))
-				r, req, cl := prepareReconcile(t, initObjs...) // there is no associated MasterUserRecord
+				r, req, cl := prepareReconcile(t, basicTier, turtest.NewTemplateUpdateRequest("user-1", *basicTier)) // there is no associated MasterUserRecord
 				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
 					if _, ok := obj.(*toolchainv1alpha1.TemplateUpdateRequest); ok {
 						return errors.NewNotFound(schema.GroupResource{}, key.Name)
@@ -577,9 +575,7 @@ func TestReconcile(t *testing.T) {
 			t.Run("other error", func(t *testing.T) {
 				// given
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-				initObjs := []runtime.Object{basicTier}
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier))
-				r, req, cl := prepareReconcile(t, initObjs...) // there is no associated MasterUserRecord
+				r, req, cl := prepareReconcile(t, basicTier, turtest.NewTemplateUpdateRequest("user-1", *basicTier)) // there is no associated MasterUserRecord
 				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
 					if _, ok := obj.(*toolchainv1alpha1.TemplateUpdateRequest); ok {
 						return fmt.Errorf("mock error")
@@ -600,9 +596,7 @@ func TestReconcile(t *testing.T) {
 			t.Run("tier not found", func(t *testing.T) {
 				// given
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-				initObjs := []runtime.Object{basicTier}
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier))
-				r, req, cl := prepareReconcile(t, initObjs...) // there is no associated MasterUserRecord
+				r, req, cl := prepareReconcile(t, basicTier, turtest.NewTemplateUpdateRequest("user-1", *basicTier)) // there is no associated MasterUserRecord
 				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
 					if _, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
 						return errors.NewNotFound(schema.GroupResource{}, key.Name)
@@ -619,9 +613,7 @@ func TestReconcile(t *testing.T) {
 			t.Run("other error", func(t *testing.T) {
 				// given
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-				initObjs := []runtime.Object{basicTier}
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier))
-				r, req, cl := prepareReconcile(t, initObjs...) // there is no associated MasterUserRecord
+				r, req, cl := prepareReconcile(t, basicTier, turtest.NewTemplateUpdateRequest("user-1", *basicTier)) // there is no associated MasterUserRecord
 				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
 					if _, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
 						return fmt.Errorf("mock error")
@@ -641,11 +633,8 @@ func TestReconcile(t *testing.T) {
 			// given
 			previousBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
 			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-			initObjs := []runtime.Object{basicTier}
-			initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier))
 			mur := murtest.NewMasterUserRecord(t, "user-1", murtest.Account("cluster1", *previousBasicTier, murtest.SyncIndex("1")))
-			initObjs = append(initObjs, mur)
-			r, req, cl := prepareReconcile(t, initObjs...)
+			r, req, cl := prepareReconcile(t, basicTier, turtest.NewTemplateUpdateRequest("user-1", *basicTier), mur)
 			cl.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.TemplateUpdateRequest); ok {
 					return fmt.Errorf("mock error")
@@ -664,11 +653,8 @@ func TestReconcile(t *testing.T) {
 			// given
 			previousBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
 			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-			initObjs := []runtime.Object{basicTier}
-			initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier))
 			mur := murtest.NewMasterUserRecord(t, "user-1", murtest.Account("cluster1", *previousBasicTier, murtest.SyncIndex("1")))
-			initObjs = append(initObjs, mur)
-			r, req, cl := prepareReconcile(t, initObjs...)
+			r, req, cl := prepareReconcile(t, basicTier, turtest.NewTemplateUpdateRequest("user-1", *basicTier), mur)
 			cl.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
 					return fmt.Errorf("mock error")
@@ -698,11 +684,9 @@ func TestReconcile(t *testing.T) {
 			previousBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
 			basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
 			space := spacetest.NewSpace("user-1", spacetest.WithTierNameAndHashLabelFor(previousBasicTier)) // space's hash matches TUR hash
-			initObjs := []runtime.Object{basicTier, space}
 			previousHash, err := tierutil.ComputeHashForNSTemplateTier(previousBasicTier)
 			require.NoError(t, err)
-			initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
-			r, req, cl := prepareReconcile(t, initObjs...)
+			r, req, cl := prepareReconcile(t, basicTier, space, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
 			// when
 			res, err := r.Reconcile(context.TODO(), req)
 			// then
@@ -728,11 +712,9 @@ func TestReconcile(t *testing.T) {
 						Reason: toolchainv1alpha1.TemplateUpdateRequestUpdatingReason,
 					},
 				)) // space's hash updated to new tier
-				initObjs := []runtime.Object{basicTier, space}
 				previousHash, err := tierutil.ComputeHashForNSTemplateTier(previousBasicTier)
 				require.NoError(t, err)
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
-				r, req, cl := prepareReconcile(t, initObjs...)
+				r, req, cl := prepareReconcile(t, basicTier, space, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
 				// when
 				res, err := r.Reconcile(context.TODO(), req)
 				// then
@@ -758,11 +740,9 @@ func TestReconcile(t *testing.T) {
 						Reason: toolchainv1alpha1.SpaceProvisionedReason,
 					}),
 				)
-				initObjs := []runtime.Object{basicTier, space}
 				previousHash, err := tierutil.ComputeHashForNSTemplateTier(previousBasicTier)
 				require.NoError(t, err)
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
-				r, req, cl := prepareReconcile(t, initObjs...)
+				r, req, cl := prepareReconcile(t, basicTier, space, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
 				// when
 				res, err := r.Reconcile(context.TODO(), req)
 				// then
@@ -783,11 +763,9 @@ func TestReconcile(t *testing.T) {
 				// given
 				previousBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-				initObjs := []runtime.Object{basicTier}
 				previousHash, err := tierutil.ComputeHashForNSTemplateTier(previousBasicTier)
 				require.NoError(t, err)
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
-				r, req, cl := prepareReconcile(t, initObjs...)
+				r, req, cl := prepareReconcile(t, basicTier, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
 				// when
 				res, err := r.Reconcile(context.TODO(), req)
 				// then
@@ -807,11 +785,9 @@ func TestReconcile(t *testing.T) {
 				// given
 				previousBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-				initObjs := []runtime.Object{basicTier}
 				previousHash, err := tierutil.ComputeHashForNSTemplateTier(previousBasicTier)
 				require.NoError(t, err)
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
-				r, req, cl := prepareReconcile(t, initObjs...)
+				r, req, cl := prepareReconcile(t, basicTier, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
 				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
 					if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 						return fmt.Errorf("mock error")
@@ -831,11 +807,9 @@ func TestReconcile(t *testing.T) {
 				previousBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
 				space := spacetest.NewSpace("user-1", spacetest.WithTierNameAndHashLabelFor(previousBasicTier)) // space's hash matches TUR hash
-				initObjs := []runtime.Object{basicTier, space}
 				previousHash, err := tierutil.ComputeHashForNSTemplateTier(previousBasicTier)
 				require.NoError(t, err)
-				initObjs = append(initObjs, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
-				r, req, cl := prepareReconcile(t, initObjs...)
+				r, req, cl := prepareReconcile(t, basicTier, space, turtest.NewTemplateUpdateRequest("user-1", *basicTier, turtest.CurrentTierHash(previousHash)))
 				cl.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					if _, ok := obj.(*toolchainv1alpha1.TemplateUpdateRequest); ok {
 						return fmt.Errorf("mock error")

--- a/controllers/templateupdaterequest/templateupdaterequest_controller_test.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller_test.go
@@ -721,7 +721,13 @@ func TestReconcile(t *testing.T) {
 				// given
 				previousBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates, tiertest.WithCurrentUpdateInProgress())
-				space := spacetest.NewSpace("user-1", spacetest.WithTierNameAndHashLabelFor(basicTier)) // space's hash updated to new tier
+				space := spacetest.NewSpace("user-1", spacetest.WithTierNameAndHashLabelFor(basicTier), spacetest.WithCondition(
+					toolchainv1alpha1.Condition{
+						Type:   toolchainv1alpha1.TemplateUpdateRequestComplete,
+						Status: corev1.ConditionFalse,
+						Reason: toolchainv1alpha1.TemplateUpdateRequestUpdatingReason,
+					},
+				)) // space's hash updated to new tier
 				initObjs := []runtime.Object{basicTier, space}
 				previousHash, err := tierutil.ComputeHashForNSTemplateTier(previousBasicTier)
 				require.NoError(t, err)

--- a/test/templateupdaterequest/templateupdaterequest.go
+++ b/test/templateupdaterequest/templateupdaterequest.go
@@ -116,6 +116,16 @@ func (t TierName) applyToTemplateUpdateRequest(r *toolchainv1alpha1.TemplateUpda
 	}
 }
 
+// CurrentTierHash sets the hash of the current tier (before update) for a Space, it is used to check whether the Space
+// is updated after a tier update occurs
+type CurrentTierHash string
+
+var _ Option = CurrentTierHash("")
+
+func (t CurrentTierHash) applyToTemplateUpdateRequest(r *toolchainv1alpha1.TemplateUpdateRequest) {
+	r.Spec.CurrentTierHash = string(t)
+}
+
 // SyncIndexes the Sync Indexes stored in the status before the MasterUserRecord update begins
 type SyncIndexes map[string]string
 


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1315

When TemplateUpdateRequest with Spec.CurrentHash is created, then it will only monitor the associated Space until the “toolchain.dev.openshift.com/<tiername>-tier-hash” label at Space CR is different from the one stored in TemplateUpdateRequest.Spec.CurrentHash. In other words, it will wait until the “toolchain.dev.openshift.com/<tiername>-tier-hash” label has changed. When the label is changed, then the TemplateUpdateRequest controller will wait until the Ready condition in Space CR is true.