### PR TITLE
refactor: user signup status condition updates

### DIFF
--- a/controllers/deactivation/mapper_test.go
+++ b/controllers/deactivation/mapper_test.go
@@ -1,15 +1,14 @@
 package deactivation
 
 import (
-	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 	"testing"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"github.com/stretchr/testify/require"
+	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 

--- a/controllers/usersignup/status_updater.go
+++ b/controllers/usersignup/status_updater.go
@@ -6,8 +6,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commonCondition "github.com/codeready-toolchain/toolchain-common/pkg/condition"
 
-	"github.com/go-logr/logr"
-	errs "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -16,18 +14,20 @@ type StatusUpdater struct {
 	Client client.Client
 }
 
-func (u *StatusUpdater) setStatusApprovedAutomatically(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupApproved,
-			Status:  corev1.ConditionTrue,
-			Reason:  toolchainv1alpha1.UserSignupApprovedAutomaticallyReason,
-			Message: message,
-		})
+func (u *StatusUpdater) updateStatus(userSignup *toolchainv1alpha1.UserSignup, newConditions ...toolchainv1alpha1.Condition) error {
+	userSignup.Status.Conditions, _ = commonCondition.AddOrUpdateStatusConditions(userSignup.Status.Conditions, newConditions...)
+	return u.Client.Status().Update(context.TODO(), userSignup)
 }
 
-var statusApprovedByAdmin = func(_ string) toolchainv1alpha1.Condition {
+func approvedAutomatically() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupApproved,
+		Status: corev1.ConditionTrue,
+		Reason: toolchainv1alpha1.UserSignupApprovedAutomaticallyReason,
+	}
+}
+
+func approvedByAdmin() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.UserSignupApproved,
 		Status: corev1.ConditionTrue,
@@ -35,90 +35,68 @@ var statusApprovedByAdmin = func(_ string) toolchainv1alpha1.Condition {
 	}
 }
 
-var statusPendingApproval = func(message string) toolchainv1alpha1.Condition {
+func unapprovedPendingApproval() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
-		Type:    toolchainv1alpha1.UserSignupApproved,
-		Status:  corev1.ConditionFalse,
-		Reason:  toolchainv1alpha1.UserSignupPendingApprovalReason,
-		Message: message,
+		Type:   toolchainv1alpha1.UserSignupApproved,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.UserSignupPendingApprovalReason,
 	}
 }
 
-var statusIncompletePendingApproval = func(message string) toolchainv1alpha1.Condition {
+func incompletePendingApproval() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.UserSignupPendingApprovalReason,
+	}
+}
+
+func invalidMURState(message string) toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:    toolchainv1alpha1.UserSignupComplete,
 		Status:  corev1.ConditionFalse,
-		Reason:  toolchainv1alpha1.UserSignupPendingApprovalReason,
+		Reason:  toolchainv1alpha1.UserSignupInvalidMURStateReason,
 		Message: message,
 	}
 }
 
