### PR TITLE
Increase storage limit to 40Gi

### DIFF
--- a/deploy/templates/nstemplatetiers/base/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/base/cluster.yaml
@@ -15,7 +15,7 @@ objects:
         limits.ephemeral-storage: 7Gi
         requests.cpu: 1750m
         requests.memory: ${MEMORY_REQUEST}
-        requests.storage: 15Gi
+        requests.storage: 40Gi
         requests.ephemeral-storage: 7Gi
         count/persistentvolumeclaims: "5"
     selector:

--- a/deploy/templates/nstemplatetiers/base1ns/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/base1ns/ns_dev.yaml
@@ -98,7 +98,7 @@ objects:
   spec:
     hard:
       limits.ephemeral-storage: 15Gi
-      requests.storage: 15Gi
+      requests.storage: 40Gi
       requests.ephemeral-storage: 15Gi
       count/persistentvolumeclaims: "5"
 - apiVersion: v1

--- a/deploy/templates/nstemplatetiers/test/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/test/ns_dev.yaml
@@ -99,7 +99,7 @@ objects:
   spec:
     hard:
       limits.ephemeral-storage: 15Gi
-      requests.storage: 15Gi
+      requests.storage: 40Gi
       requests.ephemeral-storage: 15Gi
       count/persistentvolumeclaims: "5"
 - apiVersion: v1


### PR DESCRIPTION
Increasing storage limits to 40Gi for RHODS operator updates.

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/691