### PR TITLE
chore: revert linter changes

### DIFF
--- a/controllers/nstemplatetier/nstemplatetier_controller.go
+++ b/controllers/nstemplatetier/nstemplatetier_controller.go
@@ -243,10 +243,9 @@ func (r *Reconciler) activeTemplateUpdateRequests(logger logr.Logger, config too
 	}
 	logger.Info("checking templateUpdateRequests", "items", items)
 	count := 0
-	for i := range templateUpdateRequests.Items {
-		tur := templateUpdateRequests.Items[i] // avoids the `G601: Implicit memory aliasing in for loop. (gosec)` problem
-		logger.Info("checking templateUpdateRequest", "name", tur.Name, "deleted", util.IsBeingDeleted(&tur))
-		if util.IsBeingDeleted(&tur) {
+	for _, tur := range templateUpdateRequests.Items {
+		logger.Info("checking templateUpdateRequest", "name", tur.Name, "deleted", util.IsBeingDeleted(&tur)) // nolint:gosec
+		if util.IsBeingDeleted(&tur) {                                                                        // nolint:gosec
 			// ignore when already being deleted
 			logger.Info("skipping TemplateUpdateRequest as it is already being deleted", "name", tur.Name)
 			continue
@@ -259,7 +258,7 @@ func (r *Reconciler) activeTemplateUpdateRequests(logger logr.Logger, config too
 			if err := r.incrementCounters(logger, tier, tur); err != nil {
 				return -1, false, err
 			}
-			if err := r.Client.Delete(context.TODO(), &tur); err != nil {
+			if err := r.Client.Delete(context.TODO(), &tur); err != nil { // nolint:gosec
 				if errors.IsNotFound(err) {
 					logger.Info("skipping failed TemplateUpdateRequest as it was already deleted", "name", tur.Name)
 					continue

--- a/pkg/counter/cache.go
+++ b/pkg/counter/cache.go
@@ -255,8 +255,7 @@ func initializeFromResources(cl client.Client, namespace string) error {
 		return err
 	}
 	reset()
-	for i := range usersignups.Items {
-		usersignup := usersignups.Items[i] // avoid the `G601: Implicit memory aliasing in for loop` problem
+	for _, usersignup := range usersignups.Items {
 		activations, activationsExists := usersignup.Annotations[toolchainv1alpha1.UserSignupActivationCounterAnnotationKey]
 		if activationsExists {
 			_, err := strconv.Atoi(activations) // let's make sure the value is actually an integer
@@ -264,13 +263,12 @@ func initializeFromResources(cl client.Client, namespace string) error {
 				log.Error(err, "invalid number of activations", "name", usersignup.Name, "value", activations)
 				continue
 			}
-			domain := metrics.GetEmailDomain(&usersignup)
+			domain := metrics.GetEmailDomain(&usersignup) // nolint:gosec
 			cachedCounts.UserSignupsPerActivationAndDomainCounts[joinLabelValues(activations, string(domain))]++
 		}
 	}
-	for i := range murs.Items {
-		mur := murs.Items[i] // avoid the `G601: Implicit memory aliasing in for loop` problem
-		domain := metrics.GetEmailDomain(&mur)
+	for _, mur := range murs.Items {
+		domain := metrics.GetEmailDomain(&mur) // nolint:gosec
 		cachedCounts.MasterUserRecordPerDomainCounts[string(domain)]++
 		for _, ua := range mur.Spec.UserAccounts {
 			cachedCounts.UserAccountsPerClusterCounts[ua.TargetCluster]++


### PR DESCRIPTION
revert unneeded changes after gosec linter complains
use `// nolint:gosec` comment instead.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
