### PR TITLE
Removed banned & deprovision from MUR spec

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
@@ -60,14 +60,6 @@ spec:
           spec:
             description: MasterUserRecordSpec defines the desired state of MasterUserRecord
             properties:
-              banned:
-                description: If set to true then the corresponding user has been banned
-                  from logging in and accessing their resources
-                type: boolean
-              deprovisioned:
-                description: If set to true then the corresponding UserAccount should
-                  be deleted "false" is assumed by default
-                type: boolean
               disabled:
                 description: If set to true then the corresponding user should not
                   be able to login (but the underlying UserAccounts still exists)

--- a/config/crd/bases/toolchain.dev.openshift.com_socialevents.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_socialevents.yaml
@@ -29,7 +29,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: SocialEvent registers a toolchain event in the CodeReady Toolchain
+        description: SocialEvent registers a social event in Dev Sandbox
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -44,7 +44,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: SocialEventSpec defines the parameters for a Toolchain event,
+            description: SocialEventSpec defines the parameters for a Social event,
               such as a training session or workshop. Users may register for the event
               by using the event's unique activation code
             properties:

--- a/controllers/usersignup/masteruserrecord_test.go
+++ b/controllers/usersignup/masteruserrecord_test.go
@@ -123,11 +123,9 @@ func newExpectedMur(userSignup *toolchainv1alpha1.UserSignup) *toolchainv1alpha1
 			},
 		},
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
-			UserID:        userSignup.Spec.Userid,
-			Banned:        false,
-			Disabled:      false,
-			Deprovisioned: false,
-			TierName:      "advanced",
+			UserID:   userSignup.Spec.Userid,
+			Disabled: false,
+			TierName: "advanced",
 			UserAccounts: []toolchainv1alpha1.UserAccountEmbedded{
 				{
 					SyncIndex:     "",

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -1,5 +1,5 @@
+apiVersion: template.openshift.io/v1
 kind: Template
-apiVersion: v1
 metadata:
   name: registration-service
 objects:

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -1,5 +1,5 @@
-apiVersion: template.openshift.io/v1
 kind: Template
+apiVersion: v1
 metadata:
   name: registration-service
 objects:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20220406062208-83cd78aad988
+	github.com/codeready-toolchain/api v0.0.0-20220406171836-e70e160e9c18
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
@@ -26,7 +26,5 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime v0.10.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406140228-e28ea1ea47a9
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.10.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220405155257-58bc47bae462
+
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,6 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20220304110911-0727a0adecdc h1:oomZ1KgUkW0uwHB1mGUd3axvflOX6IKmmFK9e45lKt4=
-github.com/codeready-toolchain/api v0.0.0-20220304110911-0727a0adecdc/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220309133241-d5e8a5eb0e48 h1:kF9f8D6euL4bVbzGhVn88xuJtTwDf5/wVz4JRjEq4Rw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220309133241-d5e8a5eb0e48/go.mod h1:PV8GZKaXyWEbnmiYTQJo6F3PwL6Kslev5vNf+1ZTjtk=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -621,6 +619,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/api v0.0.0-20220405155257-58bc47bae462 h1:TZsNP02K4wZsmASt8M/GX7LElsfH7MNZ3ux3yf0vcgE=
+github.com/rajivnathan/api v0.0.0-20220405155257-58bc47bae462/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,9 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20220406062208-83cd78aad988/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/codeready-toolchain/api v0.0.0-20220406171836-e70e160e9c18 h1:tc03isLFfKuAv0eH2nXi/iJshFvQe6WCrBcQHxJtt/0=
+github.com/codeready-toolchain/api v0.0.0-20220406171836-e70e160e9c18/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9 h1:IIdePAUIagRm6BzYLNqMqr8gTxdPnvjy4h40kef/UQw=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9/go.mod h1:VbqCyyEQjgcRYsAwYbgPNxR2KY3VACCOJ8kR+nUeM50=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -619,8 +622,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/api v0.0.0-20220406140228-e28ea1ea47a9 h1:B9prfBZgE60VTVK6HNOn/xpDXmBEezn0F1alaeUCMeM=
-github.com/rajivnathan/api v0.0.0-20220406140228-e28ea1ea47a9/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-1326

Related PR: https://github.com/codeready-toolchain/api/pull/299

Removes the `Banned` and `Deprovisioned` fields from the MUR spec. They were not used.