### PR TITLE
fix: increment deactivated only when user is deactivated

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -696,7 +696,9 @@ func (r *Reconciler) updateUserSignupMetricsByState(logger logr.Logger, userSign
 			logger.Info("segment client not configure to track account activations")
 		}
 	case toolchainv1alpha1.UserSignupStateLabelValueDeactivated:
-		metrics.UserSignupDeactivatedTotal.Inc()
+		if oldState == toolchainv1alpha1.UserSignupStateLabelValueApproved {
+			metrics.UserSignupDeactivatedTotal.Inc()
+		}
 	case toolchainv1alpha1.UserSignupStateLabelValueBanned:
 		metrics.UserSignupBannedTotal.Inc()
 	}

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -3863,6 +3863,23 @@ func TestUpdateMetricsByState(t *testing.T) {
 			segmenttest.AssertNoMessageQueued(t, r.SegmentClient)
 		})
 
+		t.Run("pending -> deactivated - do NOT increment UserSignupDeactivatedTotal", func(t *testing.T) {
+			// given
+			metrics.Reset()
+			r := &Reconciler{
+				SegmentClient: segment.NewClient(segmenttest.NewClient()),
+			}
+			// when
+			r.updateUserSignupMetricsByState(logger, userSignup, "pending", "deactivated")
+			// then
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupApprovedTotal)
+			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+			segmenttest.AssertNoMessageQueued(t, r.SegmentClient)
+		})
+
 		t.Run("deactivated -> banned - increment UserSignupBannedTotal", func(t *testing.T) {
 			// given
 			metrics.Reset()


### PR DESCRIPTION
increment deactivated counter only when a user is really deactivated (originally was approved). Not when a user is in `verificationRequired` state for an extended period of time.