### PR TITLE
Remove appstudio user SA

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -27,6 +27,7 @@ objects:
           - get
           - update
           - list
+          - watch
       - apiGroups:
           - toolchain.dev.openshift.com
         resources:

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -4,13 +4,6 @@ metadata:
   name: appstudio-spacerole-admin # name is used in e2e tests
 objects:
 
-# ServiceAccounts that represents the AppStudio user - the token of this SA is used by the proxy for forwarding the requests from UI (or any other client)
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    namespace: ${NAMESPACE}
-    name: appstudio-${USERNAME}
-
 # Role(s) and RoleBinding(s) that grant limited CRUD permissions on AppStudio components CRDs & secrets to the user's SA
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
@@ -139,34 +132,7 @@ objects:
     - patch
     - delete
     - deletecollection
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    namespace: ${NAMESPACE}
-    name: appstudio-${USERNAME}-user-actions
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: appstudio-user-actions
-  subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: appstudio-${USERNAME}
 
-# RoleBinding that grants view permissions to the user's SA
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    namespace: ${NAMESPACE}
-    name: appstudio-${USERNAME}-view
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: view
-  subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: appstudio-${USERNAME}
 # RoleBinding that grants limited CRUD permissions to the User
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_viewer.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_viewer.yaml
@@ -3,28 +3,6 @@ kind: Template
 metadata:
   name: appstudio-spacerole-viewer # name is used in e2e tests
 objects:
-
-# ServiceAccounts that represents the AppStudio user - the token of this SA is used by the proxy for forwarding the requests from UI (or any other client)
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    namespace: ${NAMESPACE}
-    name: appstudio-${USERNAME}
-
-# Role & RoleBinding that grants view permissions to the user's SA
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    namespace: ${NAMESPACE}
-    name: appstudio-${USERNAME}-view
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: view
-  subjects:
-  - apiGroup: ""
-    kind: ServiceAccount
-    name: appstudio-${USERNAME}
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:


### PR DESCRIPTION
The proxy now uses impersonation so the user SA and its RoleBindings are no longer needed. See https://github.com/codeready-toolchain/registration-service/pull/289

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/642