### PR TITLE
Additional registration service permissions required for informers

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -37,6 +37,8 @@ objects:
           - socialevents
         verbs:
           - get
+          - list
+          - watch
       - apiGroups:
           - toolchain.dev.openshift.com
         resources:


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1619

This is in preparation for changes to the registration service that will use [shared informers](https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go).

Get, List and Watch permissions are required to get the Shared Informers working.

https://github.com/codeready-toolchain/registration-service/blob/master/deploy/registration-service.yaml will be updated to match in an upcoming PR.