### PR TITLE
feat: set space label on appstudio namespace

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
@@ -12,6 +12,7 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       name: ${USERNAME}
+      toolchain.dev.openshift.com/workspace: ${USERNAME}
     name: ${USERNAME}
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding


### PR DESCRIPTION
included in the `appstudio` template.

E2E test: https://github.com/codeready-toolchain/toolchain-e2e/pull/433

Fixes https://issues.redhat.com/browse/CRT-1383

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
