### PR TITLE
reduce log level when no spacebinding exists

### DIFF
--- a/controllers/spacebindingcleanup/mapper.go
+++ b/controllers/spacebindingcleanup/mapper.go
@@ -26,7 +26,7 @@ func MapToSpaceBindingByBoundObjectName(cl client.Client, label string) func(obj
 			return []reconcile.Request{}
 		}
 		if len(spaceBindings.Items) == 0 {
-			logger.Error(err, "no SpaceBinding found for an object")
+			logger.Info("no SpaceBinding found for an object")
 			return []reconcile.Request{}
 		}
 


### PR DESCRIPTION
no need to dump a stacktrace in the logs when there is no spacebinding

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
