### PR TITLE
refactor: SpaceController watching NSTemplateTiers

### DIFF
--- a/controllers/nstemplatetier/label_selector.go
+++ b/controllers/nstemplatetier/label_selector.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// outdatedSelector creates a label selector to find MasterUserRecords or Spaces which are not up-to-date with
+// OutdatedTierSelector creates a label selector to find MasterUserRecords or Spaces which are not up-to-date with
 // the templateRefs of the given NSTemplateTier.
 //
 // (longer explanation)
@@ -20,7 +20,7 @@ import (
 // but with a template version (defined by `<hash>`) which is NOT to the expected value (the one provided by `instance`).
 //
 // Note: The `hash` value is computed from the TemplateRefs. See `computeTemplateRefsHash()`
-func outdatedTierSelector(tier *toolchainv1alpha1.NSTemplateTier) (client.MatchingLabelsSelector, error) {
+func OutdatedTierSelector(tier *toolchainv1alpha1.NSTemplateTier) (client.MatchingLabelsSelector, error) {
 	// compute the hash of the `.spec.namespaces[].templateRef` + `.spec.clusteResource.TemplateRef`
 	hash, err := tierutil.ComputeHashForNSTemplateTier(tier)
 	if err != nil {

--- a/controllers/space/nstemplatetier_spaces_mapper.go
+++ b/controllers/space/nstemplatetier_spaces_mapper.go
@@ -1,0 +1,42 @@
+package space
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/controllers/nstemplatetier"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var mapperLog = ctrl.Log.WithName("MapNSTemplateTierToSpaces")
+
+func MapNSTemplateTierToSpaces(namespace string, cl client.Client) func(object client.Object) []reconcile.Request {
+	return func(obj client.Object) []reconcile.Request {
+		if tmplTier, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok {
+			matchOutdated, err := nstemplatetier.OutdatedTierSelector(tmplTier)
+			if err != nil {
+				mapperLog.Error(err, "cannot map NSTemplateTier to Spaces")
+			}
+			// look-up all spaces associated with the NSTemplateTier
+			spaces := &toolchainv1alpha1.SpaceList{}
+			if err := cl.List(context.TODO(), spaces, client.InNamespace(namespace), matchOutdated); err != nil {
+				mapperLog.Error(err, "cannot map NSTemplateTier to Spaces")
+			}
+			mapperLog.Info("enqueuing reconcile requests after NSTemplateTier was updated", "name", tmplTier.Name, "request_count", len(spaces.Items))
+			requests := make([]reconcile.Request, len(spaces.Items))
+			for i, s := range spaces.Items {
+				requests[i] = reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: s.Namespace,
+					Name:      s.Name,
+				}}
+			}
+			return requests
+		}
+		mapperLog.Error(nil, "cannot map to Spaces")
+		return nil
+	}
+}

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -207,7 +207,8 @@ func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, space *toolchainv1a
 	logger.Info("NSTemplateSet already exists")
 
 	// update the NSTemplateSet if needed
-	if !tierutil.TierHashMatches(tmplTier, nsTmplSet.Spec) {
+	if !tierutil.TierHashMatches(tmplTier, nsTmplSet.Spec) &&
+		condition.IsTrue(space.Status.Conditions, toolchainv1alpha1.ConditionReady) {
 		// postpone if needed, so we don't overflow the cluster with too many concurrent updates
 		if time.Since(r.lastExecutedUpdate) < time.Second {
 			if time.Now().After(r.nextScheduledUpdate) {

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -138,7 +138,7 @@ const postponeDelay = 2 * time.Second
 // - the Space's `Ready=false/Updating` condition is too recent, so we're not sure that the NSTemplateSetController was triggered.
 // OR if the space needs to be updated but later (use returned duration for as `requeueAfter`)
 // Returns `false` otherwise
-func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, space *toolchainv1alpha1.Space) (bool, time.Duration, error) {
+func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, space *toolchainv1alpha1.Space) (bool, time.Duration, error) { //nolint:gocyclo
 	// deprovision from space.Status.TargetCluster if needed
 	if space.Status.TargetCluster != "" && space.Spec.TargetCluster != space.Status.TargetCluster {
 		logger.Info("retargeting space", "from_cluster", space.Status.TargetCluster, "to_cluster", space.Spec.TargetCluster)

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -63,7 +63,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, memberClusters map[strin
 
 // Reconcile ensures that there is an NSTemplateSet resource defined in the target member cluster
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx, "namespace", r.Namespace).WithValues("name", request.Name)
+	logger := log.FromContext(ctx, "namespace", r.Namespace)
 	logger.Info("reconciling Space")
 
 	// Fetch the Space
@@ -217,6 +217,7 @@ func (r *Reconciler) ensureNSTemplateSet(logger logr.Logger, space *toolchainv1a
 				r.nextScheduledUpdate = r.nextScheduledUpdate.Add(2 * time.Second)
 			}
 			// return the duration when it should be requeued
+			logger.Info("postponing NSTemplateSet update", "until", r.nextScheduledUpdate.String())
 			return true, time.Until(r.nextScheduledUpdate), nil
 		}
 		r.lastExecutedUpdate = time.Now()

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -876,8 +876,8 @@ func TestUpdateSpaceTier(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.Greater(t, res.RequeueAfter, 1*time.Second) // explicitly requeued 2 seconds after `now`
-		assert.LessOrEqual(t, res.RequeueAfter, 2*time.Second)
+		assert.Greater(t, res.RequeueAfter, 0*time.Second) // explicitly requeued 1 second after `now`
+		assert.LessOrEqual(t, res.RequeueAfter, 1*time.Second)
 		spacetest.AssertThatSpace(t, test.HostOperatorNs, s2.Name, hostClient).
 			Exists().
 			HasTier(basicTier.Name).
@@ -899,8 +899,8 @@ func TestUpdateSpaceTier(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.Greater(t, res.RequeueAfter, 3*time.Second) // explicitly requeued 2 seconds after s2, i.e, almost 4s after `now`
-		assert.LessOrEqual(t, res.RequeueAfter, 4*time.Second)
+		assert.Greater(t, res.RequeueAfter, 1*time.Second) // explicitly requeued 1 seconds after s2, i.e, almost 2s after `now`
+		assert.LessOrEqual(t, res.RequeueAfter, 2*time.Second)
 		spacetest.AssertThatSpace(t, test.HostOperatorNs, s3.Name, hostClient).
 			Exists().
 			HasTier(basicTier.Name).

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -745,7 +745,7 @@ func TestUpdateSpaceTier(t *testing.T) {
 		})
 	})
 
-	t.Run("tier update (same tier but updated references)", func(t *testing.T) {
+	t.Run("tier update for single space (same tier but updated references)", func(t *testing.T) {
 		// get an older basic tier (with outdated references) that the nstemplateset can be referenced to for setup
 		olderBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
 		// given that Space is set to the same tier that has been updated and the corresponding NSTemplateSet is not up-to-date
@@ -811,6 +811,109 @@ func TestUpdateSpaceTier(t *testing.T) {
 				HasMatchingTierLabelForTier(basicTier). // label updated
 				HasFinalizer()
 		})
+	})
+
+	t.Run("tier update for 3 spaces (same tier but updated references)", func(t *testing.T) {
+		// get an older basic tier (with outdated references) that the nstemplateset can be referenced to for setup
+		olderBasicTier := tiertest.BasicTier(t, tiertest.PreviousBasicTemplates)
+		// given that Space is set to the same tier that has been updated and the corresponding NSTemplateSet is not up-to-date
+		s1 := spacetest.NewSpace("oddity1",
+			spacetest.WithTierNameAndHashLabelFor(olderBasicTier),
+			spacetest.WithSpecTargetCluster("member-1"),
+			spacetest.WithStatusTargetCluster("member-1"), // already provisioned on a target cluster
+			spacetest.WithFinalizer(),
+			spacetest.WithCondition(spacetest.Ready()))
+		nsTmplSet1 := nstemplatetsettest.NewNSTemplateSet(s1.Name, nstemplatetsettest.WithReferencesFor(olderBasicTier), nstemplatetsettest.WithReadyCondition()) // NSTemplateSet has references to old basic tier
+		s2 := spacetest.NewSpace("oddity2",
+			spacetest.WithTierNameAndHashLabelFor(olderBasicTier),
+			spacetest.WithSpecTargetCluster("member-1"),
+			spacetest.WithStatusTargetCluster("member-1"), // already provisioned on a target cluster
+			spacetest.WithFinalizer(),
+			spacetest.WithCondition(spacetest.Ready()))
+		nsTmplSet2 := nstemplatetsettest.NewNSTemplateSet(s2.Name, nstemplatetsettest.WithReferencesFor(olderBasicTier), nstemplatetsettest.WithReadyCondition()) // NSTemplateSet has references to old basic tier
+		s3 := spacetest.NewSpace("oddity3",
+			spacetest.WithTierNameAndHashLabelFor(olderBasicTier),
+			spacetest.WithSpecTargetCluster("member-1"),
+			spacetest.WithStatusTargetCluster("member-1"), // already provisioned on a target cluster
+			spacetest.WithFinalizer(),
+			spacetest.WithCondition(spacetest.Ready()))
+		nsTmplSet3 := nstemplatetsettest.NewNSTemplateSet(s3.Name, nstemplatetsettest.WithReferencesFor(olderBasicTier), nstemplatetsettest.WithReadyCondition()) // NSTemplateSet has references to old basic tier
+		hostClient := test.NewFakeClient(t, s1, s2, s3, basicTier)
+		member1Client := test.NewFakeClient(t, nsTmplSet1, nsTmplSet2, nsTmplSet3)
+		member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
+		member2 := NewMemberCluster(t, "member-2", corev1.ConditionTrue)
+		ctrl := newReconciler(hostClient, member1, member2)
+
+		// when reconciling space `s1`
+		res, err := ctrl.Reconcile(context.TODO(), requestFor(s1))
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: 1 * time.Second, // wait 1s for NSTemplateSet update to begin
+		}, res) // explicitly requeue while the NSTemplate update is triggered by its controller
+		spacetest.AssertThatSpace(t, test.HostOperatorNs, s1.Name, hostClient).
+			Exists().
+			HasTier(basicTier.Name).
+			HasSpecTargetCluster("member-1").
+			HasStatusTargetCluster("member-1").
+			HasConditions(spacetest.Updating()).
+			HasMatchingTierLabelForTier(olderBasicTier)
+		nsTmplSet1 = nstemplatetsettest.AssertThatNSTemplateSet(t, test.MemberOperatorNs, nsTmplSet1.Name, member1.Client).
+			Exists().
+			HasTierName(basicTier.Name).
+			HasClusterResourcesTemplateRef("basic-clusterresources-123456new").
+			HasNamespaceTemplateRefs("basic-code-123456new", "basic-dev-123456new", "basic-stage-123456new"). // updated
+			Get()
+		require.True(t, tierutil.TierHashMatches(basicTier, nsTmplSet1.Spec))
+
+		// when reconciling space `s2`
+		res, err = ctrl.Reconcile(context.TODO(), requestFor(s2))
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, res.Requeue)
+		assert.Greater(t, res.RequeueAfter, 1*time.Second) // explicitly requeued 2 seconds after `now`
+		assert.LessOrEqual(t, res.RequeueAfter, 2*time.Second)
+		spacetest.AssertThatSpace(t, test.HostOperatorNs, s2.Name, hostClient).
+			Exists().
+			HasTier(basicTier.Name).
+			HasSpecTargetCluster("member-1").
+			HasStatusTargetCluster("member-1").
+			HasConditions(spacetest.Ready()).           // unchanged
+			HasMatchingTierLabelForTier(olderBasicTier) // unchanged
+		nsTmplSet2 = nstemplatetsettest.AssertThatNSTemplateSet(t, test.MemberOperatorNs, nsTmplSet2.Name, member1.Client).
+			Exists().
+			HasTierName(basicTier.Name).
+			HasClusterResourcesTemplateRef("basic-clusterresources-123456old").
+			HasNamespaceTemplateRefs("basic-code-123456old", "basic-dev-123456old", "basic-stage-123456old"). // not updated yet
+			Get()
+		require.True(t, tierutil.TierHashMatches(olderBasicTier, nsTmplSet2.Spec)) // unchanged
+
+		// when reconciling space `s3`
+		res, err = ctrl.Reconcile(context.TODO(), requestFor(s3))
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, res.Requeue)
+		assert.Greater(t, res.RequeueAfter, 3*time.Second) // explicitly requeued 2 seconds after s2, i.e, almost 4s after `now`
+		assert.LessOrEqual(t, res.RequeueAfter, 4*time.Second)
+		spacetest.AssertThatSpace(t, test.HostOperatorNs, s3.Name, hostClient).
+			Exists().
+			HasTier(basicTier.Name).
+			HasSpecTargetCluster("member-1").
+			HasStatusTargetCluster("member-1").
+			HasConditions(spacetest.Ready()).           // unchanged
+			HasMatchingTierLabelForTier(olderBasicTier) // unchanged
+		nsTmplSet2 = nstemplatetsettest.AssertThatNSTemplateSet(t, test.MemberOperatorNs, nsTmplSet3.Name, member1.Client).
+			Exists().
+			HasTierName(basicTier.Name).
+			HasClusterResourcesTemplateRef("basic-clusterresources-123456old").
+			HasNamespaceTemplateRefs("basic-code-123456old", "basic-dev-123456old", "basic-stage-123456old"). // not updated yet
+			Get()
+		require.True(t, tierutil.TierHashMatches(olderBasicTier, nsTmplSet2.Spec)) // unchanged
+
 	})
 
 	t.Run("update not needed", func(t *testing.T) {

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -876,8 +876,8 @@ func TestUpdateSpaceTier(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.Greater(t, res.RequeueAfter, 0*time.Second) // explicitly requeued 1 second after `now`
-		assert.LessOrEqual(t, res.RequeueAfter, 1*time.Second)
+		assert.Greater(t, res.RequeueAfter, 1*time.Second) // explicitly requeued 2 seconds after `now`
+		assert.LessOrEqual(t, res.RequeueAfter, 2*time.Second)
 		spacetest.AssertThatSpace(t, test.HostOperatorNs, s2.Name, hostClient).
 			Exists().
 			HasTier(basicTier.Name).
@@ -899,8 +899,8 @@ func TestUpdateSpaceTier(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.Greater(t, res.RequeueAfter, 1*time.Second) // explicitly requeued 1 seconds after s2, i.e, almost 2s after `now`
-		assert.LessOrEqual(t, res.RequeueAfter, 2*time.Second)
+		assert.Greater(t, res.RequeueAfter, 3*time.Second) // explicitly requeued 2 seconds after s2, i.e, almost 4s after `now`
+		assert.LessOrEqual(t, res.RequeueAfter, 4*time.Second)
 		spacetest.AssertThatSpace(t, test.HostOperatorNs, s3.Name, hostClient).
 			Exists().
 			HasTier(basicTier.Name).

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -640,7 +640,8 @@ func TestUpdateSpaceTier(t *testing.T) {
 			spacetest.WithTierNameFor(otherTier), // assume that at this point, the `TemplateTierHash` label was already removed by the ChangeTierRequestController
 			spacetest.WithSpecTargetCluster("member-1"),
 			spacetest.WithStatusTargetCluster("member-1"), // already provisioned on a target cluster
-			spacetest.WithFinalizer())
+			spacetest.WithFinalizer(),
+			spacetest.WithCondition(spacetest.Ready()))
 		hostClient := test.NewFakeClient(t, s, basicTier, otherTier)
 		nstmplSet := nstemplatetsettest.NewNSTemplateSet("oddity", nstemplatetsettest.WithReferencesFor(basicTier), nstemplatetsettest.WithReadyCondition())
 		member1Client := test.NewFakeClient(t, nstmplSet)
@@ -753,7 +754,8 @@ func TestUpdateSpaceTier(t *testing.T) {
 			spacetest.WithTierNameAndHashLabelFor(olderBasicTier),
 			spacetest.WithSpecTargetCluster("member-1"),
 			spacetest.WithStatusTargetCluster("member-1"), // already provisioned on a target cluster
-			spacetest.WithFinalizer())
+			spacetest.WithFinalizer(),
+			spacetest.WithCondition(spacetest.Ready()))
 		hostClient := test.NewFakeClient(t, s, basicTier)
 		nsTmplSet := nstemplatetsettest.NewNSTemplateSet("oddity", nstemplatetsettest.WithReferencesFor(olderBasicTier), nstemplatetsettest.WithReadyCondition()) // NSTemplateSet has references to old basic tier
 		member1Client := test.NewFakeClient(t, nsTmplSet)
@@ -990,7 +992,8 @@ func TestUpdateSpaceTier(t *testing.T) {
 				spacetest.WithTierNameFor(otherTier),
 				spacetest.WithSpecTargetCluster("member-1"),
 				spacetest.WithStatusTargetCluster("member-1"), // already provisioned on a target cluster
-				spacetest.WithFinalizer())
+				spacetest.WithFinalizer(),
+				spacetest.WithCondition(spacetest.Ready()))
 			hostClient := test.NewFakeClient(t, s, basicTier, otherTier)
 			nstmplSet := nstemplatetsettest.NewNSTemplateSet("oddity", nstemplatetsettest.WithReferencesFor(basicTier), nstemplatetsettest.WithReadyCondition())
 			member1Client := test.NewFakeClient(t, nstmplSet)

--- a/controllers/templateupdaterequest/templateupdaterequest_controller.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller.go
@@ -32,7 +32,6 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&toolchainv1alpha1.TemplateUpdateRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}}, &handler.EnqueueRequestForObject{}).
-		// Watches(&source.Kind{Type: &toolchainv1alpha1.Space{}}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }
 

--- a/controllers/templateupdaterequest/templateupdaterequest_controller.go
+++ b/controllers/templateupdaterequest/templateupdaterequest_controller.go
@@ -32,7 +32,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&toolchainv1alpha1.TemplateUpdateRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.MasterUserRecord{}}, &handler.EnqueueRequestForObject{}).
-		Watches(&source.Kind{Type: &toolchainv1alpha1.Space{}}, &handler.EnqueueRequestForObject{}).
+		// Watches(&source.Kind{Type: &toolchainv1alpha1.Space{}}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }
 


### PR DESCRIPTION
SpaceController wathc NSTemplateTier updates using a custom
mapper, and triggers Space updates (when needed) with a progressive
requeue strategy (1 space every 2s) to:
- avoid flooding the cluster with hundreds of concurrent space updates
- give room for new space to be created while the update is still in
  progress

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
