### PR TITLE
Remove write access to all GitOpsDeployment* resources, from all roles

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -43,7 +43,9 @@ objects:
       - gitopsdeploymentrepositorycredentials
       - gitopsdeploymentsyncruns
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
   - apiGroups:
       - tekton.dev
     resources:

--- a/test/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/test/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -61,7 +61,9 @@ objects:
       - gitopsdeploymentrepositorycredentials
       - gitopsdeploymentsyncruns
     verbs:
-    - '*'
+      - get
+      - list
+      - watch
   - apiGroups:
     - tekton.dev
     resources:


### PR DESCRIPTION
For security purposes, only the GitOps Service controllers should be able to create/modify/delete the `GitOpsDeployment*` resources, at this time.

* Note this does not effect the Environment API (Snapshots, Environments, SnapshotEnvironmentBindings, etc).

#### Corresponding PRs:
- *Book*: https://github.com/redhat-appstudio/book/pull/97
- *Toolchain-e2e*: https://github.com/codeready-toolchain/toolchain-e2e/pull/712