### PR TITLE
appstudio: Allow manage pipeline serviceaccount

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -133,6 +133,19 @@ objects:
     - patch
     - delete
     - deletecollection
+  # Allow to manage pipeline ServiceAccount for linking secrets used for repositories
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts 
+    resourceNames:
+    - pipeline  
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+    - patch
 
 # RoleBinding that grants limited CRUD permissions to the User
 - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Pipeline serviceAccount is used for running tekton pipelines and users should be able to attach secrets for container and git repositories.