### PR TITLE
feat: introduce SpaceBindingCleanup controller

### DIFF
--- a/controllers/spacebindingcleanup/mapper.go
+++ b/controllers/spacebindingcleanup/mapper.go
@@ -1,0 +1,44 @@
+package spacebindingcleanup
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var mapperLog = ctrl.Log.WithName("MapToSpaceBindingByBoundObjectName")
+
+// MapToSpaceBindingByBoundObjectName maps the bound object (MUR or Space) to the associated SpaceBindings.
+// The correct SpaceBindings are listed using the given label whose value should equal to the object's name.
+func MapToSpaceBindingByBoundObjectName(cl client.Client, label string) func(object client.Object) []reconcile.Request {
+	return func(obj client.Object) []reconcile.Request {
+		logger := mapperLog.WithValues("object-name", obj.GetName(), "object-kind", obj.GetObjectKind())
+		spaceBindings := &toolchainv1alpha1.SpaceBindingList{}
+		err := cl.List(context.TODO(), spaceBindings,
+			client.InNamespace(obj.GetNamespace()),
+			client.MatchingLabels{label: obj.GetName()})
+		if err != nil {
+			logger.Error(err, "unable to get SpaceBinding for an object")
+			return []reconcile.Request{}
+		}
+		if len(spaceBindings.Items) == 0 {
+			logger.Error(err, "no SpaceBinding found for an object")
+			return []reconcile.Request{}
+		}
+
+		req := make([]reconcile.Request, len(spaceBindings.Items))
+		for i, item := range spaceBindings.Items {
+			req[i] = reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: item.Namespace,
+					Name:      item.Name,
+				},
+			}
+		}
+		return req
+	}
+}

--- a/controllers/spacebindingcleanup/mapper_test.go
+++ b/controllers/spacebindingcleanup/mapper_test.go
@@ -1,0 +1,102 @@
+package spacebindingcleanup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/test/space"
+	sb "github.com/codeready-toolchain/host-operator/test/spacebinding"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestMapToSpaceBindingByBoundObject(t *testing.T) {
+	// given
+	sbLaraCompAdmin := sb.NewSpaceBinding("lara-admin", "lara", "comp", "admin")
+	sbJoeCompView := sb.NewSpaceBinding("joe-view", "joe", "comp", "view")
+	sbLaraOtherEdit := sb.NewSpaceBinding("lara-edit", "lara", "other", "edit")
+
+	compSpace := space.NewSpace("comp")
+	orphanSpace := space.NewSpace("orphan")
+
+	laraMur := masteruserrecord.NewMasterUserRecord(t, "lara")
+	joeMur := masteruserrecord.NewMasterUserRecord(t, "joe")
+	orphanMur := masteruserrecord.NewMasterUserRecord(t, "orphan")
+
+	cl := test.NewFakeClient(t, sbLaraCompAdmin, sbJoeCompView, sbLaraOtherEdit)
+
+	t.Run("should return two SpaceBinding requests for comp space, when mapping from space", func(t *testing.T) {
+		// when
+		requests := MapToSpaceBindingByBoundObjectName(cl, v1alpha1.SpaceBindingSpaceLabelKey)(compSpace)
+
+		// then
+		require.Len(t, requests, 2)
+		assert.Contains(t, requests, newRequest("lara-admin"))
+		assert.Contains(t, requests, newRequest("joe-view"))
+	})
+
+	t.Run("should return two SpaceBindings for lara MUR, when mapping from mur", func(t *testing.T) {
+		// when
+		requests := MapToSpaceBindingByBoundObjectName(cl, v1alpha1.SpaceBindingMasterUserRecordLabelKey)(laraMur)
+
+		// then
+		require.Len(t, requests, 2)
+		assert.Contains(t, requests, newRequest("lara-admin"))
+		assert.Contains(t, requests, newRequest("lara-edit"))
+	})
+
+	t.Run("should return one SpaceBinding request for joe MUR, when mapping from mur", func(t *testing.T) {
+		// when
+		requests := MapToSpaceBindingByBoundObjectName(cl, v1alpha1.SpaceBindingMasterUserRecordLabelKey)(joeMur)
+
+		// then
+		require.Len(t, requests, 1)
+		assert.Contains(t, requests, newRequest("joe-view"))
+	})
+
+	t.Run("should not return any SpaceBinding request when there is no for the given space", func(t *testing.T) {
+		// when
+		requests := MapToSpaceBindingByBoundObjectName(cl, v1alpha1.SpaceBindingSpaceLabelKey)(orphanSpace)
+
+		// then
+		require.Empty(t, requests)
+	})
+
+	t.Run("should not return any SpaceBinding request when there is no for the given MUR", func(t *testing.T) {
+		// when
+		requests := MapToSpaceBindingByBoundObjectName(cl, v1alpha1.SpaceBindingMasterUserRecordLabelKey)(orphanMur)
+
+		// then
+		require.Empty(t, requests)
+	})
+
+	t.Run("should not return any SpaceBinding requests when list fails", func(t *testing.T) {
+		// given
+		cl := test.NewFakeClient(t, sbLaraCompAdmin, sbJoeCompView, sbLaraOtherEdit)
+		cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		requests := MapToSpaceBindingByBoundObjectName(cl, v1alpha1.SpaceBindingMasterUserRecordLabelKey)(orphanMur)
+
+		// then
+		require.Empty(t, requests)
+	})
+}
+
+func newRequest(name string) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      name,
+		},
+	}
+}

