### PR TITLE
Add reg service permissions to watch spaces and add startup probe

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -32,9 +32,10 @@ objects:
           - toolchain.dev.openshift.com
         resources:
           - masteruserrecords
+          - socialevents
+          - spaces
           - toolchainconfigs
           - toolchainstatuses
-          - socialevents
         verbs:
           - get
           - list
@@ -98,7 +99,7 @@ objects:
                 - registration-service
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                failureThreshold: 3
+                failureThreshold: 5
                 httpGet:
                   path: /api/v1/health
                   port: 8080

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -119,13 +119,13 @@ objects:
                 successThreshold: 1
                 timeoutSeconds: 1
               startupProbe:
-                failureThreshold: 18
+                failureThreshold: 180
                 httpGet:
                   path: /api/v1/health
                   port: 8080
                   scheme: HTTP
                 initialDelaySeconds: 1
-                periodSeconds: 10
+                periodSeconds: 1
                 successThreshold: 1
                 timeoutSeconds: 1
               env:

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -99,12 +99,12 @@ objects:
                 - registration-service
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                failureThreshold: 5
+                failureThreshold: 3
                 httpGet:
                   path: /api/v1/health
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 30
+                initialDelaySeconds: 1
                 periodSeconds: 10
                 successThreshold: 1
                 timeoutSeconds: 1
@@ -114,8 +114,18 @@ objects:
                   path: /api/v1/health
                   port: 8080
                   scheme: HTTP
-                initialDelaySeconds: 30
+                initialDelaySeconds: 1
                 periodSeconds: 1
+                successThreshold: 1
+                timeoutSeconds: 1
+              startupProbe:
+                failureThreshold: 18
+                httpGet:
+                  path: /api/v1/health
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 1
+                periodSeconds: 10
                 successThreshold: 1
                 timeoutSeconds: 1
               env:


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/CRT-1637

Reg service PR with matching deployment yaml: https://github.com/codeready-toolchain/registration-service/pull/300

*Update*
Since populating the informers cache only happens on startup I reverted the changes to the liveness and readiness probes and introduced a startup probe with a higher failureThreshold.