### PR TITLE
Remove UserAccountSpecEmbedded from MUR

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
@@ -90,79 +90,6 @@ spec:
                   belong to this MasterUserRecord
                 items:
                   properties:
-                    spec:
-                      description: The spec of the corresponding UserAccount
-                      properties:
-                        nsLimit:
-                          description: The namespace limit name
-                          type: string
-                        nsTemplateSet:
-                          description: Namespace template set
-                          properties:
-                            clusterResources:
-                              description: the cluster resources template (for cluster-wide
-                                quotas, etc.)
-                              properties:
-                                templateRef:
-                                  description: TemplateRef The name of the TierTemplate
-                                    resource which exists in the host cluster and
-                                    which contains the template to use
-                                  type: string
-                              required:
-                              - templateRef
-                              type: object
-                            namespaces:
-                              description: The namespace templates
-                              items:
-                                description: NSTemplateSetNamespace the namespace
-                                  definition in an NSTemplateSet resource
-                                properties:
-                                  templateRef:
-                                    description: TemplateRef The name of the TierTemplate
-                                      resource which exists in the host cluster and
-                                      which contains the template to use
-                                    type: string
-                                required:
-                                - templateRef
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            spaceRoles:
-                              description: the role template and the users to whom
-                                the templates should be applied to
-                              items:
-                                description: NSTemplateSetSpaceRole the role template
-                                  and the users to whom the templates should be applied
-                                  to
-                                properties:
-                                  templateRef:
-                                    description: TemplateRef The name of the TierTemplate
-                                      resource which exists in the host cluster and
-                                      which contains the template to use
-                                    type: string
-                                  usernames:
-                                    description: Usernames the usernames to which
-                                      the template applies
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - templateRef
-                                - usernames
-                                type: object
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            tierName:
-                              description: The name of the tier represented by this
-                                template set
-                              type: string
-                          required:
-                          - namespaces
-                          - tierName
-                          type: object
-                      required:
-                      - nsLimit
-                      type: object
                     syncIndex:
                       description: SyncIndex is to be updated by UserAccount Controller
                         when the member needs to trigger MasterUserRecord <-> UserAccount
@@ -172,7 +99,6 @@ spec:
                       description: The cluster in which the user exists
                       type: string
                   required:
-                  - spec
                   - syncIndex
                   - targetCluster
                   type: object

--- a/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
@@ -82,16 +82,10 @@ spec:
                   belong to this MasterUserRecord
                 items:
                   properties:
-                    syncIndex:
-                      description: SyncIndex is to be updated by UserAccount Controller
-                        when the member needs to trigger MasterUserRecord <-> UserAccount
-                        synchronization
-                      type: string
                     targetCluster:
                       description: The cluster in which the user exists
                       type: string
                   required:
-                  - syncIndex
                   - targetCluster
                   type: object
                 type: array

--- a/controllers/changetierrequest/changetierrequest_controller_test.go
+++ b/controllers/changetierrequest/changetierrequest_controller_test.go
@@ -56,7 +56,6 @@ func TestChangeTierSuccess(t *testing.T) {
 		require.NoError(t, err)
 		murtest.AssertThatMasterUserRecord(t, "john", cl).
 			HasTier(*teamTier).
-			UserAccountHasNoTier(test.MemberClusterName).
 			DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 	})
@@ -74,8 +73,6 @@ func TestChangeTierSuccess(t *testing.T) {
 		require.NoError(t, err)
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
 			HasTier(*teamTier).
-			UserAccountHasNoTier(test.MemberClusterName).
-			UserAccountHasNoTier("another-cluster").
 			DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 	})
@@ -92,7 +89,6 @@ func TestChangeTierSuccess(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
-			UserAccountHasNoTier("another-cluster").
 			DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 	})
@@ -114,7 +110,6 @@ func TestChangeTierSuccess(t *testing.T) {
 		assert.True(t, result.RequeueAfter > cast.ToDuration("1s"))
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
 			HasTier(murtest.DefaultNSTemplateTier()).
-			UserAccountHasNoTier(test.MemberClusterName).
 			DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete())
 	})
