### PR TITLE
reduce log level on kube-rbac-proxy sidecar container

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=3"
         ports:
         - containerPort: 8443
           name: https


### PR DESCRIPTION
no need to be so verbose, which will also make fluentd less verbose
(less non-json messages to drop)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
