### PR TITLE
Add WTO NetworkPolicy to -stage

### DIFF
--- a/deploy/templates/nstemplatetiers/base/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/base/ns_stage.yaml
@@ -169,6 +169,20 @@ objects:
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:
+    name: allow-from-codeready-workspaces-operator
+    namespace: ${USERNAME}-stage
+  spec:
+    ingress:
+      - from:
+          - namespaceSelector:
+              matchLabels:
+                network.openshift.io/policy-group: codeready-workspaces
+    podSelector: {}
+    policyTypes:
+      - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
     name: allow-from-olm-namespaces
     namespace: ${USERNAME}-stage
   spec:


### PR DESCRIPTION
Since WTO and CRW share the same NetworkPolicy group we have to allow traffic from that group to both -dev and -stage. Otherwise WTO can't connect to the terminal pod in -stage.

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/509