@@ -135,7 +130,6 @@ func TestChangeTierSuccess(t *testing.T) {
 		assert.False(t, result.Requeue)
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
 			HasTier(murtest.DefaultNSTemplateTier()).
-			UserAccountHasNoTier(test.MemberClusterName).
 			DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 		AssertThatChangeTierRequestIsDeleted(t, cl, changeTierRequest.Name)
 	})
@@ -226,7 +220,6 @@ func TestChangeTierSuccess(t *testing.T) {
 			require.NoError(t, err)
 			murtest.AssertThatMasterUserRecord(t, "john", cl).
 				HasTier(*teamTier).
-				UserAccountHasNoTier(test.MemberClusterName).
 				DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 			spacetest.AssertThatSpace(t, test.HostOperatorNs, space.Name, cl).
 				HasTier(teamTier.Name).
@@ -353,7 +346,6 @@ func TestChangeTierFailure(t *testing.T) {
 		// then
 		require.EqualError(t, err, "failed to delete changeTierRequest: unable to delete ChangeTierRequest object 'request-name': error")
 		murtest.AssertThatMasterUserRecord(t, "johny", cl).
-			UserAccountHasNoTier(test.MemberClusterName).
 			DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(murtest.DefaultNSTemplateTierName))
 		AssertThatChangeTierRequestHasCondition(t, cl, changeTierRequest.Name, toBeComplete(), toBeDeletionError("unable to delete ChangeTierRequest object 'request-name': error"))
 	})

--- a/controllers/masteruserrecord/masteruserrecord_controller_test.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller_test.go
@@ -146,7 +146,7 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 	require.NoError(t, err)
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
-		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec).
+		MatchMasterUserRecord(mur).
 		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic")
 	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
 		HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")).
@@ -194,7 +194,7 @@ func TestCreateUserAccountWhenItWasPreviouslyDeleted(t *testing.T) {
 	require.NoError(t, err)
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
-		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec).
+		MatchMasterUserRecord(mur).
 		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic")
 	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
 		HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")).
@@ -239,11 +239,11 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 	assert.False(t, result.Requeue)
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
-		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec).
+		MatchMasterUserRecord(mur).
 		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic")
 	uatest.AssertThatUserAccount(t, "john", memberClient2).
 		Exists().
-		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[1].Spec).
+		MatchMasterUserRecord(mur).
 		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic")
 	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
 		HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")).
@@ -644,7 +644,7 @@ func TestModifyUserAccounts(t *testing.T) {
 	require.NoError(t, err)
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
-		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec).
+		MatchMasterUserRecord(mur).
 		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic")
 
 	// when ensuring 2nd account
@@ -653,7 +653,7 @@ func TestModifyUserAccounts(t *testing.T) {
 	require.NoError(t, err)
 	uatest.AssertThatUserAccount(t, "john", memberClient2).
 		Exists().
-		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[1].Spec).
+		MatchMasterUserRecord(mur).
 		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic")
 
 	// when ensuring 3rd account
@@ -662,7 +662,7 @@ func TestModifyUserAccounts(t *testing.T) {
 	require.NoError(t, err)
 	uatest.AssertThatUserAccount(t, "john", memberClient3).
 		Exists().
-		MatchMasterUserRecord(mur, mur.Spec.UserAccounts[2].Spec).
+		MatchMasterUserRecord(mur).
 		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic")
 	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
 		HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordUpdatingReason, ""))
@@ -741,17 +741,17 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 		uatest.AssertThatUserAccount(t, "john", memberClient).
 			Exists().
-			MatchMasterUserRecord(mur, mur.Spec.UserAccounts[0].Spec).
+			MatchMasterUserRecord(mur).
 			HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic").
 			HasConditions(userAccount.Status.Conditions...)
 		uatest.AssertThatUserAccount(t, "john", memberClient2).
 			Exists().
