### PR TITLE
feat: introduce SpaceCompletion controller

### DIFF
--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -150,6 +150,12 @@ func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, space *toolchainv1a
 		}
 	}
 
+	if space.Spec.TierName == "" {
+		if err := r.setStateLabel(logger, space, toolchainv1alpha1.SpaceStateLabelValuePending); err != nil {
+			return false, err
+		}
+		return false, r.setStatusProvisioningPending(space, "unspecified tier name")
+	}
 	if space.Spec.TargetCluster == "" {
 		if err := r.setStateLabel(logger, space, toolchainv1alpha1.SpaceStateLabelValuePending); err != nil {
 			return false, err

--- a/controllers/spacecompletion/space_completion_controller.go
+++ b/controllers/spacecompletion/space_completion_controller.go
@@ -35,6 +35,7 @@ type Reconciler struct {
 // Watches the Space resources and the ToolchainStatus CRD
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("spacecompletion").
 		// watch Spaces in the host cluster
 		For(&toolchainv1alpha1.Space{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
@@ -47,7 +48,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile ensures that Space has set all missing fields that are needed for proper provisoning
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx, "namespace", r.Namespace).WithName("completion")
+	logger := log.FromContext(ctx, "namespace", r.Namespace)
 	logger.Info("reconciling Space")
 
 	// Fetch the Space

--- a/controllers/spacecompletion/space_completion_controller.go
+++ b/controllers/spacecompletion/space_completion_controller.go
@@ -1,0 +1,110 @@
+package spacecompletion
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
+	"github.com/codeready-toolchain/host-operator/pkg/capacity"
+	"github.com/codeready-toolchain/host-operator/pkg/pending"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/go-logr/logr"
+	"github.com/redhat-cop/operator-utils/pkg/util"
+
+	errs "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Reconciler reconciles a Space object
+type Reconciler struct {
+	Client            client.Client
+	Namespace         string
+	GetMemberClusters cluster.GetMemberClustersFunc
+}
+
+// SetupWithManager sets up the controller reconciler with the Manager
+// Watches the Space resources and the ToolchainStatus CRD
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		// watch Spaces in the host cluster
+		For(&toolchainv1alpha1.Space{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&source.Kind{Type: &toolchainv1alpha1.ToolchainStatus{}},
+			handler.EnqueueRequestsFromMapFunc(pending.NewSpaceMapper(mgr.GetClient()).MapToOldestPending)).
+		Complete(r)
+}
+
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaces,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile ensures that Space has set all missing fields that are needed for proper provisoning
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx, "namespace", r.Namespace).WithName("completion")
+	logger.Info("reconciling Space")
+
+	// Fetch the Space
+	space := &toolchainv1alpha1.Space{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      request.Name,
+	}, space)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Space not found")
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, errs.Wrap(err, "unable to get the current Space")
+	}
+
+	// if is being deleted, then skip it as there is nothing te be completed
+	if util.IsBeingDeleted(space) {
+		logger.Info("Space is being deleted - skipping...")
+		return reconcile.Result{}, nil
+	}
+
+	if changed, err := r.ensureFields(logger, space); err != nil || !changed {
+		return reconcile.Result{}, err
+	}
+
+	return ctrl.Result{}, r.Client.Update(context.TODO(), space)
+}
+
+func (r *Reconciler) ensureFields(logger logr.Logger, space *toolchainv1alpha1.Space) (bool, error) {
+	if space.Spec.TierName == "" {
+		config, err := toolchainconfig.GetToolchainConfig(r.Client)
+		if err != nil {
+			return false, errs.Wrapf(err, "unable to set the TierName")
+		}
+		space.Spec.TierName = config.Tiers().DefaultSpaceTier()
+		logger.Info("TierName has been set", "tierName", config.Tiers().DefaultSpaceTier())
+		return true, nil
+	}
+
+	if space.Spec.TargetCluster == "" {
+		targetCluster, err := capacity.GetOptimalTargetCluster("", space.Namespace, r.GetMemberClusters, r.Client)
+		if err != nil {
+			return false, errs.Wrapf(err, "unable to get the optimal target cluster")
+		}
+		if targetCluster == "" {
+			logger.Info("no cluster available")
+			return false, nil
+		}
+		space.Spec.TargetCluster = targetCluster
+		logger.Info("TargetCluster has been set", "targetCluster", targetCluster)
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/controllers/spacecompletion/space_completion_controller_test.go
+++ b/controllers/spacecompletion/space_completion_controller_test.go
@@ -1,0 +1,203 @@
+package spacecompletion_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/controllers/spacecompletion"
+	"github.com/codeready-toolchain/host-operator/pkg/apis"
+	"github.com/codeready-toolchain/host-operator/pkg/counter"
+	. "github.com/codeready-toolchain/host-operator/test"
+	spacetest "github.com/codeready-toolchain/host-operator/test/space"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestCreateSpace(t *testing.T) {
+	member1 := NewMemberCluster(t, "member1", corev1.ConditionTrue)
+	getMemberClusters := NewGetMemberClusters(member1)
+
+	t.Run("without any field set - then it sets only tierName", func(t *testing.T) {
+		// given
+		space := spacetest.NewSpace("without-fields",
+			spacetest.WithTierName(""))
+		r, req, cl := prepareReconcile(t, space, getMemberClusters)
+
+		// when
+		_, err := r.Reconcile(context.TODO(), req)
+
+		// then
+		require.NoError(t, err)
+		spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
+			HasTier("base").
+			HasSpecTargetCluster("")
+	})
+
+	t.Run("with tierName but without targetCluster - only targetCluster should be set", func(t *testing.T) {
+		// given
+		space := spacetest.NewSpace("without-targetCluster",
+			spacetest.WithTierName("advanced"))
+		r, req, cl := prepareReconcile(t, space, getMemberClusters)
+
+		// when
+		_, err := r.Reconcile(context.TODO(), req)
+
+		// then
+		require.NoError(t, err)
+		spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
+			HasTier("advanced").
+			HasSpecTargetCluster("member1")
+	})
+
+	t.Run("with targetCluster but without tierName - only tierName should be set", func(t *testing.T) {
+		// given
+		space := spacetest.NewSpace("without-tierName",
+			spacetest.WithTierName(""),
+			spacetest.WithSpecTargetCluster("member2"))
+		r, req, cl := prepareReconcile(t, space, getMemberClusters)
+
+		// when
+		_, err := r.Reconcile(context.TODO(), req)
+
+		// then
+		require.NoError(t, err)
+		spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
+			HasTier("base").
+			HasSpecTargetCluster("member2")
+	})
+
+	t.Run("no updates expected", func(t *testing.T) {
+		t.Run("with both fields set", func(t *testing.T) {
+			// given
+			space := spacetest.NewSpace("with-fields",
+				spacetest.WithTierName("advanced"),
+				spacetest.WithSpecTargetCluster("member2"))
+			r, req, cl := prepareReconcile(t, space, getMemberClusters)
+
+			// when
+			_, err := r.Reconcile(context.TODO(), req)
+
+			// then
+			require.NoError(t, err)
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
+				HasTier("advanced").
+				HasSpecTargetCluster("member2")
+		})
+
+		t.Run("when is being deleted, then nothing should be set", func(t *testing.T) {
+			// given
+			space := spacetest.NewSpace("without-fields",
+				spacetest.WithTierName(""),
+				spacetest.WithDeletionTimestamp())
+			r, req, cl := prepareReconcile(t, space, getMemberClusters)
+
+			// when
+			_, err := r.Reconcile(context.TODO(), req)
+
+			// then
+			require.NoError(t, err)
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
+				HasTier("").
+				HasSpecTargetCluster("")
+		})
+
+		t.Run("when no member cluster available and when tierName is set", func(t *testing.T) {
+			// given
+			space := spacetest.NewSpace("without-members",
+				spacetest.WithTierName("advanced"))
+			r, req, cl := prepareReconcile(t, space, NewGetMemberClusters())
+
+			// when
+			_, err := r.Reconcile(context.TODO(), req)
+
+			// then
+			require.NoError(t, err)
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
+				HasTier("advanced").
+				HasSpecTargetCluster("")
+		})
+
+		t.Run("when Get ToolchainConfig fails and no field is set", func(t *testing.T) {
+			// given
+			space := spacetest.NewSpace("oddity",
+				spacetest.WithTierName(""))
+			r, req, cl := prepareReconcile(t, space, NewGetMemberClusters())
+			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				if key.Name == "config" {
+					return fmt.Errorf("some error")
+				}
+				return cl.Client.Get(ctx, key, obj)
+			}
+
+			// when
+			_, err := r.Reconcile(context.TODO(), req)
+
+			// then
+			require.Error(t, err)
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
+				HasTier("").
+				HasSpecTargetCluster("")
+		})
+
+		t.Run("when Get ToolchainConfig fails and only targetCluster is missing", func(t *testing.T) {
+			// given
+			space := spacetest.NewSpace("oddity",
+				spacetest.WithTierName("advanced"))
+			r, req, cl := prepareReconcile(t, space, NewGetMemberClusters())
+			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+				if key.Name == "config" {
+					return fmt.Errorf("some error")
+				}
+				return cl.Client.Get(ctx, key, obj)
+			}
+
+			// when
+			_, err := r.Reconcile(context.TODO(), req)
+
+			// then
+			require.Error(t, err)
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
+				HasTier("advanced").
+				HasSpecTargetCluster("")
+		})
+	})
+}
+
+func prepareReconcile(t *testing.T, space *toolchainv1alpha1.Space, getMemberClusters cluster.GetMemberClustersFunc) (*spacecompletion.Reconciler, reconcile.Request, *test.FakeClient) {
+	require.NoError(t, os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs))
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+
+	toolchainStatus := NewToolchainStatus(
+		WithMember("member1", WithNodeRoleUsage("worker", 68), WithNodeRoleUsage("master", 65)))
+	t.Cleanup(counter.Reset)
+	InitializeCounters(t, toolchainStatus)
+
+	conf := configuration.NewToolchainConfigObjWithReset(t)
+
+	fakeClient := test.NewFakeClient(t, toolchainStatus, space, conf)
+
+	r := &spacecompletion.Reconciler{
+		Client:            fakeClient,
+		Namespace:         test.HostOperatorNs,
+		GetMemberClusters: getMemberClusters,
+	}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      space.Name,
+		},
+	}
+	return r, req, fakeClient
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/nstemplatetier"
 	"github.com/codeready-toolchain/host-operator/controllers/space"
 	"github.com/codeready-toolchain/host-operator/controllers/spacebindingcleanup"
