### PR TITLE
feat: add email annotation to UserAccount CR

### DIFF
--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -137,7 +137,7 @@ func (r *Reconciler) ensureUserAccount(logger logr.Logger, murAccount toolchainv
 	if err := memberCluster.Client.Get(context.TODO(), nsdName, userAccount); err != nil {
 		if errors.IsNotFound(err) {
 			// does not exist - should create
-			userAccount = newUserAccount(nsdName, murAccount.Spec, mur.Spec)
+			userAccount = newUserAccount(nsdName, murAccount.Spec, mur)
 
 			// Remove this after all users have been migrated to new IdP client
 			userAccount.Spec.OriginalSub = mur.Spec.OriginalSub
@@ -346,18 +346,21 @@ func updateStatusConditions(logger logr.Logger, cl client.Client, mur *toolchain
 	return err
 }
 
-func newUserAccount(nsdName types.NamespacedName, spec toolchainv1alpha1.UserAccountSpecEmbedded, murSpec toolchainv1alpha1.MasterUserRecordSpec) *toolchainv1alpha1.UserAccount {
+func newUserAccount(nsdName types.NamespacedName, spec toolchainv1alpha1.UserAccountSpecEmbedded, mur *toolchainv1alpha1.MasterUserRecord) *toolchainv1alpha1.UserAccount {
 	return &toolchainv1alpha1.UserAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nsdName.Name,
 			Namespace: nsdName.Namespace,
+			Annotations: map[string]string{
+				toolchainv1alpha1.UserEmailAnnotationKey: mur.Annotations[toolchainv1alpha1.MasterUserRecordEmailAnnotationKey],
+			},
 			Labels: map[string]string{
-				toolchainv1alpha1.TierLabelKey: murSpec.TierName,
+				toolchainv1alpha1.TierLabelKey: mur.Spec.TierName,
 			},
 		},
 		Spec: toolchainv1alpha1.UserAccountSpec{
-			UserID:   murSpec.UserID,
-			Disabled: murSpec.Disabled,
+			UserID:   mur.Spec.UserID,
+			Disabled: mur.Spec.Disabled,
 			UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{
 				NSLimit:       spec.UserAccountSpecBase.NSLimit,
 				NSTemplateSet: spec.UserAccountSpecBase.NSTemplateSet,

--- a/controllers/masteruserrecord/sync.go
+++ b/controllers/masteruserrecord/sync.go
@@ -45,11 +45,15 @@ func (s *Synchronizer) synchronizeSpec() error {
 		s.memberUserAcc.Spec.UserID = s.record.Spec.UserID
 		s.memberUserAcc.Spec.OriginalSub = s.record.Spec.OriginalSub
 
-		// in addition to synchronizing the spec, ensure the tier label is set
+		// in addition to synchronizing the spec, ensure both the tier label and email annotation are set
 		if s.memberUserAcc.Labels == nil {
 			s.memberUserAcc.Labels = map[string]string{}
 		}
 		s.memberUserAcc.Labels[toolchainv1alpha1.TierLabelKey] = s.record.Spec.TierName
+		if s.memberUserAcc.Annotations == nil {
+			s.memberUserAcc.Annotations = map[string]string{}
+		}
+		s.memberUserAcc.Annotations[toolchainv1alpha1.UserEmailAnnotationKey] = s.record.Annotations[toolchainv1alpha1.MasterUserRecordEmailAnnotationKey]
 
 		err := s.memberCluster.Client.Update(context.TODO(), s.memberUserAcc)
 		if err != nil {
@@ -65,7 +69,8 @@ func (s *Synchronizer) isSynchronized() bool {
 	return reflect.DeepEqual(s.memberUserAcc.Spec.UserAccountSpecBase, s.recordSpecUserAcc.Spec.UserAccountSpecBase) &&
 		s.memberUserAcc.Spec.Disabled == s.record.Spec.Disabled &&
 		s.memberUserAcc.Spec.UserID == s.record.Spec.UserID &&
-		s.memberUserAcc.Labels != nil && s.memberUserAcc.Labels[toolchainv1alpha1.TierLabelKey] == s.record.Spec.TierName
+		s.memberUserAcc.Labels != nil && s.memberUserAcc.Labels[toolchainv1alpha1.TierLabelKey] == s.record.Spec.TierName &&
+		s.memberUserAcc.Annotations != nil && s.memberUserAcc.Annotations[toolchainv1alpha1.UserEmailAnnotationKey] == s.record.Annotations[toolchainv1alpha1.MasterUserRecordEmailAnnotationKey]
 }
 
 func (s *Synchronizer) synchronizeStatus() error {

--- a/controllers/masteruserrecord/sync_test.go
+++ b/controllers/masteruserrecord/sync_test.go
@@ -3,6 +3,7 @@ package masteruserrecord
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -128,6 +129,9 @@ func setupSynchronizerItems() (toolchainv1alpha1.MasterUserRecord, toolchainv1al
 			Labels: map[string]string{
 				toolchainv1alpha1.TierLabelKey: "basic",
 			},
+			Annotations: map[string]string{
+				toolchainv1alpha1.UserEmailAnnotationKey: "foo@bar.com",
+			},
 		},
 		Spec: toolchainv1alpha1.UserAccountSpec{
 			UserID:              "foo",
@@ -141,6 +145,11 @@ func setupSynchronizerItems() (toolchainv1alpha1.MasterUserRecord, toolchainv1al
 		},
 	}
 	record := toolchainv1alpha1.MasterUserRecord{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				toolchainv1alpha1.UserEmailAnnotationKey: "foo@bar.com",
+			},
+		},
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
 			UserID:   "foo",
 			Disabled: false,
@@ -162,6 +171,30 @@ func TestSynchronizeSpec(t *testing.T) {
 
 	murtest.ModifyUaInMur(mur, test.MemberClusterName, murtest.NsLimit("advanced"),
 		murtest.UserAccountTierName("admin"), murtest.Namespace("ide", "54321"))
+
+	hostClient := test.NewFakeClient(t, mur)
+	sync, memberClient := prepareSynchronizer(t, userAccount, mur, hostClient)
+
+	// when
+	err := sync.synchronizeSpec()
+
+	// then
+	require.NoError(t, err)
+	uatest.AssertThatUserAccount(t, "john", memberClient).
+		Exists().
+		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec)
+
+	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+		HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordUpdatingReason, ""))
+}
+
+func TestSynchronizeAnnotation(t *testing.T) {
+	// given
+	apiScheme(t)
+	mur := murtest.NewMasterUserRecord(t, "john", murtest.StatusCondition(toBeProvisioned()))
+
+	userAccount := uatest.NewUserAccountFromMur(mur)
+	userAccount.Annotations = nil
 
 	hostClient := test.NewFakeClient(t, mur)
 	sync, memberClient := prepareSynchronizer(t, userAccount, mur, hostClient)
@@ -734,6 +767,7 @@ func TestRoutes(t *testing.T) {
 }
 
 func prepareSynchronizer(t *testing.T, userAccount *toolchainv1alpha1.UserAccount, mur *toolchainv1alpha1.MasterUserRecord, hostClient *test.FakeClient) (Synchronizer, client.Client) {
+	require.NoError(t, os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs))
 	copiedMur := mur.DeepCopy()
 	toolchainStatus := NewToolchainStatus(
 		WithMember(test.MemberClusterName, WithRoutes("https://console.member-cluster/", "http://che-toolchain-che.member-cluster/", ToBeReady())))

--- a/go.mod
+++ b/go.mod
@@ -29,4 +29,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.8.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20220214184131-404951e4159a
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20220214184443-ca6f8b574953
+
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -117,11 +117,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20220128071955-6baa0dfc9574/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/api v0.0.0-20220128141941-727c0ecfe260 h1:o4s1tSe2YP9JyjBEaV41ZTM2U67agrU/utnB3NEEpF4=
-github.com/codeready-toolchain/api v0.0.0-20220128141941-727c0ecfe260/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084 h1:9V+OvCQU9h7V3W6bx0hhqO3JQL/hyENwuRPeq24XYf4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220128072729-4dd5728f0084/go.mod h1:+wXPryRgWG13u0OQ1iv8ZxjLdEV0VwomkVceAu2bRKI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -416,6 +411,10 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/matousjobanek/api v0.0.0-20220214184131-404951e4159a h1:2mDhTCNMKdOgkwSm6BfHsr6eC9O2JsGCCdoCJfWHbLg=
+github.com/matousjobanek/api v0.0.0-20220214184131-404951e4159a/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/matousjobanek/toolchain-common v0.0.0-20220214184443-ca6f8b574953 h1:M6gDN8wOW3qW5LfKxFbYDrYK767WoXDTtkFbb8bcHb8=
+github.com/matousjobanek/toolchain-common v0.0.0-20220214184443-ca6f8b574953/go.mod h1:iKuv2cEPXMu5CNyJ87lheKELRcQjx26eYCfGkZQ4IYY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
copies the email annotation from MUR to UserAccount.
In the next PR, the useraccount controller will copy the email annotation to the User resource.

depends on:
https://github.com/codeready-toolchain/api/pull/293
https://github.com/codeready-toolchain/toolchain-common/pull/240