-func (u *StatusUpdater) setStatusInvalidMURState(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupInvalidMURStateReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusFailedToCreateMUR(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUnableToCreateMURReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusFailedToDeleteMUR(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUnableToDeleteMURReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusFailedToCreateSpace(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUnableToCreateSpaceReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusFailedToCreateSpaceBinding(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUnableToCreateSpaceBindingReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) set(conditionCreators ...func(message string) toolchainv1alpha1.Condition) func(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return func(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-		conditions := make([]toolchainv1alpha1.Condition, len(conditionCreators))
-		for index, createCondition := range conditionCreators {
-			conditions[index] = createCondition(message)
-		}
-		return u.updateStatusConditions(userSignup, conditions...)
+func failedToCreateMUR(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupUnableToCreateMURReason,
+		Message: message,
 	}
 }
 
-var statusNoClustersAvailable = func(message string) toolchainv1alpha1.Condition {
+func failedToDeleteMUR(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupUnableToDeleteMURReason,
+		Message: message,
+	}
+}
+
+func failedToCreateSpace(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupUnableToCreateSpaceReason,
+		Message: message,
+	}
+}
+
+func failedToCreateSpaceBinding(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupUnableToCreateSpaceBindingReason,
+		Message: message,
+	}
+}
+
+func noClustersAvailable(message string) toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:    toolchainv1alpha1.UserSignupComplete,
 		Status:  corev1.ConditionFalse,
@@ -127,278 +105,181 @@ var statusNoClustersAvailable = func(message string) toolchainv1alpha1.Condition
 	}
 }
 
-func (u *StatusUpdater) setStatusNoUserTierAvailable(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupNoUserTierAvailableReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusNoTemplateTierAvailable(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupNoTemplateTierAvailableReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusBanning(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUserBanningReason,
-			Message: message,
-		})
-}
-
-// setStatusBanned sets the Complete status to True, as the banning operation has been successful (with a reason of "Banned")
-func (u *StatusUpdater) setStatusBanned(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionTrue,
-			Reason:  toolchainv1alpha1.UserSignupUserBannedReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusDeactivationInProgress(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupDeactivationInProgressReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusDeactivated(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionTrue,
-			Reason:  toolchainv1alpha1.UserSignupUserDeactivatedReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusFailedToReadBannedUsers(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupFailedToReadBannedUsersReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusInvalidMissingUserEmailAnnotation(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupMissingUserEmailAnnotationReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusMissingEmailHash(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupMissingEmailHashLabelReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusInvalidEmailHash(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupInvalidEmailHashLabelReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusVerificationRequired(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupVerificationRequiredReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusFailedToUpdateStateLabel(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUnableToUpdateStateLabelReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusFailedToUpdateAnnotation(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupUnableToUpdateAnnotationReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusDeactivationNotificationCreated(userSignup *toolchainv1alpha1.UserSignup, _ string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: corev1.ConditionTrue,
-			Reason: toolchainv1alpha1.UserSignupDeactivatedNotificationCRCreatedReason,
-		})
-}
-
-func (u *StatusUpdater) setStatusDeactivationNotificationUserIsActive(userSignup *toolchainv1alpha1.UserSignup, _ string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: corev1.ConditionFalse,
-			Reason: toolchainv1alpha1.UserSignupDeactivatedNotificationUserIsActiveReason,
-		})
-}
-
-func (u *StatusUpdater) setStatusDeactivationNotificationCreationFailed(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupDeactivatedNotificationCRCreationFailedReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) setStatusDeactivatingNotificationCreated(userSignup *toolchainv1alpha1.UserSignup, _ string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: corev1.ConditionTrue,
-			Reason: toolchainv1alpha1.UserSignupDeactivatingNotificationCRCreatedReason,
-		})
-}
-
-func (u *StatusUpdater) setStatusDeactivatingNotificationNotInPreDeactivation(userSignup *toolchainv1alpha1.UserSignup, _ string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: corev1.ConditionFalse,
-			Reason: toolchainv1alpha1.UserSignupDeactivatingNotificationUserNotInPreDeactivationReason,
-		})
-}
-
-func (u *StatusUpdater) setStatusDeactivatingNotificationCreationFailed(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupDeactivatingNotificationCRCreationFailedReason,
-			Message: message,
-		})
-}
-
-func (u *StatusUpdater) updateStatus(logger logr.Logger, userSignup *toolchainv1alpha1.UserSignup,
-	statusUpdater func(userAcc *toolchainv1alpha1.UserSignup, message string) error) error {
-
-	if err := statusUpdater(userSignup, ""); err != nil {
-		logger.Error(err, "status update failed")
-		return err
-	}
-
-	return nil
-}
-
-func (u *StatusUpdater) updateIncompleteStatus(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-	return u.updateStatusConditions(
-		userSignup,
-		toolchainv1alpha1.Condition{
-			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  corev1.ConditionFalse,
-			Reason:  toolchainv1alpha1.UserSignupProvisioningSpaceReason,
-			Message: message,
-		})
-}
-
-// updateCompleteStatus updates the `CompliantUsername` and `Conditions` in the status, should only be invoked on completion because
-// both completion and the compliant username require the master user record to be created.
-func (u *StatusUpdater) updateCompleteStatus(logger logr.Logger, compliantUsername string) func(userSignup *toolchainv1alpha1.UserSignup, message string) error { //nolint: unparam
-	return func(userSignup *toolchainv1alpha1.UserSignup, message string) error {
-
-		usernameUpdated := userSignup.Status.CompliantUsername != compliantUsername
-		userSignup.Status.CompliantUsername = compliantUsername
-
-		var conditionUpdated bool
-		userSignup.Status.Conditions, conditionUpdated = commonCondition.AddOrUpdateStatusConditions(userSignup.Status.Conditions,
-			toolchainv1alpha1.Condition{
-				Type:    toolchainv1alpha1.UserSignupComplete,
-				Status:  corev1.ConditionTrue,
-				Reason:  "",
-				Message: message,
-			})
-
-		if !usernameUpdated && !conditionUpdated {
-			// Nothing changed
-			return nil
-		}
-
-		return u.Client.Status().Update(context.TODO(), userSignup)
+func noUserTierAvailable(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupNoUserTierAvailableReason,
+		Message: message,
 	}
 }
 
-// wrapErrorWithStatusUpdate wraps the error and update the UserSignup status. If the update fails then the error is logged.
-func (u *StatusUpdater) wrapErrorWithStatusUpdate(logger logr.Logger, userSignup *toolchainv1alpha1.UserSignup,
-	statusUpdater StatusUpdaterFunc, err error, format string, args ...interface{}) error {
-	if err == nil {
-		return nil
+func noTemplateTierAvailable(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupNoTemplateTierAvailableReason,
+		Message: message,
 	}
-	if err := statusUpdater(userSignup, err.Error()); err != nil {
-		logger.Error(err, "Error updating UserSignup status")
-	}
-	return errs.Wrapf(err, format, args...)
 }
 
-func (u *StatusUpdater) updateStatusConditions(userSignup *toolchainv1alpha1.UserSignup, newConditions ...toolchainv1alpha1.Condition) error {
-	var updated bool
-	userSignup.Status.Conditions, updated = commonCondition.AddOrUpdateStatusConditions(userSignup.Status.Conditions, newConditions...)
-	if !updated {
-		// Nothing changed
-		return nil
+func userBanning() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.UserSignupUserBanningReason,
 	}
-	return u.Client.Status().Update(context.TODO(), userSignup)
+}
+
+// userBanned sets the Complete status to True, as the banning operation has been successful (with a reason of "Banned")
+func userBanned() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionTrue,
+		Reason: toolchainv1alpha1.UserSignupUserBannedReason,
+	}
+}
+
+func deactivationInProgress() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.UserSignupDeactivationInProgressReason,
+	}
+}
+
+func userDeactivated() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionTrue,
+		Reason: toolchainv1alpha1.UserSignupUserDeactivatedReason,
+	}
+}
+
+func failedToReadBannedUsers(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupFailedToReadBannedUsersReason,
+		Message: message,
+	}
+}
+
+func missingUserEmailAnnotation(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupMissingUserEmailAnnotationReason,
+		Message: message,
+	}
+}
+
+func missingEmailHash(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupMissingEmailHashLabelReason,
+		Message: message,
+	}
+}
+
+func invalidEmailHash(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupInvalidEmailHashLabelReason,
+		Message: message,
+	}
+}
+
+func verificationRequired() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.UserSignupVerificationRequiredReason,
+	}
+}
+
+func failedToUpdateStateLabel(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupUnableToUpdateStateLabelReason,
+		Message: message,
+	}
+}
+
+func failedToUpdateAnnotation(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupUnableToUpdateAnnotationReason,
+		Message: message,
+	}
+}
+
+func deactivatedNotificationCreated() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
+		Status: corev1.ConditionTrue,
+		Reason: toolchainv1alpha1.UserSignupDeactivatedNotificationCRCreatedReason,
+	}
+}
+
+func deactivatedNotificationUserIsActive() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.UserSignupDeactivatedNotificationUserIsActiveReason,
+	}
+}
+
+func deactivatedNotificationCreationFailed(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupDeactivatedNotificationCRCreationFailedReason,
+		Message: message,
+	}
+}
+
+func deactivatingNotificationCreated() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
+		Status: corev1.ConditionTrue,
+		Reason: toolchainv1alpha1.UserSignupDeactivatingNotificationCRCreatedReason,
+	}
+}
+
+func deactivatingNotificationNotInPreDeactivation() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.UserSignupDeactivatingNotificationUserNotInPreDeactivationReason,
+	}
+}
+
+func deactivatingNotificationCreationFailed(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupDeactivatingNotificationCRCreationFailedReason,
+		Message: message,
+	}
+}
+
+func provisioningSpace(message string) toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.UserSignupComplete,
+		Status:  corev1.ConditionFalse,
+		Reason:  toolchainv1alpha1.UserSignupProvisioningSpaceReason,
+		Message: message,
+	}
+}
+
+func complete() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionTrue,
+	}
 }

