### PR TITLE
refactoring: move capacity management logic to separate package

### DIFF
--- a/pkg/capacity/manager.go
+++ b/pkg/capacity/manager.go
@@ -1,0 +1,95 @@
+package capacity
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
+	"github.com/codeready-toolchain/host-operator/pkg/counter"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func hasNotReachedMaxNumberOfUsersThreshold(config toolchainconfig.ToolchainConfig, counts counter.Counts) cluster.Condition {
+	return func(cluster *cluster.CachedToolchainCluster) bool {
+		if config.AutomaticApproval().MaxNumberOfUsersOverall() != 0 {
+			if config.AutomaticApproval().MaxNumberOfUsersOverall() <= (counts.MasterUserRecords()) {
+				return false
+			}
+		}
+		numberOfUserAccounts := counts.UserAccountsPerClusterCounts[cluster.Name]
+		threshold := config.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster()[cluster.Name]
+		return threshold == 0 || numberOfUserAccounts < threshold
+	}
+}
+
+func hasEnoughResources(config toolchainconfig.ToolchainConfig, status *toolchainv1alpha1.ToolchainStatus) cluster.Condition {
+	return func(cluster *cluster.CachedToolchainCluster) bool {
+		threshold, found := config.AutomaticApproval().ResourceCapacityThresholdSpecificPerMemberCluster()[cluster.Name]
+		if !found {
+			threshold = config.AutomaticApproval().ResourceCapacityThresholdDefault()
+		}
+		if threshold == 0 {
+			return true
+		}
+		for _, memberStatus := range status.Status.Members {
+			if memberStatus.ClusterName == cluster.Name {
+				return hasMemberREnoughResources(memberStatus, threshold)
+			}
+		}
+		return false
+	}
+}
+
+func hasMemberREnoughResources(memberStatus toolchainv1alpha1.Member, threshold int) bool {
+	if len(memberStatus.MemberStatus.ResourceUsage.MemoryUsagePerNodeRole) > 0 {
+		for _, usagePerNode := range memberStatus.MemberStatus.ResourceUsage.MemoryUsagePerNodeRole {
+			if usagePerNode >= threshold {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// GetOptimalTargetCluster returns the first available cluster with enough capacity where a Space could be provisioned.
+// If the preferredCluster is provided and it is also one of the available clusters, then the same name is returned, otherwise, it returns the first available one.
+func GetOptimalTargetCluster(preferredCluster, namespace string, getMemberClusters cluster.GetMemberClustersFunc, cl client.Client) (string, error) {
+	config, err := toolchainconfig.GetToolchainConfig(cl)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to get ToolchainConfig")
+	}
+
+	counts, err := counter.GetCounts()
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to get the number of provisioned users")
+	}
+
+	status := &toolchainv1alpha1.ToolchainStatus{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: toolchainconfig.ToolchainStatusName}, status); err != nil {
+		return "", errors.Wrapf(err, "unable to read ToolchainStatus resource")
+	}
+
+	return getOptimalTargetCluster(preferredCluster, getMemberClusters, hasNotReachedMaxNumberOfUsersThreshold(config, counts), hasEnoughResources(config, status)), nil
+}
+
+func getOptimalTargetCluster(preferredCluster string, getMemberClusters cluster.GetMemberClustersFunc, conditions ...cluster.Condition) string {
+	// Automatic cluster selection based on cluster readiness
+	members := getMemberClusters(append(conditions, cluster.Ready)...)
+	if len(members) == 0 {
+		return ""
+	}
+
+	// if the preferred cluster is provided and it is also one of the available clusters, then the same name is returned, otherwise, it returns the first available one
+	if preferredCluster != "" {
+		for _, m := range members {
+			if preferredCluster == m.Name {
+				return m.Name
+			}
+		}
+	}
+	return members[0].Name
+}

--- a/pkg/capacity/manager_test.go
+++ b/pkg/capacity/manager_test.go
@@ -1,0 +1,253 @@
+package capacity_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/capacity"
+	"github.com/codeready-toolchain/host-operator/pkg/metrics"
+	. "github.com/codeready-toolchain/host-operator/test"
+	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestGetOptimalTargetCluster(t *testing.T) {
+	// given
+	toolchainStatus := NewToolchainStatus(
+		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
+			string(metrics.Internal): 100,
+			string(metrics.External): 800,
+		}),
+		WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
+			"1,internal": 200,
+			"1,external": 700,
+		}),
+		WithMember("member1", WithUserAccountCount(700), WithNodeRoleUsage("worker", 68), WithNodeRoleUsage("master", 65)),
+		WithMember("member2", WithUserAccountCount(200), WithNodeRoleUsage("worker", 55), WithNodeRoleUsage("master", 60)))
+
+	t.Run("with one cluster and enough capacity", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(2000, testconfig.PerMemberCluster("member1", 1000)).
+				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70)))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "member1", clusterName)
+	})
+
+	t.Run("with two clusters and enough capacity in both of them so it returns the first one", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(2000, testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
+				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "member1", clusterName)
+	})
+
+	t.Run("with two clusters and enough capacity in both of them, but the second one is the preferred", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(2000, testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
+				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("member2", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "member2", clusterName)
+	})
+
+	t.Run("with two clusters where the first one reaches resource threshold", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(2000, testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
+				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 60), testconfig.PerMemberCluster("member2", 75)))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "member2", clusterName)
+	})
+
+	t.Run("with two clusters where the first one reaches max number of UserAccounts, so the second one is returned even when the first is defined as the preferred one", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(2000, testconfig.PerMemberCluster("member1", 700), testconfig.PerMemberCluster("member2", 1000)).
+				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 90), testconfig.PerMemberCluster("member2", 95)))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("member1", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "member2", clusterName)
+	})
+
+	t.Run("with two clusters, none of them is returned since it reaches max number of MURs, no matter what is defined as preferred", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(800, testconfig.PerMemberCluster("member1", 6000), testconfig.PerMemberCluster("member2", 1000)).
+				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 60), testconfig.PerMemberCluster("member2", 75)))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("member2", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "", clusterName)
+	})
+
+	t.Run("with two clusters but only the second one has enough capacity - using the default values", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(2000).
+				ResourceCapacityThreshold(62))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "member2", clusterName)
+	})
+
+	t.Run("with two clusters but none of them has enough capacity - using the default memory values", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(5000).
+				ResourceCapacityThreshold(1))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "", clusterName)
+	})
+
+	t.Run("with two clusters and enough capacity in both of them but first one is not ready", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.AutomaticApproval().
+				MaxNumberOfUsers(2000, testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
+				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionFalse), NewMemberCluster(t, "member2", v1.ConditionTrue))
+
+		// when
+		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "member2", clusterName)
+	})
+
+	t.Run("failures", func(t *testing.T) {
+		t.Run("unable to get ToolchainConfig", func(t *testing.T) {
+			// given
+			fakeClient := NewFakeClient(t, toolchainStatus)
+			InitializeCounters(t, toolchainStatus)
+			fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				return fmt.Errorf("some error")
+			}
+			InitializeCounters(t, toolchainStatus)
+			clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
+
+			// when
+			clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+			// then
+			require.EqualError(t, err, "unable to get ToolchainConfig: some error")
+			assert.Equal(t, "", clusterName)
+		})
+
+		t.Run("unable to read ToolchainStatus", func(t *testing.T) {
+			// given
+			fakeClient := NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
+			fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				if _, ok := obj.(*toolchainv1alpha1.ToolchainStatus); ok {
+					return fmt.Errorf("some error")
+				}
+				return fakeClient.Client.Get(ctx, key, obj)
+			}
+			InitializeCounters(t, toolchainStatus)
+			clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
+
+			// when
+			clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+			// then
+			require.EqualError(t, err, "unable to read ToolchainStatus resource: some error")
+			assert.Equal(t, "", clusterName)
+		})
+	})
+}
+
+func TestGetOptimalTargetClusterWhenCounterIsNotInitialized(t *testing.T) {
+	// given
+	toolchainStatus := NewToolchainStatus(
+		WithMember("member1", WithNodeRoleUsage("worker", 68), WithNodeRoleUsage("master", 65)))
+	fakeClient := NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
+	clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
+
+	// when
+	clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+
+	// then
+	require.EqualError(t, err, "unable to get the number of provisioned users: counter is not initialized")
+	assert.Equal(t, "", clusterName)
+}


### PR DESCRIPTION
move capacity management logic to separate package so it can be reused in SpaceCompletion controller

https://issues.redhat.com/browse/CRT-1333