### PR TITLE
proxy: grant permissions to create TokenRequest API

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
@@ -32,6 +32,12 @@ objects:
     verbs:
     - get
     - list
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts/token
+    verbs:
+    - create
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:


### PR DESCRIPTION
needed by AppStudio Proxy to obtain a token for a ServiceAccount

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/592

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
