### PR TITLE
Allow access to some JVM Build Service Objects

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -125,6 +125,20 @@ objects:
     - list
     - watch
     - delete
+  - apiGroups:
+    - jvmbuildservice.io
+    resources:
+    - jbsconfigs
+    - artifactbuilds
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+    - patch
+    - delete
+    - deletecollection
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:


### PR DESCRIPTION
This allows users of the staging cluster to configure their workspace, and interact with rebuilt artifacts.

fixes PLNSRVCE-893

Users of the appstudio staging cluster that want to use the JVM Build Service (https://github.com/redhat-appstudio/jvm-build-service) need permission to modify these objects to be able to do anything meaningful. 

I am not 100% sure how all this works, so let me know if this is not the right place for this.
