### PR TITLE
feat: choose the target cluster based on capacity in a balanced way

### DIFF
--- a/pkg/capacity/manager_test.go
+++ b/pkg/capacity/manager_test.go
@@ -71,7 +71,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		assert.Equal(t, "member1", clusterName)
 	})
 
-	t.Run("with two clusters and enough capacity in both of them so it returns the with more capacity (the third one)", func(t *testing.T) {
+	t.Run("with three clusters and enough capacity in both of them so it returns the with more capacity (the third one)", func(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.AutomaticApproval().


### PR DESCRIPTION
By default, choose the target cluster based on capacity in a balanced way, because I got bored by trying to achieve the same thing via modifying the thresholds over and over again.

The capacity manager returns the cluster with the most capacity available there.