### PR TITLE
move the namespace name to subject of idler notification

### DIFF
--- a/deploy/templates/notificationtemplates/idlertriggered/notification.html
+++ b/deploy/templates/notificationtemplates/idlertriggered/notification.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>
-        Notice: Your applications in {{.Namespace}} are being idled
+        Notice: Your running application in namespace has been idled
     </title>
     <style>
         a:hover {

--- a/deploy/templates/notificationtemplates/idlertriggered/subject.txt
+++ b/deploy/templates/notificationtemplates/idlertriggered/subject.txt
@@ -1,1 +1,1 @@
-Notice: Your application is being idled
+Notice: Your running application in namespace {{.Namespace}} has been idled

--- a/pkg/templates/notificationtemplates/notification_generator_test.go
+++ b/pkg/templates/notificationtemplates/notification_generator_test.go
@@ -72,7 +72,7 @@ func TestGetNotificationTemplate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, template)
 			assert.True(t, found)
-			assert.Equal(t, "Notice: Your application is being idled", template.Subject)
+			assert.Equal(t, "Notice: Your running application in namespace {{.Namespace}} has been idled", template.Subject)
 			assert.Contains(t, template.Content, "In accordance with the usage terms of Developer Sandbox, we have reduced the number of instances of your\n        application to zero (0).")
 
 		})


### PR DESCRIPTION
adding namespace name to title of the body does not show up in the email, moving the namespace name to subject.