### PR TITLE
chore: include quota for SBO spec API

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/cluster.yaml
@@ -146,7 +146,8 @@ objects:
   spec:
     quota:
       hard:
-        count/servicebindings.binding.operators.coreos.com: "100"
+        count/servicebindings.binding.operators.coreos.com: "50"
+        count/servicebindings.servicebinding.io: "50"
     selector:
       annotations:
         openshift.io/requester: ${USERNAME}

--- a/deploy/templates/nstemplatetiers/base/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/base/cluster.yaml
@@ -146,7 +146,8 @@ objects:
   spec:
     quota:
       hard:
-        count/servicebindings.binding.operators.coreos.com: "100"
+        count/servicebindings.binding.operators.coreos.com: "50"
+        count/servicebindings.servicebinding.io: "50"
     selector:
       annotations:
         openshift.io/requester: ${USERNAME}


### PR DESCRIPTION
SBO supports 2 API but the quota was only set for one of them.

This PR:
* Adds quotas for the second (SPEC) API
* distributes the overall quota between the two