### PR TITLE
Make initialDelaySeconds 30 seconds for reg service

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -113,7 +113,7 @@ objects:
                   path: /api/v1/health
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 1
+                initialDelaySeconds: 30
                 periodSeconds: 1
                 successThreshold: 1
                 timeoutSeconds: 1

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -103,7 +103,7 @@ objects:
                   path: /api/v1/health
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 1
+                initialDelaySeconds: 30
                 periodSeconds: 10
                 successThreshold: 1
                 timeoutSeconds: 1


### PR DESCRIPTION
Make initialDelaySeconds 30 seconds for the reg service since startup takes a longer time while waiting for the shared informers cache to sync. Related to https://github.com/codeready-toolchain/registration-service/pull/297