### PR TITLE
feat: retarget space to another member cluster

### DIFF
--- a/controllers/changetierrequest/changetierrequest_controller_test.go
+++ b/controllers/changetierrequest/changetierrequest_controller_test.go
@@ -186,7 +186,7 @@ func TestChangeTierSuccess(t *testing.T) {
 			// given
 			changeTierRequest := newChangeTierRequest("john", teamTier.Name)
 			mur := murtest.NewMasterUserRecord(t, "john", murtest.WithOwnerLabel(userSignup.Name))
-			space := spacetest.NewSpace("john", spacetest.WithTargetCluster("member-1"),
+			space := spacetest.NewSpace("john", spacetest.WithSpecTargetCluster("member-1"),
 				spacetest.WithTierNameAndHashLabelFor(basicTier))
 			basicTierName := space.Spec.TierName
 			controller, request, cl := newController(t, changeTierRequest, config, userSignup, mur, space, teamTier)
@@ -202,7 +202,7 @@ func TestChangeTierSuccess(t *testing.T) {
 				DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 			spacetest.AssertThatSpace(t, space.Namespace, space.Name, cl).
 				HasTier(teamTier.Name).
-				HasTargetCluster("member-1").                                       // unchanged
+				HasSpecTargetCluster("member-1").                                   // unchanged
 				DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(basicTierName)). // label for old tier is removed
 				DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(teamTier.Name))  // label for new tier is not set yet
 			AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
@@ -211,7 +211,7 @@ func TestChangeTierSuccess(t *testing.T) {
 		t.Run("when the MasterUserRecord does not exist", func(t *testing.T) {
 			// given
 			changeTierRequest := newChangeTierRequest("john", teamTier.Name)
-			space := spacetest.NewSpace("john", spacetest.WithTargetCluster("member-1"))
+			space := spacetest.NewSpace("john", spacetest.WithSpecTargetCluster("member-1"))
 			controller, request, cl := newController(t, changeTierRequest, config, userSignup, space, teamTier)
 
 			// when
@@ -221,7 +221,7 @@ func TestChangeTierSuccess(t *testing.T) {
 			require.NoError(t, err)
 			spacetest.AssertThatSpace(t, space.Namespace, space.Name, cl).
 				HasTier(teamTier.Name).
-				HasTargetCluster("member-1"). // unchanged
+				HasSpecTargetCluster("member-1"). // unchanged
 				DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(changeTierRequest.Spec.TierName))
 			AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 		})
@@ -229,7 +229,7 @@ func TestChangeTierSuccess(t *testing.T) {
 		t.Run("when the Space tier already up-to-date", func(t *testing.T) {
 			// given
 			changeTierRequest := newChangeTierRequest("john", teamTier.Name)
-			space := spacetest.NewSpace("john", spacetest.WithTargetCluster("member-1"), spacetest.WithTierNameAndHashLabelFor(teamTier))
+			space := spacetest.NewSpace("john", spacetest.WithSpecTargetCluster("member-1"), spacetest.WithTierNameAndHashLabelFor(teamTier))
 			controller, request, cl := newController(t, changeTierRequest, config, userSignup, space, teamTier)
 
 			// when
@@ -239,7 +239,7 @@ func TestChangeTierSuccess(t *testing.T) {
 			require.NoError(t, err)
 			spacetest.AssertThatSpace(t, space.Namespace, space.Name, cl).
 				HasTier(teamTier.Name).                                                      // unchanged
-				HasTargetCluster("member-1").                                                // unchanged
+				HasSpecTargetCluster("member-1").                                            // unchanged
 				HasLabel(tierutil.TemplateTierHashLabelKey(changeTierRequest.Spec.TierName)) // not removed since there was no update to perform in this case
 			AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete()) // ChangeTierRequest is complete.
 		})
@@ -408,7 +408,7 @@ func TestChangeTierFailure(t *testing.T) {
 		t.Run("when fetching fails", func(t *testing.T) {
 			// given
 			changeTierRequest := newChangeTierRequest("john", "team")
-			space := spacetest.NewSpace("john", spacetest.WithTargetCluster("member-1"))
+			space := spacetest.NewSpace("john", spacetest.WithSpecTargetCluster("member-1"))
 			controller, request, cl := newController(t, changeTierRequest, config, userSignup, space, teamTier)
 			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
@@ -430,7 +430,7 @@ func TestChangeTierFailure(t *testing.T) {
 		t.Run("when updating fails", func(t *testing.T) {
 			// given
 			changeTierRequest := newChangeTierRequest("john", "team")
-			space := spacetest.NewSpace("john", spacetest.WithTargetCluster("member-1"))
+			space := spacetest.NewSpace("john", spacetest.WithSpecTargetCluster("member-1"))
 			controller, request, cl := newController(t, changeTierRequest, config, userSignup, space, teamTier)
 			cl.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -152,10 +152,14 @@ func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, space *toolchainv1a
 	if space.Spec.TargetCluster == "" {
 		return false, r.setStatusProvisioningPending(space, "unspecified target member cluster")
 	}
+	// copying the `space.Spec.TargetCluster` into `space.Status.TargetCluster` in case the former is reset or changed (ie, when retargeting to another cluster)
+	space.Status.TargetCluster = space.Spec.TargetCluster
+
 	memberCluster, found := r.MemberClusters[space.Spec.TargetCluster]
 	if !found {
 		return false, r.setStatusProvisioningFailed(logger, space, fmt.Errorf("unknown target member cluster '%s'", space.Spec.TargetCluster))
 	}
+
 	logger = logger.WithValues("target_member_cluster", space.Spec.TargetCluster)
 	// look-up the NSTemplateTier
 	tmplTier := &toolchainv1alpha1.NSTemplateTier{}
@@ -345,9 +349,6 @@ func (r *Reconciler) setStatusProvisioned(space *toolchainv1alpha1.Space) error 
 }
 
 func (r *Reconciler) setStatusProvisioning(space *toolchainv1alpha1.Space) error {
-	if space.Spec.TargetCluster != "" { // copying the `space.Spec.TargetCluster` into `space.Status.TargetCluster` in case the former is reset or changed (ie, when retargeting to another cluster)
-		space.Status.TargetCluster = space.Spec.TargetCluster
-	}
 	return r.updateStatus(
 		space,
 		toolchainv1alpha1.Condition{
@@ -358,9 +359,6 @@ func (r *Reconciler) setStatusProvisioning(space *toolchainv1alpha1.Space) error
 }
 
 func (r *Reconciler) setStatusProvisioningPending(space *toolchainv1alpha1.Space, cause string) error {
-	if space.Spec.TargetCluster != "" { // copying the `space.Spec.TargetCluster` into `space.Status.TargetCluster` in case the former is reset or changed (ie, when retargeting to another cluster)
-		space.Status.TargetCluster = space.Spec.TargetCluster
-	}
 	if err := r.updateStatus(
 		space,
 		toolchainv1alpha1.Condition{
@@ -376,9 +374,6 @@ func (r *Reconciler) setStatusProvisioningPending(space *toolchainv1alpha1.Space
 }
 
 func (r *Reconciler) setStatusProvisioningFailed(logger logr.Logger, space *toolchainv1alpha1.Space, cause error) error {
-	if space.Spec.TargetCluster != "" { // copying the `space.Spec.TargetCluster` into `space.Status.TargetCluster` in case the former is reset or changed (ie, when retargeting to another cluster)
-		space.Status.TargetCluster = space.Spec.TargetCluster
-	}
 	if err := r.updateStatus(
 		space,
 		toolchainv1alpha1.Condition{
@@ -454,9 +449,6 @@ func (r *Reconciler) setStatusTerminatingFailed(logger logr.Logger, space *toolc
 }
 
 func (r *Reconciler) setStatusNSTemplateSetCreationFailed(logger logr.Logger, space *toolchainv1alpha1.Space, cause error) error {
-	if space.Spec.TargetCluster != "" { // copying the `space.Spec.TargetCluster` into `space.Status.TargetCluster` in case the former is reset or changed (ie, when retargeting to another cluster)
-		space.Status.TargetCluster = space.Spec.TargetCluster
-	}
 	if err := r.updateStatus(
 		space,
 		toolchainv1alpha1.Condition{

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -139,11 +139,11 @@ func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, space *toolchainv1a
 			logger.Info("wait while NSTemplateSet is being deleted", "member_cluster", space.Status.TargetCluster)
 			return false, r.setStatusRetargeting(space)
 		} else {
-			logger.Info("resetting 'space.Stπatus.TargetCluster' field")
+			logger.Info("resetting 'space.Status.TargetCluster' field")
 			// NSTemplateSet was removed: reset `space.Status.TargetCluster`
 			space.Status.TargetCluster = ""
-			if err := r.Client.Update(context.TODO(), space); err != nil {
-				return false, r.setStatusRetargetFailed(logger, space, err)
+			if err := r.Client.Status().Update(context.TODO(), space); err != nil {
+				return false, err
 			}
 			// and continue with the provisioning on the new target member cluster (if specified)
 		}

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -198,7 +198,7 @@ func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, space *toolchainv1a
 		nsTmplSetSpec := usersignup.NewNSTemplateSetSpec(tmplTier)
 		nsTmplSet.Spec = *nsTmplSetSpec
 		if err := memberCluster.Client.Update(context.TODO(), nsTmplSet); err != nil {
-			return false, r.setStatusNSTemplateSetCreationFailed(logger, space, err)
+			return false, r.setStatusNSTemplateSetUpdateFailed(logger, space, err)
 		}
 		// also, immediately update Space condition
 		logger.Info("NSTemplateSet updated on target member cluster")
@@ -455,6 +455,21 @@ func (r *Reconciler) setStatusNSTemplateSetCreationFailed(logger logr.Logger, sp
 			Type:    toolchainv1alpha1.ConditionReady,
 			Status:  corev1.ConditionFalse,
 			Reason:  toolchainv1alpha1.SpaceUnableToCreateNSTemplateSetReason,
+			Message: cause.Error(),
+		}); err != nil {
+		logger.Error(cause, "unable to create NSTemplateSet")
+		return err
+	}
+	return cause
+}
+
+func (r *Reconciler) setStatusNSTemplateSetUpdateFailed(logger logr.Logger, space *toolchainv1alpha1.Space, cause error) error {
+	if err := r.updateStatus(
+		space,
+		toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.ConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.SpaceUnableToUpdateNSTemplateSetReason,
 			Message: cause.Error(),
 		}); err != nil {
 		logger.Error(cause, "unable to create NSTemplateSet")

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -1005,7 +1005,7 @@ func TestRetargetSpace(t *testing.T) {
 				res, err := ctrl.Reconcile(context.TODO(), requestFor(s))
 				// then
 				require.NoError(t, err)
-				assert.True(t, res.Requeue) // requeue requested explictely when NSTemplateSet is created, even though watching the resource is enough to trigger a new reconcile loop
+				assert.True(t, res.Requeue) // requeue requested explicitly when NSTemplateSet is created, even though watching the resource is enough to trigger a new reconcile loop
 				spacetest.AssertThatSpace(t, s.Namespace, s.Name, hostClient).
 					HasFinalizer().
 					HasSpecTargetCluster("member-2").

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -904,7 +904,6 @@ func TestRetargetSpace(t *testing.T) {
 		ctrl := newReconciler(hostClient, member1, member2)
 
 		// when
-		s.Spec.TargetCluster = ""
 		res, err := ctrl.Reconcile(context.TODO(), requestFor(s))
 
 		// then

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -463,7 +463,7 @@ func TestDeleteSpace(t *testing.T) {
 				// stop the test here: it verified that the NSTemlateSet deletion was triggered (the rest is already covered above)
 			})
 
-			t.Run("no target cluster", func(t *testing.T) {
+			t.Run("without spec and status target cluster", func(t *testing.T) {
 				// given
 				s := spacetest.NewSpace("oddity",
 					spacetest.WithFinalizer(),

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211222155949-1691f31b6437
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20220103155800-de97f92f337d
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20211222155949-1691f31b6437
+
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go v0.60.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20211216074502-fe3952c3820a
+	github.com/codeready-toolchain/api v0.0.0-20220105073825-91ab6024979a
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20211221162123-511f85a643df
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
@@ -30,7 +30,5 @@ require (
 	k8s.io/kubectl v0.20.2
 	sigs.k8s.io/controller-runtime v0.8.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20220103155800-de97f92f337d
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -558,8 +558,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/xcoulon/api v0.0.0-20211222155949-1691f31b6437 h1:rfYAHobcesQBCkwK4KgZP1hOzcIvuG1UtikOK5rNVoI=
-github.com/xcoulon/api v0.0.0-20211222155949-1691f31b6437/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/xcoulon/api v0.0.0-20220103155800-de97f92f337d h1:ZtkLruusVMmBg2KUdARlBuCi1pLp9xQmQNnEdM6t+SU=
+github.com/xcoulon/api v0.0.0-20220103155800-de97f92f337d/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,9 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/codeready-toolchain/api v0.0.0-20211206130419-fedaada130c4/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20220105073825-91ab6024979a h1:+e/fFBmNIQ5qn4d6p9jV137gts5URvK2IAbLlQTNB/g=
+github.com/codeready-toolchain/api v0.0.0-20220105073825-91ab6024979a/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211221162123-511f85a643df h1:ZQiCVR6+uo11RAYsRYXfZ4Ty9UtfsTSlMOksesVyt6I=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211221162123-511f85a643df/go.mod h1:1rh5rsl4yL3flRVdVESKxRPhLkfDl/111DbH1PuTedQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -558,8 +561,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
-github.com/xcoulon/api v0.0.0-20220103155800-de97f92f337d h1:ZtkLruusVMmBg2KUdARlBuCi1pLp9xQmQNnEdM6t+SU=
-github.com/xcoulon/api v0.0.0-20220103155800-de97f92f337d/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -113,9 +113,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20211206130419-fedaada130c4/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20211216074502-fe3952c3820a h1:cyg6w23/VEI70tm0Nnh0uk78I5X60dBpkSAxXeho5G0=
-github.com/codeready-toolchain/api v0.0.0-20211216074502-fe3952c3820a/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211221162123-511f85a643df h1:ZQiCVR6+uo11RAYsRYXfZ4Ty9UtfsTSlMOksesVyt6I=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20211221162123-511f85a643df/go.mod h1:1rh5rsl4yL3flRVdVESKxRPhLkfDl/111DbH1PuTedQ=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -561,6 +558,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/xcoulon/api v0.0.0-20211222155949-1691f31b6437 h1:rfYAHobcesQBCkwK4KgZP1hOzcIvuG1UtikOK5rNVoI=
+github.com/xcoulon/api v0.0.0-20211222155949-1691f31b6437/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/test/space/space.go
+++ b/test/space/space.go
@@ -14,13 +14,13 @@ import (
 
 type Option func(space *toolchainv1alpha1.Space)
 
-func WithoutTargetCluster() Option {
+func WithoutSpecTargetCluster() Option {
 	return func(space *toolchainv1alpha1.Space) {
 		space.Spec.TargetCluster = ""
 	}
 }
 
-func WithTargetCluster(name string) Option {
+func WithSpecTargetCluster(name string) Option {
 	return func(space *toolchainv1alpha1.Space) {
 		space.Spec.TargetCluster = name
 	}

--- a/test/space/space_assertions.go
+++ b/test/space/space_assertions.go
@@ -48,10 +48,10 @@ func (a *Assertion) Exists() *Assertion {
 	return a
 }
 
-func (a *Assertion) HasFinalizer(name string) *Assertion {
+func (a *Assertion) HasFinalizer() *Assertion {
 	err := a.loadResource()
 	require.NoError(a.t, err)
-	assert.Contains(a.t, a.space.Finalizers, name)
+	assert.Contains(a.t, a.space.Finalizers, toolchainv1alpha1.FinalizerName)
 	return a
 }
 
@@ -84,7 +84,14 @@ func (a *Assertion) DoesNotHaveLabel(key string) *Assertion {
 	return a
 }
 
-func (a *Assertion) HasTargetCluster(targetCluster string) *Assertion {
+func (a *Assertion) HasNoSpecTargetCluster() *Assertion {
+	err := a.loadResource()
+	require.NoError(a.t, err)
+	assert.Empty(a.t, a.space.Spec.TargetCluster)
+	return a
+}
+
+func (a *Assertion) HasSpecTargetCluster(targetCluster string) *Assertion {
 	err := a.loadResource()
 	require.NoError(a.t, err)
 	assert.Equal(a.t, targetCluster, a.space.Spec.TargetCluster)
@@ -141,6 +148,23 @@ func ProvisioningFailed(msg string) toolchainv1alpha1.Condition {
 		Type:    toolchainv1alpha1.ConditionReady,
 		Status:  corev1.ConditionFalse,
 		Reason:  toolchainv1alpha1.SpaceProvisioningFailedReason,
+		Message: msg,
+	}
+}
+
+func Retargeting() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.ConditionReady,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.SpaceRetargetingReason,
+	}
+}
+
+func RetargetingFailed(msg string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.ConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.SpaceRetargetingFailedReason,
 		Message: msg,
 	}
 }

--- a/test/space/space_assertions.go
+++ b/test/space/space_assertions.go
@@ -186,6 +186,15 @@ func UnableToCreateNSTemplateSet(msg string) toolchainv1alpha1.Condition {
 	}
 }
 
+func UnableToUpdateNSTemplateSet(msg string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.ConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.SpaceUnableToUpdateNSTemplateSetReason,
+		Message: msg,
+	}
+}
+
 func Ready() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,


### PR DESCRIPTION
also, refactor logic to set status.targetCluster when
updating status conditions, and appy changes in existing tests
(mostly, ensure initial status is correctly set)

See also:
- https://github.com/codeready-toolchain/api/pull/283
- https://github.com/codeready-toolchain/toolchain-e2e/pull/431

Fixes https://issues.redhat.com/browse/CRT-1392

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
