### PR TITLE
feat(HACBS-1969): add read rbac of DT, DTC and DeploymentTargetClass to nstemplatetiers

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -45,6 +45,16 @@ objects:
   - apiGroups:
     - appstudio.redhat.com
     resources:
+    - deploymenttargets
+    - deploymenttargetclaims
+    - deploymenttargetclasses
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
     - enterprisecontractpolicies
     - integrationtestscenarios
     - releases


### PR DESCRIPTION
This PR add read RBAC of DT, DTC and DeploymentTargetClass to nstemplatetiers.

Corresponding test repo PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/680