--- a/controllers/usersignup/status_updater_test.go
+++ b/controllers/usersignup/status_updater_test.go
@@ -1,52 +1,66 @@
 package usersignup
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var testLog = ctrl.Log.WithName("test")
 
 func TestUpdateStatus(t *testing.T) {
 	// given
-	userSignup := &toolchainv1alpha1.UserSignup{}
-
-	statusUpdater := StatusUpdater{Client: test.NewFakeClient(t)}
-
+	woopsy := func(message string) toolchainv1alpha1.Condition {
+		return toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.SpaceProvisioningFailedReason,
+			Message: message,
+		}
+	}
 	t.Run("status updated", func(t *testing.T) {
 		// given
-		updateStatus := func(_ *toolchainv1alpha1.UserSignup, message string) error {
-			assert.Equal(t, "oopsy woopsy", message)
-			return nil
-		}
+		userSignup := commonsignup.NewUserSignup()
+		cl := test.NewFakeClient(t, userSignup)
+		statusUpdater := StatusUpdater{Client: cl}
 
 		// when
-		err := statusUpdater.wrapErrorWithStatusUpdate(testLog, userSignup, updateStatus, apierrors.NewBadRequest("oopsy woopsy"), "failed to create namespace")
+		err := statusUpdater.updateStatus(userSignup, woopsy("oopsy woopsy"))
 
 		// then
-		require.Error(t, err)
-		assert.Equal(t, "failed to create namespace: oopsy woopsy", err.Error())
+		require.NoError(t, err)
+		err = cl.Get(context.TODO(), client.ObjectKeyFromObject(userSignup), userSignup)
+		require.NoError(t, err)
+		test.AssertConditionsMatch(t, userSignup.Status.Conditions, toolchainv1alpha1.Condition{
+			Type:    toolchainv1alpha1.UserSignupComplete,
+			Status:  corev1.ConditionFalse,
+			Reason:  toolchainv1alpha1.SpaceProvisioningFailedReason,
+			Message: "oopsy woopsy",
+		})
 	})
 
 	t.Run("status update failed", func(t *testing.T) {
-		// given
-		updateStatus := func(_ *toolchainv1alpha1.UserSignup, _ string) error {
-			return fmt.Errorf("unable to update status")
+		userSignup := &toolchainv1alpha1.UserSignup{}
+		cl := test.NewFakeClient(t, userSignup)
+		cl.MockStatusUpdate = func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+			return fmt.Errorf("failed to update status")
 		}
+		statusUpdater := StatusUpdater{Client: cl}
 
 		// when
-		err := statusUpdater.wrapErrorWithStatusUpdate(testLog, userSignup, updateStatus, apierrors.NewBadRequest("oopsy woopsy"), "failed to create namespace")
+		err := statusUpdater.updateStatus(userSignup, woopsy("oopsy woopsy"))
 
 		// then
 		require.Error(t, err)
-		assert.Equal(t, "failed to create namespace: oopsy woopsy", err.Error())
+		err = cl.Get(context.TODO(), client.ObjectKeyFromObject(userSignup), userSignup)
+		require.NoError(t, err)
+		assert.Empty(t, userSignup.Status.Conditions)
 	})
 }

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -2324,7 +2324,7 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 
 		// then
 		require.Error(t, err)
-		require.Equal(t, "Failed to create user deactivation notification: unable to create deactivation notification", err.Error())
+		require.Equal(t, "failed to create user deactivation notification: unable to create deactivation notification", err.Error())
 
 		// Lookup the UserSignup
 		err = r.Client.Get(context.TODO(), key, userSignup)
@@ -4185,7 +4185,7 @@ func TestUserSignupLastTargetClusterAnnotation(t *testing.T) {
 		res, err := r.Reconcile(context.TODO(), req)
 
 		// then
-		require.EqualError(t, err, "unable to update last target cluster annotation on UserSignup resource: error")
+		require.EqualError(t, err, "some error")
 		assert.False(t, res.Requeue)
 		AssertThatUserSignup(t, req.Namespace, userSignupName, cl).
 			HasNoAnnotation(toolchainv1alpha1.UserSignupLastTargetClusterAnnotationKey)


### PR DESCRIPTION
- remove the `wrapErrorWithStatusUpdate`, `updateStatusConditions`,
`updateCompleteStatus` and `updateIncompleteStatus` in favor of
`updateStatus` only
- replace all `func (u *StatusUpdater) setStatusXYZ` methods with
funcs that return a new condition only, but do not update the usersignup
(this is done by `updateStatus`)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
