### PR TITLE
Use compliant username in segment event

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -488,14 +488,14 @@ func (r *Reconciler) setStateLabel(logger logr.Logger, userSignup *toolchainv1al
 		return r.wrapErrorWithStatusUpdate(logger, userSignup, r.setStatusFailedToUpdateStateLabel, err,
 			"unable to update state label at UserSignup resource")
 	}
-	r.updateUserSignupMetricsByState(logger, userSignup, oldState, state)
+	r.updateUserSignupMetricsByState(oldState, state)
 	// increment the counter *only if the client update did not fail*
 	domain := metrics.GetEmailDomain(userSignup)
 	counter.UpdateUsersPerActivationCounters(logger, activations, domain) // will ignore if `activations == 0`
 	return nil
 }
 
-func (r *Reconciler) updateUserSignupMetricsByState(logger logr.Logger, userSignup *toolchainv1alpha1.UserSignup, oldState string, newState string) {
+func (r *Reconciler) updateUserSignupMetricsByState(oldState string, newState string) {
 	if oldState == "" {
 		metrics.UserSignupUniqueTotal.Inc()
 	}

--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -598,7 +598,7 @@ func (r *Reconciler) provisionMasterUserRecord(logger logr.Logger, config toolch
 	if r.SegmentClient != nil {
 		r.SegmentClient.TrackAccountActivation(compliantUsername, userSignup.Spec.Userid, userSignup.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey])
 	} else {
-		logger.Info("segment client not configure to track account activations")
+		logger.Info("segment client not configured to track account activations")
 	}
 
 	logger.Info("Created MasterUserRecord", "Name", mur.Name, "TargetCluster", targetCluster)

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -151,7 +151,7 @@ func TestUserSignupCreateMUROk(t *testing.T) {
 			}
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal) // zero because we started with a not-ready state instead of empty as per usual
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
-			segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+			segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 			AssertThatCountersAndMetrics(t).
 				HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
@@ -353,7 +353,7 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+	segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 	murtest.AssertThatMasterUserRecords(t, r.Client).HaveCount(1)
 	mur := murtest.AssertThatMasterUserRecord(t, userSignup.Spec.Username, r.Client).
 		HasLabelWithValue(toolchainv1alpha1.MasterUserRecordOwnerLabelKey, userSignup.Name).
@@ -457,7 +457,7 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+	segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 }
 
 func TestUserSignupWithMissingEmailAnnotationFails(t *testing.T) {
@@ -682,7 +682,7 @@ func TestNonDefaultNSTemplateTier(t *testing.T) {
 	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+	segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 	murtest.AssertThatMasterUserRecords(t, r.Client).HaveCount(1)
 	murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).
@@ -832,9 +832,8 @@ func TestUserSignupFailedMissingTier(t *testing.T) {
 					Reason: "UserIsActive",
 				})
 			assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
-			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)                         // incremented, even though the provisioning failed due to missing NSTemplateTier
-			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)                           // incremented, even though the provisioning failed due to missing NSTemplateTier
-			segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated) // message sent, even though the provisioning failed due to missing NSTemplateTier
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal) // incremented, even though the provisioning failed due to missing NSTemplateTier
+			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)   // incremented, even though the provisioning failed due to missing NSTemplateTier
 			AssertThatCountersAndMetrics(t).
 				HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
 					string(metrics.External): 1,
@@ -1003,7 +1002,7 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 	assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+	segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 	murtest.AssertThatMasterUserRecords(t, r.Client).HaveCount(1)
 	mur := murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).
 		HasLabelWithValue(toolchainv1alpha1.MasterUserRecordOwnerLabelKey, userSignup.Name).
@@ -1073,7 +1072,7 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 			assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-			segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+			segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
@@ -1138,7 +1137,7 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 	assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+	segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 	murtest.AssertThatMasterUserRecords(t, r.Client).HaveCount(1)
 	mur := murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).
@@ -1212,7 +1211,7 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 			assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-			segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+			segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
@@ -1337,7 +1336,7 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 	assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+	segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 	murtest.AssertThatMasterUserRecords(t, r.Client).HaveCount(1)
 	mur := murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).
@@ -1413,7 +1412,7 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 			assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-			segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+			segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
@@ -1598,7 +1597,6 @@ func TestUserSignupMUROrSpaceOrSpaceBindingCreateFails(t *testing.T) {
 			assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-			segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
 		})
 	}
 }
@@ -1646,7 +1644,6 @@ func TestUserSignupMURReadFails(t *testing.T) {
 	assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
 }
 
 func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
