### PR TITLE
chore: update codecov/codecov-action to v3

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,7 +31,7 @@ jobs:
         make test-with-coverage
 
     - name: Upload code coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         files: ./build/_output/coverage/coverage.txt
         flags: unittests # optional


### PR DESCRIPTION
v1 has been deprecated since Feb 2022

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
