### PR TITLE
Drop counts for objects defined by CRDs from user quotas

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/cluster.yaml
@@ -125,33 +125,6 @@ objects:
       annotations:
         openshift.io/requester: ${USERNAME}
       labels: null
-- apiVersion: quota.openshift.io/v1
-  kind: ClusterResourceQuota
-  metadata:
-    name: for-${USERNAME}-rhoas
-  spec:
-    quota:
-      hard:
-        count/cloudservicesrequests.rhoas.redhat.com: "2"
-        count/kafkaconnections.rhoas.redhat.com: "5"
-        count/cloudserviceaccountrequest.rhoas.redhat.com: "2"
-    selector:
-      annotations:
-        openshift.io/requester: ${USERNAME}
-      labels: null
-- apiVersion: quota.openshift.io/v1
-  kind: ClusterResourceQuota
-  metadata:
-    name: for-${USERNAME}-sbo
-  spec:
-    quota:
-      hard:
-        count/servicebindings.binding.operators.coreos.com: "50"
-        count/servicebindings.servicebinding.io: "50"
-    selector:
-      annotations:
-        openshift.io/requester: ${USERNAME}
-      labels: null
 - apiVersion: toolchain.dev.openshift.com/v1alpha1
   kind: Idler
   metadata:

--- a/deploy/templates/nstemplatetiers/base/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/base/cluster.yaml
@@ -125,33 +125,6 @@ objects:
       annotations:
         openshift.io/requester: ${USERNAME}
       labels: null
-- apiVersion: quota.openshift.io/v1
-  kind: ClusterResourceQuota
-  metadata:
-    name: for-${USERNAME}-rhoas
-  spec:
-    quota:
-      hard:
-        count/cloudservicesrequests.rhoas.redhat.com: "2"
-        count/kafkaconnections.rhoas.redhat.com: "5"
-        count/cloudserviceaccountrequest.rhoas.redhat.com: "2"
-    selector:
-      annotations:
-        openshift.io/requester: ${USERNAME}
-      labels: null
-- apiVersion: quota.openshift.io/v1
-  kind: ClusterResourceQuota
-  metadata:
-    name: for-${USERNAME}-sbo
-  spec:
-    quota:
-      hard:
-        count/servicebindings.binding.operators.coreos.com: "50"
-        count/servicebindings.servicebinding.io: "50"
-    selector:
-      annotations:
-        openshift.io/requester: ${USERNAME}
-      labels: null
 - apiVersion: toolchain.dev.openshift.com/v1alpha1
   kind: Idler
   metadata:


### PR DESCRIPTION
It looks like the CR object counts are not supported in 4.10. It was undocumented in 4.9 (see table 7.3 in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/building_applications/quotas#quotas-resources-managed_quotas-setting-per-project) but worked. It doesn't work in 4.10 anymore.

See https://issues.redhat.com/browse/OHSS-10763 for more details.

E2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/506