### PR TITLE
Allow to access tekton-results

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
@@ -75,6 +75,14 @@ objects:
     verbs:
     - create
     - delete
+  - apiGroups:
+    - results.tekton.dev
+    resources:
+    - results
+    - records
+    verbs:
+    - get
+    - list
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:


### PR DESCRIPTION
Allow users to access results and records stored in tekton-results.

Tekton results: https://github.com/tektoncd/results
Deployed to stage cluster by https://github.com/redhat-appstudio/infra-deployments/pull/136

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/500