### PR TITLE
Update the appstudio user actions role with the new requirements

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
@@ -63,6 +63,12 @@ objects:
     - list
     - watch
   - apiGroups:
+    - appstudio.redhat.com
+    resources:
+    - spiaccesstokendataupdates
+    verbs:
+    - create
+  - apiGroups:
     - tekton.dev
     resources:
     - pipelineruns
@@ -70,11 +76,6 @@ objects:
     - "*"
   - apiGroups:
     - ""
-    resources:
-    - secrets
-    verbs:
-    - create
-    - delete
   - apiGroups:
     - results.tekton.dev
     resources:

--- a/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
@@ -76,6 +76,11 @@ objects:
     - "*"
   - apiGroups:
     - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+    - delete
   - apiGroups:
     - results.tekton.dev
     resources:


### PR DESCRIPTION
This updates the appstudio users role to conform to the latest requirements of the SPI.
Namely, we no longer require the user to create or delete secrets, but we do require them to create `SPIAccessTokenDataUpdate` objects so that they can update the token data.

E2e test PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/540