### PR TITLE
avoid space deletion when spacebinding is not created yet

### DIFF
--- a/controllers/spacecleanup/space_cleanup_controller.go
+++ b/controllers/spacecleanup/space_cleanup_controller.go
@@ -38,7 +38,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-const deletionTimeThreshold = 30 * time.Second
+const deletionTimeThreshold = 60 * time.Second
 
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaces,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spacebindings,verbs=get;list;watch

--- a/controllers/spacecleanup/space_cleanup_controller_test.go
+++ b/controllers/spacecleanup/space_cleanup_controller_test.go
@@ -24,9 +24,9 @@ import (
 
 func TestCleanupSpace(t *testing.T) {
 
-	t.Run("without any SpaceBinding and created more than 30 seconds ago", func(t *testing.T) {
+	t.Run("without any SpaceBinding and created more than 60 seconds ago", func(t *testing.T) {
 		// given
-		space := spacetest.NewSpace("without-spacebinding", spacetest.WithCreationTimestamp(time.Now().Add(-31*time.Second)))
+		space := spacetest.NewSpace("without-spacebinding", spacetest.WithCreationTimestamp(time.Now().Add(-61*time.Second)))
 		r, req, cl := prepareReconcile(t, space)
 
 		// when
@@ -39,9 +39,9 @@ func TestCleanupSpace(t *testing.T) {
 			DoesNotExist()
 	})
 
-	t.Run("without any SpaceBinding and created less than 30 seconds ago- Space shouldn't be deleted, just requeued", func(t *testing.T) {
+	t.Run("without any SpaceBinding and created less than 60 seconds ago- Space shouldn't be deleted, just requeued", func(t *testing.T) {
 		// given
-		space := spacetest.NewSpace("without-spacebinding", spacetest.WithCreationTimestamp(time.Now().Add(-29*time.Second)))
+		space := spacetest.NewSpace("without-spacebinding", spacetest.WithCreationTimestamp(time.Now().Add(-59*time.Second)))
 		r, req, cl := prepareReconcile(t, space)
 
 		// when


### PR DESCRIPTION
Observed a series of failures regarding e2e test regarding TestCreateSpace.

failure log example https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/codeready-toolchain_host-operator/770/pull-ci-codeready-toolchain-host-operator-master-e2e/1639611710845227008/build-log.txt

Paired with:
- https://github.com/codeready-toolchain/toolchain-e2e/pull/689