--- a/controllers/spacebindingcleanup/mapper_test.go
+++ b/controllers/spacebindingcleanup/mapper_test.go
@@ -19,9 +19,9 @@ import (
 
 func TestMapToSpaceBindingByBoundObject(t *testing.T) {
 	// given
-	sbLaraCompAdmin := sb.NewSpaceBinding("lara-admin", "lara", "comp", "admin")
-	sbJoeCompView := sb.NewSpaceBinding("joe-view", "joe", "comp", "view")
-	sbLaraOtherEdit := sb.NewSpaceBinding("lara-edit", "lara", "other", "edit")
+	sbLaraCompAdmin := sb.NewSpaceBinding("lara", "comp", "admin")
+	sbJoeCompView := sb.NewSpaceBinding("joe", "comp", "view")
+	sbLaraOtherEdit := sb.NewSpaceBinding("lara", "other", "edit")
 
 	compSpace := space.NewSpace("comp")
 	orphanSpace := space.NewSpace("orphan")
@@ -38,8 +38,8 @@ func TestMapToSpaceBindingByBoundObject(t *testing.T) {
 
 		// then
 		require.Len(t, requests, 2)
-		assert.Contains(t, requests, newRequest("lara-admin"))
-		assert.Contains(t, requests, newRequest("joe-view"))
+		assert.Contains(t, requests, newRequest(sbLaraCompAdmin.Name))
+		assert.Contains(t, requests, newRequest(sbJoeCompView.Name))
 	})
 
 	t.Run("should return two SpaceBindings for lara MUR, when mapping from mur", func(t *testing.T) {
@@ -48,8 +48,8 @@ func TestMapToSpaceBindingByBoundObject(t *testing.T) {
 
 		// then
 		require.Len(t, requests, 2)
-		assert.Contains(t, requests, newRequest("lara-admin"))
-		assert.Contains(t, requests, newRequest("lara-edit"))
+		assert.Contains(t, requests, newRequest(sbLaraCompAdmin.Name))
+		assert.Contains(t, requests, newRequest(sbLaraOtherEdit.Name))
 	})
 
 	t.Run("should return one SpaceBinding request for joe MUR, when mapping from mur", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestMapToSpaceBindingByBoundObject(t *testing.T) {
 
 		// then
 		require.Len(t, requests, 1)
-		assert.Contains(t, requests, newRequest("joe-view"))
+		assert.Contains(t, requests, newRequest(sbJoeCompView.Name))
 	})
 
 	t.Run("should not return any SpaceBinding request when there is no for the given space", func(t *testing.T) {

--- a/controllers/spacebindingcleanup/predicate.go
+++ b/controllers/spacebindingcleanup/predicate.go
@@ -1,0 +1,27 @@
+package spacebindingcleanup
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ predicate.Predicate = OnlyDeleteAndGenericPredicate{}
+
+type OnlyDeleteAndGenericPredicate struct {
+}
+
+func (p OnlyDeleteAndGenericPredicate) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (p OnlyDeleteAndGenericPredicate) Update(e event.UpdateEvent) bool {
+	return false
+}
+
+func (p OnlyDeleteAndGenericPredicate) Delete(e event.DeleteEvent) bool {
+	return true
+}
+
+func (p OnlyDeleteAndGenericPredicate) Generic(e event.GenericEvent) bool {
+	return true
+}

--- a/controllers/spacebindingcleanup/predicate_test.go
+++ b/controllers/spacebindingcleanup/predicate_test.go
@@ -1,0 +1,55 @@
+package spacebindingcleanup
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/host-operator/test/space"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestOnlyDeletionAndGenericPredicate(t *testing.T) {
+	// given
+	predicate := &OnlyDeleteAndGenericPredicate{}
+	sp := space.NewSpace("space")
+
+	t.Run("for create", func(t *testing.T) {
+		for _, ev := range []event.CreateEvent{{}, {Object: sp}} {
+			// when
+			shouldReconcile := predicate.Create(ev)
+
+			// then
+			assert.False(t, shouldReconcile)
+		}
+	})
+
+	t.Run("for update", func(t *testing.T) {
+		for _, ev := range []event.UpdateEvent{{}, {ObjectOld: sp, ObjectNew: sp}} {
+			// when
+			shouldReconcile := predicate.Update(ev)
+
+			// then
+			assert.False(t, shouldReconcile)
+		}
+	})
+
+	t.Run("for delete", func(t *testing.T) {
+		for _, ev := range []event.DeleteEvent{{}, {Object: sp}} {
+			// when
+			shouldReconcile := predicate.Delete(ev)
+
+			// then
+			assert.True(t, shouldReconcile)
+		}
+	})
+
+	t.Run("for generic", func(t *testing.T) {
+		for _, ev := range []event.GenericEvent{{}, {Object: sp}} {
+			// when
+			shouldReconcile := predicate.Generic(ev)
+
+			// then
+			assert.True(t, shouldReconcile)
+		}
+	})
+}

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
@@ -49,7 +49,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	logger := log.FromContext(ctx).WithName("cleanup")
 	logger.Info("Reconciling SpaceBinding")
 
-	// Fetch the UserSignup instance
+	// Fetch the SpaceBinding instance
 	spaceBinding := &toolchainv1alpha1.SpaceBinding{}
 	err := r.Client.Get(context.TODO(), request.NamespacedName, spaceBinding)
 	if err != nil {

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
@@ -1,0 +1,95 @@
+package spacebindingcleanup
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/go-logr/logr"
+	errs "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	onlyForDeletion := builder.WithPredicates(OnlyDeleteAndGenericPredicate{})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&toolchainv1alpha1.SpaceBinding{}).
+		Watches(&source.Kind{Type: &toolchainv1alpha1.Space{}},
+			handler.EnqueueRequestsFromMapFunc(MapToSpaceBindingByBoundObjectName(r.Client, toolchainv1alpha1.SpaceBindingSpaceLabelKey)),
+			onlyForDeletion).
+		Watches(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}},
+			handler.EnqueueRequestsFromMapFunc(MapToSpaceBindingByBoundObjectName(r.Client, toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey)),
+			onlyForDeletion).
+		Complete(r)
+}
+
+// Reconciler reconciles a SpaceBinding object
+type Reconciler struct {
+	client.Client
+	Scheme    *runtime.Scheme
+	Namespace string
+}
+
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spacebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spacebindings/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spacebindings/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithName("cleanup")
+	logger.Info("Reconciling SpaceBinding")
+
+	// Fetch the UserSignup instance
+	spaceBinding := &toolchainv1alpha1.SpaceBinding{}
+	err := r.Client.Get(context.TODO(), request.NamespacedName, spaceBinding)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	spaceName := types.NamespacedName{Namespace: spaceBinding.Namespace, Name: spaceBinding.Spec.Space}
+	space := &toolchainv1alpha1.Space{}
+	if err := r.Client.Get(context.TODO(), spaceName, space); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("the Space was not found", "Space", spaceBinding.Spec.Space)
+			return ctrl.Result{}, r.deleteSpaceBinding(logger, spaceBinding)
+
+		}
+		return ctrl.Result{}, errs.Wrapf(err, "unable to get the bound Space")
+	}
+
+	murName := types.NamespacedName{Namespace: spaceBinding.Namespace, Name: spaceBinding.Spec.MasterUserRecord}
+	mur := &toolchainv1alpha1.MasterUserRecord{}
+	if err := r.Client.Get(context.TODO(), murName, mur); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("the MUR was not found", "MasterUserRecord", spaceBinding.Spec.MasterUserRecord)
+			return ctrl.Result{}, r.deleteSpaceBinding(logger, spaceBinding)
+		}
+		return ctrl.Result{}, errs.Wrapf(err, "unable to get the bound MUR")
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) deleteSpaceBinding(logger logr.Logger, spaceBinding *toolchainv1alpha1.SpaceBinding) error {
+	logger.Info("deleting the SpaceBinding")
+	if err := r.Delete(context.TODO(), spaceBinding); err != nil {
+		return errs.Wrapf(err, "unable to delete the SpaceBinding")
+	}
+	return nil
+}

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
@@ -6,6 +6,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/go-logr/logr"
 	errs "github.com/pkg/errors"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,6 +61,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