+	"github.com/codeready-toolchain/host-operator/controllers/spacecompletion"
 	"github.com/codeready-toolchain/host-operator/controllers/templateupdaterequest"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainstatus"
@@ -278,6 +279,14 @@ func main() {
 		MemberClusters: memberClusters,
 	}).SetupWithManager(mgr, memberClusters); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Space")
+		os.Exit(1)
+	}
+	if err = (&spacecompletion.Reconciler{
+		Client:            mgr.GetClient(),
+		Namespace:         namespace,
+		GetMemberClusters: commoncluster.GetMemberClusters,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SpaceCompletion")
 		os.Exit(1)
 	}
 	if err = (&spacebindingcleanup.Reconciler{

--- a/test/space/space.go
+++ b/test/space/space.go
@@ -26,9 +26,9 @@ func WithSpecTargetCluster(name string) Option {
 	}
 }
 
-func WithTierNameFor(tier *toolchainv1alpha1.NSTemplateTier) Option {
+func WithTierName(tierName string) Option {
 	return func(space *toolchainv1alpha1.Space) {
-		space.Spec.TierName = tier.Name
+		space.Spec.TierName = tierName
 	}
 }
 


### PR DESCRIPTION
Adds SpaceCompletion controller which will set TierName and TargetCluster if they are not set already.
To choose the correct TargetCluter it uses the same capacity manager as is used for UserSignup

paired with: https://github.com/codeready-toolchain/toolchain-e2e/pull/469