### PR TITLE
Add RHODS DSP labels to all user namespaces

### DIFF
--- a/deploy/templates/nstemplatetiers/base/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/base/ns_dev.yaml
@@ -12,6 +12,9 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       name: ${USERNAME}-dev
+      # For RHODS: Allow user namespace to be treated as a DSP to enable Model Serving on this NS
+      modelmesh-enabled: "true" 
+      opendatahub.io/dashboard: "true"
     name: ${USERNAME}-dev
 
 # Role and RoleBindings for CRT administration (not associated with users)

--- a/deploy/templates/nstemplatetiers/base/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/base/ns_stage.yaml
@@ -12,6 +12,9 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       name: ${USERNAME}-stage
+      # For RHODS: Allow user namespace to be treated as a DSP to enable Model Serving on this NS
+      modelmesh-enabled: "true"
+      opendatahub.io/dashboard: "true"
     name: ${USERNAME}-stage
 
 # Role and RoleBindings for CRT administration (not associated with users)

--- a/deploy/templates/nstemplatetiers/base1ns/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/base1ns/ns_dev.yaml
@@ -12,6 +12,9 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       name: ${USERNAME}-dev
+      # For RHODS: Allow user namespace to be treated as a DSP to enable Model Serving on this NS
+      modelmesh-enabled: "true"
+      opendatahub.io/dashboard: "true"
     name: ${USERNAME}-dev
 
 # Role and RoleBindings for CRT administration (not associated with users)

--- a/deploy/templates/nstemplatetiers/test/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/test/ns_dev.yaml
@@ -12,6 +12,9 @@ objects:
       openshift.io/requester: ${USERNAME}
     labels:
       name: ${USERNAME}-dev
+      # For RHODS: Allow user namespace to be treated as a DSP to enable Model Serving on this NS
+      modelmesh-enabled: "true"
+      opendatahub.io/dashboard: "true"
     name: ${USERNAME}-dev
 
 # Role and RoleBindings for CRT administration (not associated with users)


### PR DESCRIPTION
Adding the `modelmesh-enabled: "true"` and `opendatahub.io/dashboard: "true"` labels to all user namespaces across all tiers so that user's namespace is treated as a Data Science Project from a RHODS perspective. This allows users to use the Model Serving feature within RHODS