+	}
+	if util.IsBeingDeleted(spaceBinding) {
+		logger.Info("the SpaceBinding is already being deleted")
+		return reconcile.Result{}, nil
 	}
 
 	spaceName := types.NamespacedName{Namespace: spaceBinding.Namespace, Name: spaceBinding.Spec.Space}

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
@@ -45,7 +45,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraIbmEdit.Name, fakeClient).Exists()
 	})
 
-	t.Run("joe-redhat SpaceBinding removed when joe MUR space is missing", func(t *testing.T) {
+	t.Run("joe-redhat SpaceBinding removed when joe MUR is missing", func(t *testing.T) {
 
 		reconciler, request, fakeClient := prepareReconciler(t, sbJoeRedhatView, sbLaraRedhatAdmin, sbLaraIbmEdit, laraMur, ibmSpace, redhatSpace)
 

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
@@ -1,0 +1,127 @@
+package spacebindingcleanup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/apis"
+	"github.com/codeready-toolchain/host-operator/test/space"
+	sb "github.com/codeready-toolchain/host-operator/test/spacebinding"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestDeleteSpaceBinding(t *testing.T) {
+	// given
+	sbLaraRedhatAdmin := sb.NewSpaceBinding("lara-admin", "lara", "redhat", "admin")
+	sbJoeRedhatView := sb.NewSpaceBinding("joe-view", "joe", "redhat", "view")
+	sbLaraIbmEdit := sb.NewSpaceBinding("lara-edit", "lara", "ibm", "edit")
+
+	redhatSpace := space.NewSpace("redhat")
+	ibmSpace := space.NewSpace("ibm")
+
+	laraMur := masteruserrecord.NewMasterUserRecord(t, "lara")
+	joeMur := masteruserrecord.NewMasterUserRecord(t, "joe")
+
+	t.Run("lara-admin SpaceBinding removed when redhat space is missing", func(t *testing.T) {
+
+		reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, sbJoeRedhatView, sbLaraIbmEdit, laraMur, joeMur, ibmSpace)
+
+		// when
+		_, err := reconciler.Reconcile(context.TODO(), request)
+
+		// then
+		require.NoError(t, err)
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).DoesNotExist()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe-view", fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-edit", fakeClient).Exists()
+	})
+
+	t.Run("joe-view SpaceBinding removed when joe MUR space is missing", func(t *testing.T) {
+
+		reconciler, request, fakeClient := prepareReconciler(t, sbJoeRedhatView, sbLaraRedhatAdmin, sbLaraIbmEdit, laraMur, ibmSpace, redhatSpace)
+
+		// when
+		_, err := reconciler.Reconcile(context.TODO(), request)
+
+		// then
+		require.NoError(t, err)
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe-view", fakeClient).DoesNotExist()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-edit", fakeClient).Exists()
+	})
+
+	t.Run("no SpaceBinding removed when MUR and Space are present", func(t *testing.T) {
+
+		reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, sbJoeRedhatView, sbLaraIbmEdit, laraMur, joeMur, ibmSpace, redhatSpace)
+
+		// when
+		_, err := reconciler.Reconcile(context.TODO(), request)
+
+		// then
+		require.NoError(t, err)
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe-view", fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-edit", fakeClient).Exists()
+	})
+
+	t.Run("fails while getting the bound resource", func(t *testing.T) {
+
+		for _, boundResourceName := range []string{"lara", "redhat"} {
+			reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, redhatSpace, laraMur)
+			fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				if key.Name == boundResourceName {
+					return fmt.Errorf("some error")
+				}
+				return fakeClient.Client.Get(ctx, key, obj)
+			}
+
+			// when
+			_, err := reconciler.Reconcile(context.TODO(), request)
+
+			// then
+			require.Error(t, err)
+			sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).Exists()
+		}
+	})
+
+	t.Run("fails while deleting the SpaceBinding", func(t *testing.T) {
+
+		reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, redhatSpace)
+		fakeClient.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		_, err := reconciler.Reconcile(context.TODO(), request)
+
+		// then
+		require.Error(t, err)
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).Exists()
+	})
+}
+
+func prepareReconciler(t *testing.T, sb *v1alpha1.SpaceBinding, initObjects ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+
+	cl := test.NewFakeClient(t, append(initObjects, sb)...)
+
+	reconciler := &Reconciler{
+		Namespace: test.HostOperatorNs,
+		Scheme:    s,
+		Client:    cl,
+	}
+	req := reconcile.Request{
+		NamespacedName: test.NamespacedName(test.HostOperatorNs, sb.Name),
+	}
+	return reconciler, req, cl
+}

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
@@ -20,9 +20,9 @@ import (
 
 func TestDeleteSpaceBinding(t *testing.T) {
 	// given
-	sbLaraRedhatAdmin := sb.NewSpaceBinding("lara-admin", "lara", "redhat", "admin")
-	sbJoeRedhatView := sb.NewSpaceBinding("joe-view", "joe", "redhat", "view")
-	sbLaraIbmEdit := sb.NewSpaceBinding("lara-edit", "lara", "ibm", "edit")
+	sbLaraRedhatAdmin := sb.NewSpaceBinding("lara", "redhat", "admin")
+	sbJoeRedhatView := sb.NewSpaceBinding("joe", "redhat", "view")
+	sbLaraIbmEdit := sb.NewSpaceBinding("lara", "ibm", "edit")
 
 	redhatSpace := space.NewSpace("redhat")
 	ibmSpace := space.NewSpace("ibm")
@@ -39,9 +39,9 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).DoesNotExist()
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe-view", fakeClient).Exists()
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-edit", fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraRedhatAdmin.Name, fakeClient).DoesNotExist()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbJoeRedhatView.Name, fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraIbmEdit.Name, fakeClient).Exists()
 	})
 
 	t.Run("joe-view SpaceBinding removed when joe MUR space is missing", func(t *testing.T) {
@@ -53,9 +53,9 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).Exists()
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe-view", fakeClient).DoesNotExist()
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-edit", fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraRedhatAdmin.Name, fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbJoeRedhatView.Name, fakeClient).DoesNotExist()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraIbmEdit.Name, fakeClient).Exists()
 	})
 
 	t.Run("no SpaceBinding removed when MUR and Space are present", func(t *testing.T) {
@@ -67,9 +67,9 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).Exists()
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe-view", fakeClient).Exists()
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-edit", fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraRedhatAdmin.Name, fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbJoeRedhatView.Name, fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraIbmEdit.Name, fakeClient).Exists()
 	})
 
 	t.Run("fails while getting the bound resource", func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 			// then
 			require.Error(t, err)
-			sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).Exists()
+			sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraRedhatAdmin.Name, fakeClient).Exists()
 		}
 	})
 
