### PR TITLE
fix: resource name should be in plural form

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -63,7 +63,7 @@ objects:
     - spiaccesstokenbindings
     - spiaccesschecks
     - spiaccesstokens
-    - spifilecontentrequest
+    - spifilecontentrequests
     verbs:
     - create
     - get


### PR DESCRIPTION
Fixes issue: not able to create spifilecontentrequest on stonesoup stagin