### PR TITLE
update watch handler to map host namespace in reconcile request 

### DIFF
--- a/controllers/space/mapper.go
+++ b/controllers/space/mapper.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
 var mapperLog = ctrl.Log.WithName("NSTemplateSetToSpaceMapper")
 
 func MapNSTemplateSetToSpace(hostNamespace string) func(object client.Object) []reconcile.Request {

--- a/controllers/space/mapper.go
+++ b/controllers/space/mapper.go
@@ -1,0 +1,15 @@
+package space
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func MapNSTemplateSetToSpace(hostNamespace string) func(object client.Object) []reconcile.Request {
+	return func(obj client.Object) []reconcile.Request {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Namespace: hostNamespace, Name: obj.GetName()},
+		}}
+	}
+}

--- a/controllers/space/mapper.go
+++ b/controllers/space/mapper.go
@@ -1,15 +1,27 @@
 package space
 
 import (
+	"errors"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+var mapperLog = ctrl.Log.WithName("NSTemplateSetToSpaceMapper")
 
 func MapNSTemplateSetToSpace(hostNamespace string) func(object client.Object) []reconcile.Request {
 	return func(obj client.Object) []reconcile.Request {
-		return []reconcile.Request{{
-			NamespacedName: types.NamespacedName{Namespace: hostNamespace, Name: obj.GetName()},
-		}}
+		if nsTemplateSet, ok := obj.(*toolchainv1alpha1.NSTemplateSet); ok {
+			return []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Namespace: hostNamespace, Name: nsTemplateSet.GetName()},
+			}}
+		}
+		// the obj was not a NSTemplateSet
+		mapperLog.Error(errors.New("not a NSTemplateSet"),
+			"MapNSTemplateSetToSpace attempted to map an object that wasn't a NSTemplateSet",
+			"obj", obj)
+		return []reconcile.Request{}
 	}
+
 }

--- a/controllers/space/mapper_test.go
+++ b/controllers/space/mapper_test.go
@@ -1,0 +1,31 @@
+package space
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+func TestNSTemplateSetToSpaceMapper(t *testing.T) {
+	t.Run("test MapNSTemplateSetToSpace maps correctly", func(t *testing.T) {
+		// given
+		NSTemplateSet := &toolchainv1alpha1.NSTemplateSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "member-operator",
+				Name:      "foo",
+			},
+		}
+		// when
+		req := MapNSTemplateSetToSpace("host-operator")(NSTemplateSet)
+
+		// then
+		require.Len(t, req, 1)
+		require.Equal(t, types.NamespacedName{
+			Namespace: "host-operator",
+			Name:      "foo",
+		}, req[0].NamespacedName)
+	})
+
+}

--- a/controllers/space/mapper_test.go
+++ b/controllers/space/mapper_test.go
@@ -2,6 +2,7 @@ package space
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,4 +29,24 @@ func TestNSTemplateSetToSpaceMapper(t *testing.T) {
 		}, req[0].NamespacedName)
 	})
 
+	t.Run("test non-NSTemplateSet doesn't map", func(t *testing.T) {
+		// given
+		mur := &toolchainv1alpha1.MasterUserRecord{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "echo",
+				Namespace:         test.HostOperatorNs,
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: toolchainv1alpha1.MasterUserRecordSpec{
+				UserID: "echo",
+			},
+			Status: toolchainv1alpha1.MasterUserRecordStatus{},
+		}
+
+		// when
+		req := MapNSTemplateSetToSpace("host-operator")(mur)
+
+		// then
+		require.Len(t, req, 0)
+	})
 }

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -46,12 +46,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, memberClusters map[strin
 	// watch NSTemplateSets in all the member clusters
 	for _, memberCluster := range memberClusters {
 		b = b.Watches(source.NewKindWithCache(&toolchainv1alpha1.NSTemplateSet{}, memberCluster.Cache),
-			&handler.EnqueueRequestForObject{},
+			handler.EnqueueRequestsFromMapFunc(MapNSTemplateSetToSpace(r.Namespace)),
 		)
 	}
 
 	return b.Complete(r)
 }
+
 
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaces/status,verbs=get;update;patch
@@ -59,7 +60,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, memberClusters map[strin
 
 // Reconcile ensures that there is an NSTemplateSet resource defined in the target member cluster
 func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx, "namespace", r.Namespace)
+	logger := log.FromContext(ctx)
 	logger.Info("reconciling Space")
 
 	// Fetch the Space

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -53,7 +53,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, memberClusters map[strin
 	return b.Complete(r)
 }
 
-
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaces,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaces/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaces/finalizers,verbs=update


### PR DESCRIPTION
currently while watching NSTemplateSet in all member clusters from Space Controller, the event handler used was 'EnqueueRequestForObject' which would set the Namespace as the member-operator's namespace in the reconcile request. This PR updates the watch handler to use a mapper to map the host-operator's namespace in the reconcile request for the watcher.

This was also causing a delay in cleanup - space would take longer than timeout at times to delete and fail. Made minor changes in e2e test to identify the failing object in logs here - https://github.com/codeready-toolchain/toolchain-e2e/pull/489 
