### PR TITLE
Allow appstudio users create configmaps

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -71,6 +71,16 @@ objects:
     - create
     - delete
   - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - watch
+  - apiGroups:
     - results.tekton.dev
     resources:
     - results


### PR DESCRIPTION
Configmaps can be used for switching used tekton bundles.

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/564