@@ -104,7 +104,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 		// then
 		require.Error(t, err)
-		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara-admin", fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraRedhatAdmin.Name, fakeClient).Exists()
 	})
 }
 

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,7 +31,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 	laraMur := masteruserrecord.NewMasterUserRecord(t, "lara")
 	joeMur := masteruserrecord.NewMasterUserRecord(t, "joe")
 
-	t.Run("lara-admin SpaceBinding removed when redhat space is missing", func(t *testing.T) {
+	t.Run("lara-redhat SpaceBinding removed when redhat space is missing", func(t *testing.T) {
 
 		reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, sbJoeRedhatView, sbLaraIbmEdit, laraMur, joeMur, ibmSpace)
 
@@ -44,7 +45,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraIbmEdit.Name, fakeClient).Exists()
 	})
 
-	t.Run("joe-view SpaceBinding removed when joe MUR space is missing", func(t *testing.T) {
+	t.Run("joe-redhat SpaceBinding removed when joe MUR space is missing", func(t *testing.T) {
 
 		reconciler, request, fakeClient := prepareReconciler(t, sbJoeRedhatView, sbLaraRedhatAdmin, sbLaraIbmEdit, laraMur, ibmSpace, redhatSpace)
 
@@ -55,6 +56,22 @@ func TestDeleteSpaceBinding(t *testing.T) {
 		require.NoError(t, err)
 		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraRedhatAdmin.Name, fakeClient).Exists()
 		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbJoeRedhatView.Name, fakeClient).DoesNotExist()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraIbmEdit.Name, fakeClient).Exists()
+	})
+
+	t.Run("lara-redhat SpaceBinding is being deleted, so no action needed", func(t *testing.T) {
+		sbLaraRedhatAdmin := sbLaraRedhatAdmin.DeepCopy()
+		now := v1.Now()
+		sbLaraRedhatAdmin.DeletionTimestamp = &now
+		reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, sbJoeRedhatView, sbLaraIbmEdit, laraMur, joeMur, ibmSpace)
+
+		// when
+		_, err := reconciler.Reconcile(context.TODO(), request)
+
+		// then
+		require.NoError(t, err)
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraRedhatAdmin.Name, fakeClient).Exists()
+		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbJoeRedhatView.Name, fakeClient).Exists()
 		sb.AssertThatSpaceBinding(t, test.HostOperatorNs, sbLaraIbmEdit.Name, fakeClient).Exists()
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go v0.60.0 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20220111095034-396370db892b
+	github.com/codeready-toolchain/api v0.0.0-20220119113134-00f7989ab329
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20220111130042-c27616410c7e
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codeready-toolchain/api v0.0.0-20220110101730-04d30e90a574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20220111095034-396370db892b h1:p824PXd7Mis0NiB+hx9nP6Q52aY6yLbwee++mJJza88=
-github.com/codeready-toolchain/api v0.0.0-20220111095034-396370db892b/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20220119113134-00f7989ab329 h1:LwejXDyXs5V+G290v268tTZaV0TEww+8UtLXveIhcJI=
+github.com/codeready-toolchain/api v0.0.0-20220119113134-00f7989ab329/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220111130042-c27616410c7e h1:80uroEbKi5eEAEHyr/ABv8IgHS2j0Xn6vXOO/xYuQsY=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220111130042-c27616410c7e/go.mod h1:6fAhxW0MpXz2KgrNT+12zodepWFqNSOJcy6H2Ip4kV8=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/notification"
 	"github.com/codeready-toolchain/host-operator/controllers/nstemplatetier"
 	"github.com/codeready-toolchain/host-operator/controllers/space"
