### PR TITLE
Allow only read access to GitOpsDeployments

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -16,7 +16,9 @@ objects:
     resources:
     - gitopsdeployments
     verbs:
-    - "*"
+    - get
+    - list
+    - watch
   - apiGroups:
     - appstudio.redhat.com
     resources:


### PR DESCRIPTION
This PR removes write access to GitOpsDeployment from users of Stonesoup, as the ability to create/modify a GitOpsDeployment would allow the user to bypass per-user security boundaries.

Corresponding test repo PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/669

JIRA: [GITOPSRVCE-427](https://issues.redhat.com/browse/GITOPSRVCE-427)