-			MatchMasterUserRecord(mur, mur.Spec.UserAccounts[1].Spec).
+			MatchMasterUserRecord(mur).
 			HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic").
 			HasConditions(userAccount2.Status.Conditions...)
 		uatest.AssertThatUserAccount(t, "john", memberClient3).
 			Exists().
-			MatchMasterUserRecord(mur, mur.Spec.UserAccounts[2].Spec).
+			MatchMasterUserRecord(mur).
 			HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "basic").
 			HasConditions(userAccount3.Status.Conditions...)
 

--- a/controllers/masteruserrecord/sync.go
+++ b/controllers/masteruserrecord/sync.go
@@ -36,11 +36,10 @@ type Synchronizer struct {
 func (s *Synchronizer) synchronizeSpec() error {
 
 	if !s.isSynchronized() {
-		s.logger.Info("synchronizing specs", "UserAccountSpecBase", s.recordSpecUserAcc.Spec.UserAccountSpecBase)
+		s.logger.Info("synchronizing specs")
 		if err := updateStatusConditions(s.logger, s.hostClient, s.record, toBeNotReady(toolchainv1alpha1.MasterUserRecordUpdatingReason, "")); err != nil {
 			return err
 		}
-		s.memberUserAcc.Spec.UserAccountSpecBase = s.recordSpecUserAcc.Spec.UserAccountSpecBase
 		s.memberUserAcc.Spec.Disabled = s.record.Spec.Disabled
 		s.memberUserAcc.Spec.UserID = s.record.Spec.UserID
 		s.memberUserAcc.Spec.OriginalSub = s.record.Spec.OriginalSub
@@ -67,8 +66,7 @@ func (s *Synchronizer) synchronizeSpec() error {
 }
 
 func (s *Synchronizer) isSynchronized() bool {
-	return reflect.DeepEqual(s.memberUserAcc.Spec.UserAccountSpecBase, s.recordSpecUserAcc.Spec.UserAccountSpecBase) &&
-		s.memberUserAcc.Spec.Disabled == s.record.Spec.Disabled &&
+	return s.memberUserAcc.Spec.Disabled == s.record.Spec.Disabled &&
 		s.memberUserAcc.Spec.UserID == s.record.Spec.UserID &&
 		s.memberUserAcc.Labels != nil && s.memberUserAcc.Labels[toolchainv1alpha1.TierLabelKey] == s.record.Spec.TierName &&
 		s.memberUserAcc.Annotations != nil && s.memberUserAcc.Annotations[toolchainv1alpha1.UserEmailAnnotationKey] == s.record.Annotations[toolchainv1alpha1.MasterUserRecordEmailAnnotationKey]

--- a/controllers/masteruserrecord/sync_test.go
+++ b/controllers/masteruserrecord/sync_test.go
@@ -69,10 +69,23 @@ func TestIsSynchronized(t *testing.T) {
 			assert.False(t, s.isSynchronized())
 		})
 
-		t.Run("different user account", func(t *testing.T) {
+		t.Run("missing email annotation", func(t *testing.T) {
 			// given
 			record, recordSpecUserAcc, memberUserAcc := setupSynchronizerItems()
-			recordSpecUserAcc.TargetCluster = "another-cluster"
+			delete(memberUserAcc.Annotations, toolchainv1alpha1.UserEmailAnnotationKey)
+			s := Synchronizer{
+				memberUserAcc:     &memberUserAcc,
+				record:            &record,
+				recordSpecUserAcc: recordSpecUserAcc,
+			}
+			// when/then
+			assert.False(t, s.isSynchronized())
+		})
+
+		t.Run("email annotation does not match", func(t *testing.T) {
+			// given
+			record, recordSpecUserAcc, memberUserAcc := setupSynchronizerItems()
+			memberUserAcc.Annotations[toolchainv1alpha1.UserEmailAnnotationKey] = "foo"
 			s := Synchronizer{
 				memberUserAcc:     &memberUserAcc,
 				record:            &record,

--- a/controllers/usersignup/masteruserrecord.go
+++ b/controllers/usersignup/masteruserrecord.go
@@ -17,19 +17,6 @@ func migrateOrFixMurIfNecessary(mur *toolchainv1alpha1.MasterUserRecord, default
 		changed = true
 	}
 
-	// TODO this can be removed once all existing MURs have been migrated
-	for uaIndex, userAccount := range mur.Spec.UserAccounts {
-		if userAccount.Spec.NSLimit != "" {
-			mur.Spec.UserAccounts[uaIndex].Spec.NSLimit = ""
-			changed = true
-		}
-		nsTemplateSet := userAccount.Spec.NSTemplateSet
-		if nsTemplateSet != nil {
-			mur.Spec.UserAccounts[uaIndex].Spec.NSTemplateSet = nil
-			changed = true
-		}
-	}
-
 	// ensure that the MUR does not have any tier hash labels since NSTemplateSet will be handled by Spaces
 	for key := range mur.Labels {
 		if strings.HasSuffix(key, "-tier-hash") {

--- a/controllers/usersignup/masteruserrecord_test.go
+++ b/controllers/usersignup/masteruserrecord_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/codeready-toolchain/host-operator/test"
 	tiertest "github.com/codeready-toolchain/host-operator/test/nstemplatetier"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,35 +45,6 @@ func TestMigrateMurIfNecessary(t *testing.T) {
 	})
 
 	t.Run("update needed", func(t *testing.T) {
-
-		t.Run("when useraccount NSLimit was set, it should be empty after migration", func(t *testing.T) {
-			userSignup := NewUserSignup()
-			nsTemplateTier := tiertest.NewNSTemplateTier("advanced", "dev", "stage", "extra")
-			mur := newMasterUserRecord(userSignup, test.MemberClusterName, nsTemplateTier, "johny")
-			mur.Spec.UserAccounts[0].Spec.NSLimit = "default" // NSLimit is set
-
-			// when
-			changed := migrateOrFixMurIfNecessary(mur, nsTemplateTier, userSignup)
-
-			// then
-			assert.True(t, changed)
-			assert.Equal(t, newExpectedMur(userSignup), mur)
-		})
-
-		t.Run("when useraccount NSTemplateSet was set, it should be nil after migration", func(t *testing.T) {
-			userSignup := NewUserSignup()
-			nsTemplateTier := tiertest.NewNSTemplateTier("advanced", "dev", "stage", "extra")
-			testNStemplateSet := murtest.DefaultNSTemplateSet()
-			mur := newMasterUserRecord(userSignup, test.MemberClusterName, nsTemplateTier, "johny")
-			mur.Spec.UserAccounts[0].Spec.NSTemplateSet = &testNStemplateSet.Spec // NSTemplateSet is set
-
-			// when
-			changed := migrateOrFixMurIfNecessary(mur, nsTemplateTier, userSignup)
-
-			// then
-			assert.True(t, changed)
-			assert.Equal(t, newExpectedMur(userSignup), mur)
-		})
 
 		t.Run("when MUR has tier hash label, it should be removed after migration", func(t *testing.T) {
 			userSignup := NewUserSignup()

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -1750,132 +1750,6 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 	})
 }
 
-func TestMigrateExistingMURToSpace(t *testing.T) {
-	customTier := tiertest.NewNSTemplateTier("custom", "dev", "stage")
-
-	for testname, testTier := range map[string]*toolchainv1alpha1.NSTemplateTier{
-		"default tier":     baseNSTemplateTier,
-		"non-default tier": customTier,
-	} {
-		t.Run(testname, func(t *testing.T) {
-			member := NewMemberCluster(t, "member1", v1.ConditionTrue)
-			logf.SetLogger(zap.New(zap.UseDevMode(true)))
-			t.Run("MUR exists and still references NSTemplateSet", func(t *testing.T) {
-				userSignup := NewUserSignup()
-				userSignup.Annotations = map[string]string{
-					toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "foo@redhat.com",
-				}
-				userSignup.Labels = map[string]string{
-					toolchainv1alpha1.UserSignupUserEmailHashLabelKey: "fd2addbd8d82f0d2dc088fa122377eaa",
-					"toolchain.dev.openshift.com/approved":            "true",
-				}
-				userSignup.Spec.OriginalSub = "original-sub:foo"
-
-				mur := newMasterUserRecord(userSignup, "member1", testTier, "foo")
-				mur.Labels = map[string]string{toolchainv1alpha1.MasterUserRecordOwnerLabelKey: userSignup.Name}
-				templates := nstemplateSetFromTier(*testTier)
-				ua := toolchainv1alpha1.UserAccountEmbedded{
-					TargetCluster: "member1",
-					SyncIndex:     "123abc", // default value
-					Spec: toolchainv1alpha1.UserAccountSpecEmbedded{
-						UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{
-							NSLimit:       testTier.Name,
-							NSTemplateSet: &templates,
-						},
-					},
-				}
-				// set the user account
-				mur.Spec.UserAccounts = []toolchainv1alpha1.UserAccountEmbedded{ua}
-
-				// given
-				r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(member), userSignup, baseNSTemplateTier, customTier, mur)
-
-				InitializeCounters(t, NewToolchainStatus(
-					WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
-						string(metrics.External): 1,
-					}),
-					WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
-						"1,external": 1,
-					}),
-				))
-
-				// when
-				res, err := r.Reconcile(context.TODO(), req)
-
-				// then
-				require.NoError(t, err)
-				require.Equal(t, reconcile.Result{}, res)
-
-				actualUserSignup := &toolchainv1alpha1.UserSignup{}
-				err = r.Client.Get(context.TODO(), types.NamespacedName{Name: userSignup.Name, Namespace: req.Namespace}, actualUserSignup)
-				require.NoError(t, err)
-
-				AssertThatUserSignup(t, req.Namespace, actualUserSignup.Name, r.Client).HasLabel(toolchainv1alpha1.UserSignupStateLabelKey, "approved")
-				mur = murtest.AssertThatMasterUserRecord(t, mur.Name, r.Client).Exists().Get()
-				assert.Nil(t, mur.Spec.UserAccounts[0].Spec.NSTemplateSet)
-
-				// space should be created after second reconcile
-				spacetest.AssertThatSpace(t, test.HostOperatorNs, "foo", r.Client).DoesNotExist()
-				spacebindingtest.AssertThatSpaceBinding(t, test.HostOperatorNs, "foo", "foo", r.Client).DoesNotExist()
-
-				AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
-				AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-
-				AssertThatCountersAndMetrics(t).
-					HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
-						string(metrics.External): 1,
-					}).
-					HaveUsersPerActivationsAndDomain(toolchainv1alpha1.Metric{
-						"1,external": 1,
-						"1,internal": 1,
-					})
-
-				t.Run("space should be created after second reconcile", func(t *testing.T) {
-					// when
-					res, err = r.Reconcile(context.TODO(), req)
-
-					// then
-					require.NoError(t, err)
-					require.Equal(t, reconcile.Result{}, res)
-
-					spacetest.AssertThatSpace(t, test.HostOperatorNs, "foo", r.Client).
-						Exists().
-						HasSpecTargetCluster("member1").
-						HasTier(testTier.Name)
-
-					t.Run("spacebinding should be created after third reconcile", func(t *testing.T) {
-						// when
-						res, err = r.Reconcile(context.TODO(), req)
-
-						// then
-						require.NoError(t, err)
-						require.Equal(t, reconcile.Result{}, res)
-
-						spacebindingtest.AssertThatSpaceBinding(t, test.HostOperatorNs, "foo", "foo", r.Client).
-							Exists().
-							HasLabelWithValue(toolchainv1alpha1.SpaceCreatorLabelKey, userSignup.Name).
-							HasLabelWithValue(toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey, "foo").
-							HasLabelWithValue(toolchainv1alpha1.SpaceBindingSpaceLabelKey, "foo").
-							HasSpec("foo", "foo", "admin")
-					})
-				})
-			})
-		})
-	}
-}
-
-func nstemplateSetFromTier(tier toolchainv1alpha1.NSTemplateTier) toolchainv1alpha1.NSTemplateSetSpec {
-	s := toolchainv1alpha1.NSTemplateSetSpec{}
-	s.TierName = tier.Name
-	s.Namespaces = make([]toolchainv1alpha1.NSTemplateSetNamespace, len(tier.Spec.Namespaces))
-	for i, ns := range tier.Spec.Namespaces {
-		s.Namespaces[i].TemplateRef = ns.TemplateRef
-	}
-	s.ClusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{}
-	s.ClusterResources.TemplateRef = tier.Spec.ClusterResources.TemplateRef
-	return s
-}
-
 func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 	// given
 	userSignup := NewUserSignup(Approved())
@@ -3842,22 +3716,6 @@ func TestMigrateMur(t *testing.T) {
 		tierutil.TemplateTierHashLabelKey(baseNSTemplateTier.Name): "123abc",
 	}
 
-	// old MUR has NSLimit and NSTemplateSet set
-	oldMur.Spec.UserAccounts[0].Spec.NSTemplateSet = &toolchainv1alpha1.NSTemplateSetSpec{}
-	oldMur.Spec.UserAccounts[0].Spec.NSTemplateSet.TierName = "base"
-	oldMur.Spec.UserAccounts[0].Spec.NSLimit = "default"
-	oldMur.Spec.UserAccounts[0].Spec.NSTemplateSet.Namespaces = []toolchainv1alpha1.NSTemplateSetNamespace{
-		{
-			TemplateRef: "base-dev-123abc1",
-		},
-		{
-			TemplateRef: "base-stage-123abc2",
-		},
-	}
-	oldMur.Spec.UserAccounts[0].Spec.NSTemplateSet.ClusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
-		TemplateRef: "base-clusterresources-654321b",
-	}
-
 	t.Run("mur should be migrated", func(t *testing.T) {
 		// given
 		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, baseNSTemplateTier, oldMur)
@@ -3868,16 +3726,12 @@ func TestMigrateMur(t *testing.T) {
 		// then verify that the MUR exists and is complete
 		require.NoError(t, err)
 		murtest.AssertThatMasterUserRecords(t, r.Client).HaveCount(1)
-		actualMur := murtest.AssertThatMasterUserRecord(t, expectedMur.Name, r.Client).
+		murtest.AssertThatMasterUserRecord(t, expectedMur.Name, r.Client).
 			Exists().
-			HasTier(*baseNSTemplateTier).                                                        // tier name should be set
-			DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(baseNSTemplateTier.Name)).        // should not have tier hash label anymore
-			HasLabelWithValue(toolchainv1alpha1.MasterUserRecordOwnerLabelKey, userSignup.Name). // other labels unchanged
-			Get()
+			HasTier(*baseNSTemplateTier).                                                       // tier name should be set
+			DoesNotHaveLabel(tierutil.TemplateTierHashLabelKey(baseNSTemplateTier.Name)).       // should not have tier hash label anymore
+			HasLabelWithValue(toolchainv1alpha1.MasterUserRecordOwnerLabelKey, userSignup.Name) // other labels unchanged
 
-		// additional checks that we don't have MUR assertions for
-		require.Empty(t, actualMur.Spec.UserAccounts[0].Spec.NSLimit)     // NSLimit should be empty (deprecated)
-		require.Nil(t, actualMur.Spec.UserAccounts[0].Spec.NSTemplateSet) // NSTemplateSet should be nil (deprecated), they should be managed by Spaces now
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,6 @@ require (
 
 replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220406211815-95ecbd2fba27
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220407133219-d630fd267dde
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.10.3
 )
 
-replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406210610-c20edf1cbc68
+replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220406211815-95ecbd2fba27
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20220407065959-2029a1f03cfc
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20220407070729-d48e73f179f0
+	github.com/codeready-toolchain/api v0.0.0-20220407172226-5247322e920d
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20220407172553-826188a0ce5d
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v0.4.0
@@ -26,9 +26,5 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime v0.10.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220407133219-d630fd267dde
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,6 @@ require (
 
 replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220406145703-b056bd96c1d2
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.10.3
 )
 
-replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5
+replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406210610-c20edf1cbc68
 
 replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6
 

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.10.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/rajivnathan/toolchain-common v0.0.0-20220406145703-b056bd96c1d2
+
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -619,8 +619,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5 h1:HeKJ5vGmYPbH8arND4rhc2sStFoNic2smo5WepE9SrI=
 github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
-github.com/rajivnathan/toolchain-common v0.0.0-20220406145703-b056bd96c1d2 h1:6MaQZ/oyWAuNlJD7rO4hcvb/mPzORKJFSRXiCkukWdQ=
-github.com/rajivnathan/toolchain-common v0.0.0-20220406145703-b056bd96c1d2/go.mod h1:VbqCyyEQjgcRYsAwYbgPNxR2KY3VACCOJ8kR+nUeM50=
+github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6 h1:tWxgCaKAEK2hu3xzsULBxaW3qjHQbFjgrcKcuTytEdY=
+github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6/go.mod h1:7yK8z1ruegGLeyBla8p6xNRTYYLhiQ5XJJMTJ2O5Jlc=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/go.sum
+++ b/go.sum
@@ -619,8 +619,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08 h1:ruKJ/kThXVUkSuTA2k9zpBVrtUbPpni68+G6J+qMFdI=
 github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
-github.com/rajivnathan/toolchain-common v0.0.0-20220406211815-95ecbd2fba27 h1:tgGUMSEet1OejqhasBibuIM1i0hz2yTSRuNNVyAqHlY=
-github.com/rajivnathan/toolchain-common v0.0.0-20220406211815-95ecbd2fba27/go.mod h1:xkT73+WNCypIWPDOjSXxTsyQr25/fhPYSmczTIUxrHY=
+github.com/rajivnathan/toolchain-common v0.0.0-20220407133219-d630fd267dde h1:mD0ddD7Bs3hoV8h7sD4mg0CRjbs0am0P8iBfZgC+Rgk=
+github.com/rajivnathan/toolchain-common v0.0.0-20220407133219-d630fd267dde/go.mod h1:7nDboqbpXfsZFe6OFkaVLi+4FzZIPPu5RasVnM2seOI=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/go.sum
+++ b/go.sum
@@ -617,10 +617,10 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/api v0.0.0-20220406210610-c20edf1cbc68 h1:3zq2LGy793YyaZaUyvqxC6GrLyuepQqhZFESYBXSpqg=
-github.com/rajivnathan/api v0.0.0-20220406210610-c20edf1cbc68/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
-github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6 h1:tWxgCaKAEK2hu3xzsULBxaW3qjHQbFjgrcKcuTytEdY=
-github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6/go.mod h1:7yK8z1ruegGLeyBla8p6xNRTYYLhiQ5XJJMTJ2O5Jlc=
+github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08 h1:ruKJ/kThXVUkSuTA2k9zpBVrtUbPpni68+G6J+qMFdI=
+github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/rajivnathan/toolchain-common v0.0.0-20220406211815-95ecbd2fba27 h1:tgGUMSEet1OejqhasBibuIM1i0hz2yTSRuNNVyAqHlY=
+github.com/rajivnathan/toolchain-common v0.0.0-20220406211815-95ecbd2fba27/go.mod h1:xkT73+WNCypIWPDOjSXxTsyQr25/fhPYSmczTIUxrHY=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/go.sum
+++ b/go.sum
@@ -617,8 +617,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5 h1:HeKJ5vGmYPbH8arND4rhc2sStFoNic2smo5WepE9SrI=
-github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/rajivnathan/api v0.0.0-20220406210610-c20edf1cbc68 h1:3zq2LGy793YyaZaUyvqxC6GrLyuepQqhZFESYBXSpqg=
+github.com/rajivnathan/api v0.0.0-20220406210610-c20edf1cbc68/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
 github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6 h1:tWxgCaKAEK2hu3xzsULBxaW3qjHQbFjgrcKcuTytEdY=
 github.com/rajivnathan/toolchain-common v0.0.0-20220406175527-38ec9eadcaa6/go.mod h1:7yK8z1ruegGLeyBla8p6xNRTYYLhiQ5XJJMTJ2O5Jlc=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=

--- a/go.sum
+++ b/go.sum
@@ -129,10 +129,6 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20220406062208-83cd78aad988 h1:IajrKKCyxUGqhAou4eOTl7devas/DlKtCfe0+DE/8Kk=
-github.com/codeready-toolchain/api v0.0.0-20220406062208-83cd78aad988/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9 h1:IIdePAUIagRm6BzYLNqMqr8gTxdPnvjy4h40kef/UQw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20220406062847-51b0d44256d9/go.mod h1:VbqCyyEQjgcRYsAwYbgPNxR2KY3VACCOJ8kR+nUeM50=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -621,6 +617,10 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5 h1:HeKJ5vGmYPbH8arND4rhc2sStFoNic2smo5WepE9SrI=
+github.com/rajivnathan/api v0.0.0-20220406144704-b46a368d7ba5/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/rajivnathan/toolchain-common v0.0.0-20220406145703-b056bd96c1d2 h1:6MaQZ/oyWAuNlJD7rO4hcvb/mPzORKJFSRXiCkukWdQ=
+github.com/rajivnathan/toolchain-common v0.0.0-20220406145703-b056bd96c1d2/go.mod h1:VbqCyyEQjgcRYsAwYbgPNxR2KY3VACCOJ8kR+nUeM50=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,10 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20220407172226-5247322e920d h1:rcg3Gy1IYqbgkSiZOqEijPbi35Tz7DgUM8w44iOZV4Q=
+github.com/codeready-toolchain/api v0.0.0-20220407172226-5247322e920d/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220407172553-826188a0ce5d h1:eunnVVIe9XQIxOAAtBTGGXotC4tnUAYV+UyJ4DRjat4=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20220407172553-826188a0ce5d/go.mod h1:cUo/39yF9vBIUlgnVdSFe6l9QTigPnXDvbToKgWRxAc=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -617,10 +621,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08 h1:ruKJ/kThXVUkSuTA2k9zpBVrtUbPpni68+G6J+qMFdI=
-github.com/rajivnathan/api v0.0.0-20220406211358-921752d48b08/go.mod h1:yxINrgni3bMTyGKMjMaLmWwgwZt/P+WT09c/pIMP02w=
-github.com/rajivnathan/toolchain-common v0.0.0-20220407133219-d630fd267dde h1:mD0ddD7Bs3hoV8h7sD4mg0CRjbs0am0P8iBfZgC+Rgk=
-github.com/rajivnathan/toolchain-common v0.0.0-20220407133219-d630fd267dde/go.mod h1:7nDboqbpXfsZFe6OFkaVLi+4FzZIPPu5RasVnM2seOI=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf h1:fsZiv9XuFo8G7IyzFWjG02vqzJG7kSqFvD1Wiq3V/o8=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=


### PR DESCRIPTION
Related PRs:
- https://github.com/codeready-toolchain/api/pull/300
- https://github.com/codeready-toolchain/toolchain-common/pull/249
- https://github.com/codeready-toolchain/toolchain-e2e/pull/533

Summary of changes:
- generated files from api change
- code changes related to removal of `UserAccountSpecEmbedded` from MUR
- removal of migration and test functions related to MUR migration to Spaces (since some of it was dealing with the `UserAccountSpecEmbedded`)
