### PR TITLE
Provision sub-space to the same member clusters as parent space

### DIFF
--- a/controllers/spacerequest/spacerequest_controller.go
+++ b/controllers/spacerequest/spacerequest_controller.go
@@ -226,7 +226,7 @@ func (r *Reconciler) createNewSubSpace(logger logr.Logger, spaceRequest *toolcha
 		return subSpace, errs.Wrap(err, "unable to create space")
 	}
 
-	logger.Info("Created subSpace", "name", subSpace.Name, "target_cluster_roles", spaceRequest.Spec.TargetClusterRoles, "tierName", spaceRequest.Spec.TierName)
+	logger.Info("Created subSpace", "name", subSpace.Name, "target_cluster_roles", spaceRequest.Spec.TargetClusterRoles, "tierName", spaceRequest.Spec.TierName, "targetCluster", subSpace.Spec.TargetCluster)
 	return subSpace, nil
 }
 

--- a/pkg/space/space.go
+++ b/pkg/space/space.go
@@ -47,5 +47,12 @@ func NewSubSpace(spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *tool
 			ParentSpace:        parentSpace.GetName(),
 		},
 	}
+
+	// in case target cluster roles are not specified
+	// let's set target cluster to be same of the parent space
+	if len(spaceRequest.Spec.TargetClusterRoles) == 0 {
+		space.Spec.TargetCluster = parentSpace.Spec.TargetCluster
+	}
+
 	return space
 }


### PR DESCRIPTION
Provision sub-space to the same member clusters as parent space

Jira: https://issues.redhat.com/browse/ASC-349

Paired with:
- e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/700