### PR TITLE
refactor: ignore NSTemplateSet creation failure if already exists

### DIFF
--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -342,7 +342,7 @@ func (r *Reconciler) manageNSTemplateSet(logger logr.Logger, space *toolchainv1a
 			if err := memberCluster.Client.Create(context.TODO(), nsTmplSet); err != nil {
 				if errors.IsAlreadyExists(err) {
 					// requeue immediately, there's probably a race condition between the host client cache and the member cluster state
-					return nsTmplSet, norequeue, nil
+					return nsTmplSet, requeueDelay, nil
 				}
 				return nsTmplSet, norequeue, r.setStatusNSTemplateSetCreationFailed(logger, space, err)
 			}

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -341,7 +341,7 @@ func (r *Reconciler) manageNSTemplateSet(logger logr.Logger, space *toolchainv1a
 			nsTmplSet = NewNSTemplateSet(memberCluster.OperatorNamespace, space, spaceBindings.Items, tmplTier)
 			if err := memberCluster.Client.Create(context.TODO(), nsTmplSet); err != nil {
 				if errors.IsAlreadyExists(err) {
-					// requeue immediately, there's probably a race condition between the host client cache and the member cluster state
+					// requeue, there's probably a race condition between the host client cache and the member cluster state
 					return nsTmplSet, requeueDelay, nil
 				}
 				return nsTmplSet, norequeue, r.setStatusNSTemplateSetCreationFailed(logger, space, err)


### PR DESCRIPTION
there may be a delay between the creation on the member cluster and the client update on the host cluster, so failing at the second attempt should not raise an error

Fixes https://issues.redhat.com/browse/CRT-1729 

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
