### PR TITLE
allow appstudio users to work with registeredclusters

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
@@ -89,6 +89,16 @@ objects:
     verbs:
     - get
     - list
+  - apiGroups:
+    - singapore.open-cluster-management.io
+    resources:
+    - registeredclusters
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:


### PR DESCRIPTION
Add roles for AppStudio users to create, delete, get, list, watch RegisteredClusters

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/544

Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>