### PR TITLE
fix: provision Spaces in batches by 50

### DIFF
--- a/controllers/spacecompletion/space_completion_controller.go
+++ b/controllers/spacecompletion/space_completion_controller.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/pkg/capacity"
 	"github.com/codeready-toolchain/host-operator/pkg/pending"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/go-logr/logr"
 	"github.com/redhat-cop/operator-utils/pkg/util"
 
@@ -26,9 +25,9 @@ import (
 
 // Reconciler reconciles a Space object
 type Reconciler struct {
-	Client            client.Client
-	Namespace         string
-	GetMemberClusters cluster.GetMemberClustersFunc
+	Client         client.Client
+	Namespace      string
+	ClusterManager *capacity.ClusterManager
 }
 
 // SetupWithManager sets up the controller reconciler with the Manager
@@ -94,7 +93,7 @@ func (r *Reconciler) ensureFields(logger logr.Logger, space *toolchainv1alpha1.S
 	}
 
 	if space.Spec.TargetCluster == "" {
-		targetCluster, err := capacity.GetOptimalTargetCluster("", space.Namespace, r.GetMemberClusters, r.Client)
+		targetCluster, err := r.ClusterManager.GetOptimalTargetCluster("", space.Namespace)
 		if err != nil {
 			return false, errs.Wrapf(err, "unable to get the optimal target cluster")
 		}

--- a/controllers/spacecompletion/space_completion_controller_test.go
+++ b/controllers/spacecompletion/space_completion_controller_test.go
@@ -9,6 +9,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/controllers/spacecompletion"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
+	"github.com/codeready-toolchain/host-operator/pkg/capacity"
 	"github.com/codeready-toolchain/host-operator/pkg/counter"
 	. "github.com/codeready-toolchain/host-operator/test"
 	spacetest "github.com/codeready-toolchain/host-operator/test/space"
@@ -227,9 +228,9 @@ func prepareReconcile(t *testing.T, space *toolchainv1alpha1.Space, getMemberClu
 	fakeClient := test.NewFakeClient(t, toolchainStatus, space, conf)
 
 	r := &spacecompletion.Reconciler{
-		Client:            fakeClient,
-		Namespace:         test.HostOperatorNs,
-		GetMemberClusters: getMemberClusters,
+		Client:         fakeClient,
+		Namespace:      test.HostOperatorNs,
+		ClusterManager: capacity.NewClusterManager(getMemberClusters, fakeClient),
 	}
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/controllers/usersignup/approval_test.go
+++ b/controllers/usersignup/approval_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/capacity"
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	. "github.com/codeready-toolchain/host-operator/test"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
@@ -51,7 +52,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", corev1.ConditionTrue), NewMemberCluster(t, "member2", corev1.ConditionTrue))
 
 		// when
-		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 		// then
 		require.NoError(t, err)
@@ -69,7 +70,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		clusters := NewGetMemberClusters()
 
 		// when
-		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 		// then
 		require.NoError(t, err)
@@ -84,7 +85,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", corev1.ConditionTrue), NewMemberCluster(t, "member2", corev1.ConditionTrue))
 
 		// when
-		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 		// then
 		require.NoError(t, err)
@@ -99,7 +100,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", corev1.ConditionTrue), NewMemberCluster(t, "member2", corev1.ConditionTrue))
 
 		// when
-		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 		// then
 		require.NoError(t, err)
@@ -115,7 +116,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
 
 		// when
-		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 		// then
 		require.NoError(t, err)
@@ -134,7 +135,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
 
 		// when
-		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 		// then
 		require.NoError(t, err)
@@ -154,7 +155,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
 
 		// when
-		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 		// then
 		require.NoError(t, err)
@@ -172,7 +173,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually(), commonsignup.WithTargetCluster("member1"))
 
 		// when
-		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+		approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 		// then
 		require.NoError(t, err)
@@ -192,7 +193,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 			clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", corev1.ConditionTrue))
 
 			// when
-			approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+			approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 			// then
 			require.EqualError(t, err, "unable to get ToolchainConfig: some error")
@@ -213,7 +214,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 			clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", corev1.ConditionTrue))
 
 			// when
-			approved, clusterName, err := getClusterIfApproved(fakeClient, signup, clusters)
+			approved, clusterName, err := getClusterIfApproved(fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
 
 			// then
 			require.EqualError(t, err, "unable to get the optimal target cluster: unable to read ToolchainStatus resource: some error")

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/codeready-toolchain/host-operator/pkg/capacity"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -3643,9 +3644,9 @@ func prepareReconcile(t *testing.T, name string, getMemberClusters cluster.GetMe
 		StatusUpdater: &StatusUpdater{
 			Client: fakeClient,
 		},
-		Scheme:            s,
-		GetMemberClusters: getMemberClusters,
-		SegmentClient:     segment.NewClient(segmenttest.NewClient()),
+		Scheme:         s,
+		ClusterManager: capacity.NewClusterManager(getMemberClusters, fakeClient),
+		SegmentClient:  segment.NewClient(segmenttest.NewClient()),
 	}
 	return r, newReconcileRequest(name), fakeClient
 }

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/usersignup"
 	"github.com/codeready-toolchain/host-operator/controllers/usersignupcleanup"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
+	"github.com/codeready-toolchain/host-operator/pkg/capacity"
 	"github.com/codeready-toolchain/host-operator/pkg/cluster"
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/host-operator/pkg/segment"
@@ -267,10 +268,10 @@ func main() { // nolint:gocyclo
 		StatusUpdater: &usersignup.StatusUpdater{
 			Client: mgr.GetClient(),
 		},
-		Namespace:         namespace,
-		Scheme:            mgr.GetScheme(),
-		GetMemberClusters: commoncluster.GetMemberClusters,
-		SegmentClient:     segmentClient,
+		Namespace:      namespace,
+		Scheme:         mgr.GetScheme(),
+		SegmentClient:  segmentClient,
+		ClusterManager: capacity.NewClusterManager(commoncluster.GetMemberClusters, mgr.GetClient()),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UserSignup")
 		os.Exit(1)
@@ -291,9 +292,9 @@ func main() { // nolint:gocyclo
 		os.Exit(1)
 	}
 	if err = (&spacecompletion.Reconciler{
-		Client:            mgr.GetClient(),
-		Namespace:         namespace,
-		GetMemberClusters: commoncluster.GetMemberClusters,
+		Client:         mgr.GetClient(),
+		Namespace:      namespace,
+		ClusterManager: capacity.NewClusterManager(commoncluster.GetMemberClusters, mgr.GetClient()),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SpaceCompletion")
 		os.Exit(1)

--- a/pkg/capacity/manager.go
+++ b/pkg/capacity/manager.go
@@ -51,6 +51,19 @@ func hasMemberREnoughResources(memberStatus toolchainv1alpha1.Member, threshold 
 	return false
 }
 
+func NewClusterManager(getMemberClusters cluster.GetMemberClustersFunc, cl client.Client) *ClusterManager {
+	return &ClusterManager{
+		getMemberClusters: getMemberClusters,
+		client:            cl,
+	}
+}
+
+type ClusterManager struct {
+	getMemberClusters cluster.GetMemberClustersFunc
+	client            client.Client
+	lastUsed          string
+}
+
 // GetOptimalTargetCluster returns the name of the cluster with the most available capacity where a Space could be provisioned.
 //
 // If two clusters have the same limit and they both have the same usage, then the logic distributes spaces in a batches of 50.
@@ -59,8 +72,8 @@ func hasMemberREnoughResources(memberStatus toolchainv1alpha1.Member, threshold 
 // Let's say that the limit for member1 is 1000 and for member2 is 2000, then the batch of spaces would be 50 for member1 and 100 for member2.
 //
 // If the preferredCluster is provided and it is also one of the available clusters, then the same name is returned.
-func GetOptimalTargetCluster(preferredCluster, namespace string, getMemberClusters cluster.GetMemberClustersFunc, cl client.Client) (string, error) {
-	config, err := toolchainconfig.GetToolchainConfig(cl)
+func (b *ClusterManager) GetOptimalTargetCluster(preferredCluster, namespace string) (string, error) {
+	config, err := toolchainconfig.GetToolchainConfig(b.client)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to get ToolchainConfig")
 	}
@@ -71,10 +84,19 @@ func GetOptimalTargetCluster(preferredCluster, namespace string, getMemberCluste
 	}
 
 	status := &toolchainv1alpha1.ToolchainStatus{}
-	if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: toolchainconfig.ToolchainStatusName}, status); err != nil {
+	if err := b.client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: toolchainconfig.ToolchainStatusName}, status); err != nil {
 		return "", errors.Wrapf(err, "unable to read ToolchainStatus resource")
 	}
-	optimalTargetClusters := getOptimalTargetClusters(preferredCluster, getMemberClusters, hasNotReachedMaxNumberOfSpacesThreshold(config, counts), hasEnoughResources(config, status))
+	optimalTargetClusters := getOptimalTargetClusters(preferredCluster, b.getMemberClusters, hasNotReachedMaxNumberOfSpacesThreshold(config, counts), hasEnoughResources(config, status))
+
+	for _, cluster := range optimalTargetClusters {
+		if cluster == b.lastUsed {
+			provisioned := counts.SpacesPerClusterCounts[cluster]
+			if provisioned%50 != 0 {
+				return cluster, nil
+			}
+		}
+	}
 
 	sort.Slice(optimalTargetClusters, func(i, j int) bool {
 		provisioned1 := counts.SpacesPerClusterCounts[optimalTargetClusters[i]]
@@ -83,15 +105,16 @@ func GetOptimalTargetCluster(preferredCluster, namespace string, getMemberCluste
 		provisioned2 := counts.SpacesPerClusterCounts[optimalTargetClusters[j]]
 		threshold2 := config.CapacityThresholds().MaxNumberOfSpacesSpecificPerMemberCluster()[optimalTargetClusters[j]]
 
-		// Let's round the number of provisioned users down to closest multiple of 50
+		// Let's round the number of provisioned users down to the closest multiple of 50
 		// This is a trick we need to do before comparing the capacity, so we can distribute the users in batches by 50 (if the clusters have the same limit)
-		provisioned1 = (provisioned1 / 50) * 50
-		provisioned2 = (provisioned2 / 50) * 50
+		provisioned1By50 := (provisioned1 / 50) * 50
+		provisioned2By50 := (provisioned2 / 50) * 50
 
 		// now we can calculate what is the actual usage of the clusters (how many users are provisioned there compared to the threshold) and compare them
-		return float64(provisioned1)/float64(threshold1) < float64(provisioned2)/float64(threshold2)
+		return float64(provisioned1By50)/float64(threshold1) < float64(provisioned2By50)/float64(threshold2)
 	})
 
+	b.lastUsed = optimalTargetClusters[0]
 	return optimalTargetClusters[0], nil
 }
 

--- a/pkg/capacity/manager_test.go
+++ b/pkg/capacity/manager_test.go
@@ -48,7 +48,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue), NewMemberCluster(t, "member3", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue), NewMemberCluster(t, "member3", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -102,7 +102,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("member2", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("member2", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("member1", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("member1", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("member2", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("member2", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -174,7 +174,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -210,7 +210,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionFalse), NewMemberCluster(t, "member2", v1.ConditionTrue))
 
 		// when
-		clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 		// then
 		require.NoError(t, err)
@@ -229,7 +229,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
 
 			// when
-			clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+			clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 			// then
 			require.EqualError(t, err, "unable to get ToolchainConfig: some error")
@@ -249,7 +249,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
 
 			// when
-			clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+			clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 			// then
 			require.EqualError(t, err, "unable to read ToolchainStatus resource: some error")
@@ -263,73 +263,90 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 	for _, limit := range []int{800, 1000, 1234, 2500, 10000} {
 		t.Run(fmt.Sprintf("for the given limit of max number of spaces per cluster: %d", limit), func(t *testing.T) {
 
-			for _, numberOfSpaces := range []int{0, 50, 100, 550} {
+			for _, numberOfSpaces := range []int{0, 8, 50, 88, 100, 123, 555} {
 				t.Run(fmt.Sprintf("when there is a number of spaces at the very beginning %d", numberOfSpaces), func(t *testing.T) {
 
-					for _, makeItBigger := range []int{1, 2} {
-						name := "member3 has the same size as member2"
-						if makeItBigger > 1 {
-							name = fmt.Sprintf("member3 is %d times bigger than member2", makeItBigger)
+					toolchainStatus := NewToolchainStatus(
+						WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
+							string(metrics.Internal): 1000,
+						}),
+						WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
+							"1,internal": 1000,
+						}),
+						WithMember("member1", WithSpaceCount(1000), WithNodeRoleUsage("worker", 68), WithNodeRoleUsage("master", 65)),
+						WithMember("member2", WithSpaceCount(numberOfSpaces), WithNodeRoleUsage("worker", 55), WithNodeRoleUsage("master", 60)),
+						WithMember("member3", WithSpaceCount(numberOfSpaces), WithNodeRoleUsage("worker", 55), WithNodeRoleUsage("master", 50)))
+
+					// member2 and member3 have the same capacity left and the member1 is full, so no one can be provisioned there
+					toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+						testconfig.CapacityThresholds().
+							MaxNumberOfSpaces(testconfig.PerMemberCluster("member2", limit), testconfig.PerMemberCluster("member3", limit)))
+
+					fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+					InitializeCounters(t, toolchainStatus)
+					clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue), NewMemberCluster(t, "member3", v1.ConditionTrue))
+					clusterBalancer := capacity.NewClusterManager(clusters, fakeClient)
+
+					// now run in 4 cycles and expect that the users will be provisioned in batches of 50
+					member2CurrentCount := numberOfSpaces
+					member3CurrentCount := numberOfSpaces
+					for cycle := 0; cycle < 4; cycle++ {
+
+						member2MissingTo50 := 50 - member2CurrentCount%50
+						// this 50 users should go into member2 - it will be always 50
+						for i := 0; i < member2MissingTo50; i++ {
+							t.Run(fmt.Sprintf("cycle %d user %d for member2", cycle, i), func(t *testing.T) {
+								//given
+								// even when the counter of the other member is decremented, it should still use the last used one
+								// but we can decrement it only in the second cycle when the member3 has at least 50 Spaces
+								if i == 2 && cycle > 1 {
+									counter.DecrementSpaceCount(log.Log, "member3")
+									member3CurrentCount--
+								}
+
+								// when
+								clusterName, err := clusterBalancer.GetOptimalTargetCluster("", HostOperatorNs)
+
+								// then
+								require.NoError(t, err)
+								assert.Equal(t, "member2", clusterName)
+
+								counter.IncrementSpaceCount(log.Log, "member2")
+								member2CurrentCount++
+							})
 						}
-						t.Run(name, func(t *testing.T) {
 
-							toolchainStatus := NewToolchainStatus(
-								WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
-									string(metrics.Internal): 1000,
-								}),
-								WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
-									"1,internal": 1000,
-								}),
-								WithMember("member1", WithSpaceCount(1000), WithNodeRoleUsage("worker", 68), WithNodeRoleUsage("master", 65)),
-								WithMember("member2", WithSpaceCount(numberOfSpaces), WithNodeRoleUsage("worker", 55), WithNodeRoleUsage("master", 60)),
-								WithMember("member3", WithSpaceCount(numberOfSpaces*makeItBigger), WithNodeRoleUsage("worker", 55), WithNodeRoleUsage("master", 50)))
+						// reset the decremented counter back
+						if member2MissingTo50 > 2 && cycle > 1 {
+							counter.IncrementSpaceCount(log.Log, "member3")
+							member3CurrentCount++
+						}
 
-							// member2 and member3 have the same capacity left and the member1 is full, so no one can be provisioned there
-							toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
-								testconfig.CapacityThresholds().
-									MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1001), testconfig.PerMemberCluster("member2", limit), testconfig.PerMemberCluster("member3", limit*makeItBigger)))
+						member3MissingTo50 := 50 - member3CurrentCount%50
+						// this batch of users should go into member3 - the size of the batch depends on how many times the cluster is bigger than member2
+						for i := 0; i < member3MissingTo50; i++ {
+							t.Run(fmt.Sprintf("cycle %d user %d for member3", cycle, i), func(t *testing.T) {
+								// when
+								clusterName, err := clusterBalancer.GetOptimalTargetCluster("", HostOperatorNs)
 
-							fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
-							InitializeCounters(t, toolchainStatus)
-							clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue), NewMemberCluster(t, "member2", v1.ConditionTrue), NewMemberCluster(t, "member3", v1.ConditionTrue))
+								// then
+								require.NoError(t, err)
+								assert.Equal(t, "member3", clusterName)
 
-							// now run in 4 cycles and expect that the users will be provisioned in batches of 50
-							for cycle := 0; cycle < 4; cycle++ {
+								counter.IncrementSpaceCount(log.Log, "member3")
+								member3CurrentCount++
+							})
+						}
 
-								// this 50 users should go into member2 - it will be always 50
-								for i := 0; i < 50; i++ {
-									// when
-									clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
-
-									// then
-									require.NoError(t, err)
-									assert.Equal(t, "member2", clusterName)
-
-									counter.IncrementSpaceCount(log.Log, "member2")
-								}
-
-								// this batch of users should go into member3 - the size of the batch depends how many times the cluster is bigger than member2
-								for i := 0; i < 50*makeItBigger; i++ {
-									// when
-									clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
-
-									// then
-									require.NoError(t, err)
-									assert.Equal(t, "member3", clusterName)
-
-									counter.IncrementSpaceCount(log.Log, "member3")
-								}
-							}
-
-							// when
-							clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
-
-							// then
-							require.NoError(t, err)
-							// expect that it would start provisioning in member2 again
-							assert.Equal(t, "member2", clusterName)
-						})
 					}
+
+					// when
+					clusterName, err := clusterBalancer.GetOptimalTargetCluster("", HostOperatorNs)
+
+					// then
+					require.NoError(t, err)
+					// expect that it would start provisioning in member2 again
+					assert.Equal(t, "member2", clusterName)
 				})
 			}
 		})
@@ -344,7 +361,7 @@ func TestGetOptimalTargetClusterWhenCounterIsNotInitialized(t *testing.T) {
 	clusters := NewGetMemberClusters(NewMemberCluster(t, "member1", v1.ConditionTrue))
 
 	// when
-	clusterName, err := capacity.GetOptimalTargetCluster("", HostOperatorNs, clusters, fakeClient)
+	clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster("", HostOperatorNs)
 
 	// then
 	require.EqualError(t, err, "unable to get the number of provisioned spaces: counter is not initialized")


### PR DESCRIPTION
The original implementation didn't work fine because it blindly divided by 50 without reminder, but the result was in most cases the same for both clusters. 

The new approach stores the last member cluster that was used.
* If the reminder is not 0 (there is still some capacity until a multiply of 50 is reached), then it uses the last used member cluster
* otherwise, it compares the clusters and chooses the freest one for the next batch of 50 Spaces