### PR TITLE
PLNSRVCE-1167: add logs resource to tekton results RBAC

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -57,6 +57,7 @@ objects:
     resources:
       - results
       - records
+      - logs
     verbs:
       - get
       - list

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_contributor.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_contributor.yaml
@@ -72,6 +72,7 @@ objects:
         resources:
           - results
           - records
+          - logs
         verbs:
           - get
           - list

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_maintainer.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_maintainer.yaml
@@ -75,6 +75,7 @@ objects:
       resources:
         - results
         - records
+        - logs
       verbs:
         - get
         - list


### PR DESCRIPTION
since this role was created, the results REST API has been updated such that `logs` is a separate resource

(and yes, it is known that the README in the upstream repo needs to be updated :-) ) 

with this change, the following now works running the latest codeready alongside the latest appstudio pipeline-service (not yet bumped in infra-deployments):
```
gmontero ~ $ curl -k -X GET -H "Authorization: Bearer $BEARER_TOKEN" -H "Accept: application/json"   https://api-toolchain-host-operator.apps.gmontero412.devcluster.openshift.com/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/crt-sandboxtest-1-tenant/results/9244af2e-35eb-4c02-a681-211a38a84413/logs/35f62ea5-49f6-3fae-8c2a-d8bc9000537a | jq -r '.result.data' | base64 -d -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1440    0  1440    0     0   2153      0 --:--:-- --:--:-- --:--:--  2155
[task1 : prepare] 2023/04/28 18:03:51 Entrypoint initialization

[task1 : place-scripts] 2023/04/28 18:03:57 Decoded script /tekton/scripts/script-0-jcbfm
[task1 : place-scripts] 2023/04/28 18:03:57 Decoded script /tekton/scripts/script-1-hxgkt
[task1 : place-scripts] 2023/04/28 18:03:57 Decoded script /tekton/scripts/script-2-25lxq

[task1 : print-uid] TaskRun UID: a7661e44-fb0d-426f-8118-f57643718c2e
[task1 : print-uid] PipelineRun UID from params: 9244af2e-35eb-4c02-a681-211a38a84413

[task1 : print-names] Task name: test-pipelinerun-ld8w5-task1
[task1 : print-names] TaskRun name: test-pipelinerun-ld8w5-task1
[task1 : print-names] Pipeline name from params: test-pipelinerun-ld8w5
[task1 : print-names] PipelineRun name from params: test-pipelinerun-ld8w5
[task1 : print-names] PipelineRun namespace from params: crt-sandboxtest-1-tenant

[task1 : print-retries] PipelineTask retries from params: 7
[task1 : print-retries] PipelineTask current retry count: 0

gmontero ~ $ 
```

which lines up with the following in my cluster's `crt-sandboxtest-1-tenant` namespace
```
gmontero ~ $ tkn pr logs test-pipelinerun-ld8w5

[task1 : print-uid] TaskRun UID: a7661e44-fb0d-426f-8118-f57643718c2e
[task1 : print-uid] PipelineRun UID from params: 9244af2e-35eb-4c02-a681-211a38a84413

[task1 : print-names] Task name: test-pipelinerun-ld8w5-task1
[task1 : print-names] TaskRun name: test-pipelinerun-ld8w5-task1
[task1 : print-names] Pipeline name from params: test-pipelinerun-ld8w5
[task1 : print-names] PipelineRun name from params: test-pipelinerun-ld8w5
[task1 : print-names] PipelineRun namespace from params: crt-sandboxtest-1-tenant

[task1 : print-retries] PipelineTask retries from params: 7
[task1 : print-retries] PipelineTask current retry count: 0

gmontero ~ $ 
```

/assign @alexeykazakov 
/assign @MatousJobanek 
/assign @rajivnathan 

thanks gentlemen