### PR TITLE
Fix encoding of usernames with invalid end chars

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -447,6 +447,7 @@ func EncodeUserIdentifier(subject string) string {
 	DNS1123NameMaximumLength := 63
 	DNS1123NotAllowedCharacters := "[^-a-z0-9]"
 	DNS1123NotAllowedStartCharacters := "^[^a-z0-9]+"
+	DNS1123NotAllowedEndCharacters := "[^a-z0-9]+$"
 
 	// Convert to lower case
 	encoded := strings.ToLower(subject)
@@ -458,6 +459,10 @@ func EncodeUserIdentifier(subject string) string {
 	// Remove invalid start characters
 	nameNotAllowedStartChars := regexp.MustCompile(DNS1123NotAllowedStartCharacters)
 	encoded = nameNotAllowedStartChars.ReplaceAllString(encoded, "")
+
+	// Remove invalid end characters
+	nameNotAllowedEndChars := regexp.MustCompile(DNS1123NotAllowedEndCharacters)
+	encoded = nameNotAllowedEndChars.ReplaceAllString(encoded, "")
 
 	// Add a checksum prefix if the encoded value is different to the original subject value
 	if encoded != subject {

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -4172,4 +4172,13 @@ func TestUserSignupMigration(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, "Failed to update migrated UserSignup: update failed", err.Error())
 	})
+
+	t.Run("Test EncodeUserIdentifier returns expected values", func(t *testing.T) {
+		require.Equal(t, "alphabeta", EncodeUserIdentifier("alphabeta"))
+		require.Equal(t, "6ceab4a6-gammadelta", EncodeUserIdentifier("-gammadelta"))
+		require.Equal(t, "c5a75872-epsilonzeta", EncodeUserIdentifier("epsilonzeta-"))
+		require.Equal(t, "eta-theta", EncodeUserIdentifier("eta-theta"))
+		require.Equal(t, "ffaf2cbd-iota-kappa", EncodeUserIdentifier("-iota-kappa---"))
+		require.Equal(t, "29cceea2-iota-kappa", EncodeUserIdentifier("-iota-kappa-"))
+	})
 }


### PR DESCRIPTION
This PR modifies the `EncodeUserIdentifier` function used by the migration process to check if the username ends with any invalid characters, and removes them if so.

Fixes https://issues.redhat.com/browse/CRT-1514

