### PR TITLE
Add read access to additional Core GitOps APIs

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -39,10 +39,11 @@ objects:
       - managed-gitops.redhat.com
     resources:
       - gitopsdeployments
+      - gitopsdeploymentmanagedenvironments
+      - gitopsdeploymentrepositorycredentials
+      - gitopsdeploymentsyncruns
     verbs:
-      - get
-      - list
-      - watch
+      - '*'
   - apiGroups:
       - tekton.dev
     resources:

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_contributor.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_contributor.yaml
@@ -52,6 +52,9 @@ objects:
           - managed-gitops.redhat.com
         resources:
           - gitopsdeployments
+          - gitopsdeploymentmanagedenvironments
+          - gitopsdeploymentrepositorycredentials
+          - gitopsdeploymentsyncruns
         verbs:
           - get
           - list

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_maintainer.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_maintainer.yaml
@@ -55,6 +55,9 @@ objects:
         - managed-gitops.redhat.com
       resources:
         - gitopsdeployments
+        - gitopsdeploymentmanagedenvironments
+        - gitopsdeploymentrepositorycredentials
+        - gitopsdeploymentsyncruns
       verbs:
         - get
         - list

--- a/test/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/test/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -56,11 +56,12 @@ objects:
   - apiGroups:
     - managed-gitops.redhat.com
     resources:
-    - gitopsdeployments
+      - gitopsdeployments
+      - gitopsdeploymentmanagedenvironments
+      - gitopsdeploymentrepositorycredentials
+      - gitopsdeploymentsyncruns
     verbs:
-    - get
-    - list
-    - watch
+    - '*'
   - apiGroups:
     - tekton.dev
     resources:

--- a/test/templates/nstemplatetiers/appstudio/spacerole_contributor.yaml
+++ b/test/templates/nstemplatetiers/appstudio/spacerole_contributor.yaml
@@ -52,6 +52,9 @@ objects:
           - managed-gitops.redhat.com
         resources:
           - gitopsdeployments
+          - gitopsdeploymentmanagedenvironments
+          - gitopsdeploymentrepositorycredentials
+          - gitopsdeploymentsyncruns
         verbs:
           - get
           - list

--- a/test/templates/nstemplatetiers/appstudio/spacerole_maintainer.yaml
+++ b/test/templates/nstemplatetiers/appstudio/spacerole_maintainer.yaml
@@ -56,6 +56,9 @@ objects:
         - managed-gitops.redhat.com
       resources:
         - gitopsdeployments
+        - gitopsdeploymentmanagedenvironments
+        - gitopsdeploymentrepositorycredentials
+        - gitopsdeploymentsyncruns
       verbs:
         - get
         - list


### PR DESCRIPTION
Adds readonly access for appstudio users to gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncrun APIs.

Corresponding test PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/693
Corresponding book PR: https://github.com/redhat-appstudio/book/pull/90