@@ -1870,7 +1867,6 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 		assert.Equal(t, "approved", instance.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-		segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
 
 		require.Equal(t, mur.Name, instance.Status.CompliantUsername)
 		test.AssertContainsCondition(t, instance.Status.Conditions, toolchainv1alpha1.Condition{
@@ -1944,7 +1940,7 @@ func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 	assert.Equal(t, "approved", instance.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+	segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 	t.Run("second reconcile", func(t *testing.T) {
 		// when
@@ -1959,7 +1955,7 @@ func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 		assert.Equal(t, "approved", instance.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
 		AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 		AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-		segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+		segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 		t.Run("verify usersignup on third reconcile", func(t *testing.T) {
 			// given space is ready
@@ -2034,7 +2030,7 @@ func TestUserSignupWithSpecialCharOK(t *testing.T) {
 
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+	segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, "foo-bar", r.Client).Get())
 }
 
 func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
@@ -2468,7 +2464,7 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 		AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
 		AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 		AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
-		segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
+		segmenttest.AssertMessageQueuedForProvisionedMur(t, r.SegmentClient, userSignup, murtest.AssertThatMasterUserRecord(t, userSignup.Name, r.Client).Get())
 
 		// There should not be a notification created because the user was reactivated
 		ntest.AssertNoNotificationsExist(t, r.Client)
@@ -3465,7 +3461,6 @@ func TestDeathBy100Signups(t *testing.T) {
 	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
-	segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
 
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
@@ -3954,7 +3949,6 @@ func TestUpdateMetricsByState(t *testing.T) {
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
-			segmenttest.AssertMessageQueued(t, r.SegmentClient, userSignup, segment.AccountActivated)
 		})
 
 		t.Run("approved -> deactivated - increment UserSignupDeactivatedTotal", func(t *testing.T) {

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -3897,9 +3897,6 @@ func TestMigrateMur(t *testing.T) {
 
 func TestUpdateMetricsByState(t *testing.T) {
 
-	userSignup := commonsignup.NewUserSignup()
-	logger := zap.New(zap.UseDevMode(true))
-
 	t.Run("common state changes", func(t *testing.T) {
 		t.Run("empty -> not-ready - increment UserSignupUniqueTotal", func(t *testing.T) {
 			// given
@@ -3908,7 +3905,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, "", toolchainv1alpha1.UserSignupStateLabelValueNotReady)
+			r.updateUserSignupMetricsByState("", toolchainv1alpha1.UserSignupStateLabelValueNotReady)
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -3925,7 +3922,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, toolchainv1alpha1.UserSignupStateLabelValueNotReady, "pending")
+			r.updateUserSignupMetricsByState(toolchainv1alpha1.UserSignupStateLabelValueNotReady, "pending")
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -3942,7 +3939,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, "pending", "approved")
+			r.updateUserSignupMetricsByState("pending", "approved")
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -3958,7 +3955,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, "approved", "deactivated")
+			r.updateUserSignupMetricsByState("approved", "deactivated")
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -3975,7 +3972,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, "pending", "deactivated")
+			r.updateUserSignupMetricsByState("pending", "deactivated")
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -3992,7 +3989,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, "deactivated", "banned")
+			r.updateUserSignupMetricsByState("deactivated", "banned")
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupBannedTotal)
@@ -4011,7 +4008,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, "any-value", "")
+			r.updateUserSignupMetricsByState("any-value", "")
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -4028,7 +4025,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, "any-value", toolchainv1alpha1.UserSignupStateLabelValueNotReady)
+			r.updateUserSignupMetricsByState("any-value", toolchainv1alpha1.UserSignupStateLabelValueNotReady)
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)
@@ -4045,7 +4042,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 				SegmentClient: segment.NewClient(segmenttest.NewClient()),
 			}
 			// when
-			r.updateUserSignupMetricsByState(logger, userSignup, "any-value", "x")
+			r.updateUserSignupMetricsByState("any-value", "x")
 			// then
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupAutoDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupBannedTotal)

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -3468,6 +3468,7 @@ func TestDeathBy100Signups(t *testing.T) {
 	AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 	AssertMetricsCounterEquals(t, 1, metrics.UserSignupUniqueTotal)
+	segmenttest.AssertNoMessageQueued(t, r.SegmentClient)
 
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
@@ -3953,6 +3954,7 @@ func TestUpdateMetricsByState(t *testing.T) {
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupDeactivatedTotal)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupApprovedTotal)
 			AssertMetricsCounterEquals(t, 0, metrics.UserSignupUniqueTotal)
+			segmenttest.AssertNoMessageQueued(t, r.SegmentClient)
 		})
 
 		t.Run("approved -> deactivated - increment UserSignupDeactivatedTotal", func(t *testing.T) {

--- a/test/segment/assertions.go
+++ b/test/segment/assertions.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func AssertMessageQueuedForProvisionedMur(t *testing.T, cl *segment.Client, us *toolchainv1alpha1.UserSignup, mur *toolchainv1alpha1.MasterUserRecord) {
-	assertMessageQueued(t, cl, mur.Name, us.Spec.Userid, us.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey], "account activated")
+func AssertMessageQueuedForProvisionedMur(t *testing.T, cl *segment.Client, us *toolchainv1alpha1.UserSignup, murName string) {
+	assertMessageQueued(t, cl, murName, us.Spec.Userid, us.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey], "account activated")
 }
 
 func assertMessageQueued(t *testing.T, cl *segment.Client, username, userID, accountID string, event string) {


### PR DESCRIPTION
Currently there is mismatch between `userID` field in events sent to segment from web-console and Sandbox backend (host operator).
In our activation event we use the sso username while web-console uses the `User.metadata.name` which is the complaint username.
As a temporal solution we would like to start using the compliant username in the host operator too but unfortunately we don't have it available in the UserSignup when it's approved.

This PR does two things:
- Move the activation event report to the place where we create a MUR CR for the approved UserSignup instead of reporting it when it's approved.
- Start using the compliant username instead of the sso username.

See more details in slack: https://redhat-internal.slack.com/archives/CHK0J6HT6/p1680830236435579

We still need to get confirmation from Brad and Jake that it's worth doing though.