### PR TITLE
Create user tier for 365 day deactivation timeout

### DIFF
--- a/deploy/templates/usertiers/deactivate365/tier.yaml
+++ b/deploy/templates/usertiers/deactivate365/tier.yaml
@@ -1,0 +1,16 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: deactivate365-usertier
+objects:
+- kind: UserTier
+  apiVersion: toolchain.dev.openshift.com/v1alpha1
+  metadata:
+    name: deactivate365
+    namespace: ${NAMESPACE}
+  spec:
+    deactivationTimeoutDays: ${{DEACTIVATION_TIMEOUT_DAYS}}
+parameters:
+- name: NAMESPACE
+- name: DEACTIVATION_TIMEOUT_DAYS
+  value: "365"

--- a/pkg/templates/usertiers/usertier_generator_whitebox_test.go
+++ b/pkg/templates/usertiers/usertier_generator_whitebox_test.go
@@ -27,6 +27,7 @@ var expectedProdTiers = []string{
 	"deactivate80",
 	"deactivate90",
 	"deactivate180",
+	"deactivate365",
 }
 
 var expectedTestTiers = []string{
@@ -187,6 +188,8 @@ func TestNewUserTier(t *testing.T) {
 					assert.Equal(t, 90, tier.Spec.DeactivationTimeoutDays)
 				case "deactivate180":
 					assert.Equal(t, 180, tier.Spec.DeactivationTimeoutDays)
+				case "deactivate365":
+					assert.Equal(t, 365, tier.Spec.DeactivationTimeoutDays)
 				default:
 					require.Fail(t, "found unexpected tier", "tier '%s' found but not handled", tier.Name)
 				}


### PR DESCRIPTION
e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/552