+	"github.com/codeready-toolchain/host-operator/controllers/spacebindingcleanup"
 	"github.com/codeready-toolchain/host-operator/controllers/templateupdaterequest"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainstatus"
@@ -270,6 +271,14 @@ func main() {
 		MemberClusters: memberClusters,
 	}).SetupWithManager(mgr, memberClusters); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Space")
+	}
+	if err = (&spacebindingcleanup.Reconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Namespace: namespace,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SpaceBindingCleanup")
+		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder
 

--- a/test/space/space_assertions.go
+++ b/test/space/space_assertions.go
@@ -6,7 +6,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	tierutil "github.com/codeready-toolchain/host-operator/controllers/nstemplatetier/util"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"

--- a/test/spacebinding/spacebinding.go
+++ b/test/spacebinding/spacebinding.go
@@ -1,0 +1,25 @@
+package spacebinding
+
+import (
+	"github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewSpaceBinding(name, mur, space, spaceRole string) *v1alpha1.SpaceBinding {
+	return &v1alpha1.SpaceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.HostOperatorNs,
+			Labels: map[string]string{
+				v1alpha1.SpaceBindingMasterUserRecordLabelKey: mur,
+				v1alpha1.SpaceBindingSpaceLabelKey:            space,
+			},
+		},
+		Spec: v1alpha1.SpaceBindingSpec{
+			MasterUserRecord: mur,
+			Space:            space,
+			SpaceRole:        spaceRole,
+		},
+	}
+}

