### PR TITLE
feat: add optional DBaaSTenant resource

### DIFF
--- a/deploy/templates/nstemplatetiers/base/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/base/cluster.yaml
@@ -164,6 +164,22 @@ objects:
     name: ${USERNAME}-stage
   spec:
     timeoutSeconds: ${{IDLER_TIMEOUT_SECONDS}}
+- apiVersion: dbaas.redhat.com/v1alpha1
+  kind: DBaaSTenant
+  metadata:
+    annotations:
+      toolchain.dev.openshift.com/optional-resource: "yes"
+    name: "tenant-${USERNAME}-stage"
+  spec:
+    inventoryNamespace: ${USERNAME}-stage
+- apiVersion: dbaas.redhat.com/v1alpha1
+  kind: DBaaSTenant
+  metadata:
+    annotations:
+      toolchain.dev.openshift.com/optional-resource: "yes"
+    name: "tenant-${USERNAME}-dev"
+  spec:
+    inventoryNamespace: ${USERNAME}-dev
 parameters:
 - name: USERNAME
   required: true


### PR DESCRIPTION
Adds two DBaaSTenant cluster-scoped resources for RHODA operator. Both of them contain the `toolchain.dev.openshift.com/optional-resource` annotation to mark them as optional. The content of the annotation doesn't matter as we check only the presence of the annotation.
There won't be any e2e tests because the resources won't be created in e2e environment - RHODA operator is not installed there so it's missing the needed API group.

Depends on: https://github.com/codeready-toolchain/member-operator/pull/345