### PR TITLE
fix: decrement counter when NSTemplateSet is deleted

### DIFF
--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -563,7 +563,7 @@ func (r *Reconciler) deleteNSTemplateSetFromCluster(logger logr.Logger, space *t
 		}
 		return false, nil // was already deleted in the mean time
 	}
-	counter.DecrementSpaceCount(logger, space.Spec.TargetCluster)
+	counter.DecrementSpaceCount(logger, space.Status.TargetCluster)
 	logger.Info("deleted the NSTemplateSet resource")
 	return true, nil // requeue until fully deleted
 }

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -493,7 +493,6 @@ func (r *Reconciler) ensureSpaceDeletion(logger logr.Logger, space *toolchainv1a
 		return r.setStatusTerminatingFailed(logger, space, err)
 	}
 
-	counter.DecrementSpaceCount(logger, space.Spec.TargetCluster)
 	logger.Info("removed finalizer")
 	// no need to update the status of the Space once the finalizer has been removed, since
 	// the resource will be deleted
@@ -564,6 +563,7 @@ func (r *Reconciler) deleteNSTemplateSetFromCluster(logger logr.Logger, space *t
 		}
 		return false, nil // was already deleted in the mean time
 	}
+	counter.DecrementSpaceCount(logger, space.Spec.TargetCluster)
 	logger.Info("deleted the NSTemplateSet resource")
 	return true, nil // requeue until fully deleted
 }

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -1832,15 +1832,7 @@ func TestRetargetSpace(t *testing.T) {
 			member2 := NewMemberClusterWithClient(member2Client, "member-2", corev1.ConditionTrue)
 			ctrl := newReconciler(hostClient, member1, member2)
 			InitializeCounters(t,
-				NewToolchainStatus(
-					WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
-						"1,internal": 1,
-					}),
-					WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
-						string(metrics.Internal): 1,
-					}),
-					WithMember("member-1", WithSpaceCount(1)),
-				))
+				NewToolchainStatus(WithEmptyMetrics(), WithMember("member-1", WithSpaceCount(1))))
 
 			// when
 			res, err := ctrl.Reconcile(context.TODO(), requestFor(s))
@@ -1854,8 +1846,8 @@ func TestRetargetSpace(t *testing.T) {
 				HasNoConditions().
 				HasStatusTargetCluster("member-1") // NOT updated
 			AssertThatCountersAndMetrics(t).
-				HaveSpacesForCluster("member-1", 1).
-				HaveSpacesForCluster("member-2", 0) // space counter is unchanged
+				HaveSpacesForCluster("member-1", 0). // counter is decremented according to the value in status
+				HaveSpacesForCluster("member-2", 0)  // space counter is unchanged
 		})
 
 	})

--- a/pkg/counter/cache.go
+++ b/pkg/counter/cache.go
@@ -109,7 +109,7 @@ func DecrementSpaceCount(logger logr.Logger, clusterName string) {
 		if cachedCounts.SpacesPerClusterCounts[clusterName] != 0 || !cachedCounts.initialized { // counter can be decreased even if its current value is `0`, but only if the cache has not been initialized yet
 			cachedCounts.SpacesPerClusterCounts[clusterName]--
 			metrics.SpaceGaugeVec.WithLabelValues(clusterName).Set(float64(cachedCounts.SpacesPerClusterCounts[clusterName]))
-			logger.Info("decremented Spaces count", "value", cachedCounts.SpacesPerClusterCounts[clusterName])
+			logger.Info("decremented Spaces count", "clusterName", clusterName, "value", cachedCounts.SpacesPerClusterCounts[clusterName])
 		} else {
 			logger.Error(fmt.Errorf("the count of Spaces is zero"),
 				"unable to decrement the number of Spaces for the given cluster", "cluster", clusterName)
@@ -205,7 +205,7 @@ func Synchronize(cl client.Client, toolchainStatus *toolchainv1alpha1.ToolchainS
 	// `masterUserRecordsPerDomain` metric
 	toolchainStatus.Status.Metrics[toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey] = toolchainv1alpha1.Metric(cachedCounts.MasterUserRecordPerDomainCounts)
 	for domain, count := range cachedCounts.MasterUserRecordPerDomainCounts {
-		log.Info("synchronized master_user_records gauge", "domaim", domain, "count", count)
+		log.Info("synchronized master_user_records gauge", "domain", domain, "count", count)
 		metrics.MasterUserRecordGaugeVec.WithLabelValues(domain).Set(float64(count))
 	}
 	log.Info("synchronized counters", "counts", cachedCounts.Counts)

--- a/test/toolchainstatus.go
+++ b/test/toolchainstatus.go
@@ -115,6 +115,18 @@ func WithMetric(key string, metric toolchainv1alpha1.Metric) ToolchainStatusOpti
 	}
 }
 
+func WithEmptyMetrics() ToolchainStatusOption {
+	return func(status *toolchainv1alpha1.ToolchainStatus) {
+		if status.Status.Metrics == nil {
+			status.Status.Metrics = map[string]toolchainv1alpha1.Metric{}
+		}
+		status.Status.Metrics = map[string]toolchainv1alpha1.Metric{
+			toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey:        {},
+			toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey: {},
+		}
+	}
+}
+
 func ToBeReady() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,


### PR DESCRIPTION
decrement counter when NSTemplateSet is deleted and not when finalizer is removed, otherwise, we can have wrong values in the counter when space is moved from one member cluster to another

paired PR and also the case when I faced the issue with wrong numbers: https://github.com/codeready-toolchain/toolchain-e2e/pull/707