--- a/test/spacebinding/spacebinding.go
+++ b/test/spacebinding/spacebinding.go
@@ -1,15 +1,17 @@
 package spacebinding
 
 import (
+	"fmt"
+
 	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewSpaceBinding(name, mur, space, spaceRole string) *v1alpha1.SpaceBinding {
+func NewSpaceBinding(mur, space, spaceRole string) *v1alpha1.SpaceBinding {
 	return &v1alpha1.SpaceBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      fmt.Sprintf("%s-%s", mur, space),
 			Namespace: test.HostOperatorNs,
 			Labels: map[string]string{
 				v1alpha1.SpaceBindingMasterUserRecordLabelKey: mur,

--- a/test/spacebinding/spacebinding_assertions.go
+++ b/test/spacebinding/spacebinding_assertions.go
@@ -26,7 +26,7 @@ func (a *Assertion) loadResource() error {
 	return err
 }
 
-// AssertThatSpace helper func to begin with the assertions on a SpaceBinding
+// AssertThatSpaceBinding helper func to begin with the assertions on a SpaceBinding
 func AssertThatSpaceBinding(t test.T, namespace, name string, client client.Client) *Assertion {
 	return &Assertion{
 		client:         client,

--- a/test/spacebinding/spacebinding_assertions.go
+++ b/test/spacebinding/spacebinding_assertions.go
@@ -1,0 +1,55 @@
+package spacebinding
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Assertion struct {
+	spaceBinding   *toolchainv1alpha1.SpaceBinding
+	client         client.Client
+	namespacedName types.NamespacedName
+	t              test.T
+}
+
+func (a *Assertion) loadResource() error {
+	tier := &toolchainv1alpha1.SpaceBinding{}
+	err := a.client.Get(context.TODO(), a.namespacedName, tier)
+	a.spaceBinding = tier
+	return err
+}
+
+// AssertThatSpace helper func to begin with the assertions on a SpaceBinding
+func AssertThatSpaceBinding(t test.T, namespace, name string, client client.Client) *Assertion {
+	return &Assertion{
+		client:         client,
+		namespacedName: test.NamespacedName(namespace, name),
+		t:              t,
+	}
+}
+
+func (a *Assertion) Get() *toolchainv1alpha1.SpaceBinding {
+	err := a.loadResource()
+	require.NoError(a.t, err)
+	return a.spaceBinding
+}
+
+func (a *Assertion) Exists() *Assertion {
+	err := a.loadResource()
+	require.NoError(a.t, err)
+	return a
+}
+
+func (a *Assertion) DoesNotExist() *Assertion {
+	err := a.loadResource()
+	require.Error(a.t, err)
+	assert.True(a.t, errors.IsNotFound(err))
+	return a
+}


### PR DESCRIPTION
Adds SpaceBindingCleanup controller that deletes the SpaceBinding if either the bound MUR or the bound Space was deleted.

There is also:
1. Mapper that maps:
    * MUR to SpaceBinding(s) using the label: `toolchain.dev.openshift.com/masteruserrecord == mur.Name`
    * Space to SpaceBinding(s) using the label: `toolchain.dev.openshift.com/space == space.Name`

2. Predicate which ignores creation & updates of the Space & MasterUserRecord resources - allowes only deletion and the generic event

paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/453
