### PR TITLE
Increase PVC quota for AppStudio to 12

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_appstudio.yaml
@@ -87,10 +87,10 @@ objects:
     namespace: ${USERNAME}
   spec:
     hard:
-      limits.ephemeral-storage: 15Gi
-      requests.storage: 15Gi
-      requests.ephemeral-storage: 15Gi
-      count/persistentvolumeclaims: "5"
+      limits.ephemeral-storage: 50Gi
+      requests.storage: 50Gi
+      requests.ephemeral-storage: 50Gi
+      count/persistentvolumeclaims: "12"
 - apiVersion: v1
   kind: LimitRange
   metadata:


### PR DESCRIPTION
Pipeline Service keeps the latest 10 PipelineRuns, so the quota is increased to 12 to allow for 2 PipelineRuns to be created before the pruner makes more space for additional PipelineRuns.

e2e-tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/657

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>