### PR TITLE
Allow appstudio users to  create hacbs APIs

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -50,6 +50,22 @@ objects:
   - apiGroups:
     - appstudio.redhat.com
     resources:
+    - enterprisecontractpolicies
+    - integrationtestscenarios
+    - releases
+    - releasestrategies
+    - releaselinks
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
     - spiaccesstokenbindings
     - spiaccesschecks
     verbs:


### PR DESCRIPTION
This PR is paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/580