### PR TITLE
Added workspace_name label in namespace template

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio-env/ns_env.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio-env/ns_env.yaml
@@ -14,6 +14,7 @@ objects:
       name: ${SPACE_NAME}-env
       toolchain.dev.openshift.com/workspace: ${SPACE_NAME}
       argocd.argoproj.io/managed-by: gitops-service-argocd
+      #billing labels ref: https://github.com/redhat-appstudio/book/blob/main/ADR/0010-namespace-metadata.md
       appstudio.redhat.com/workspace_name: ${SPACE_NAME}
     # The ${SPACE_NAME} here is actually the space (aka workspace) name that is going to be provisioned as environment sub-space (aka sub-workspace).
     # It's a legacy parameter that needs to be renamed

--- a/deploy/templates/nstemplatetiers/appstudio-env/ns_env.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio-env/ns_env.yaml
@@ -14,6 +14,7 @@ objects:
       name: ${SPACE_NAME}-env
       toolchain.dev.openshift.com/workspace: ${SPACE_NAME}
       argocd.argoproj.io/managed-by: gitops-service-argocd
+      appstudio.redhat.com/workspace_name: ${SPACE_NAME}
     # The ${SPACE_NAME} here is actually the space (aka workspace) name that is going to be provisioned as environment sub-space (aka sub-workspace).
     # It's a legacy parameter that needs to be renamed
     # related story https://issues.redhat.com/browse/CRT-1766

--- a/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -14,6 +14,8 @@ objects:
       name: ${SPACE_NAME}-tenant
       toolchain.dev.openshift.com/workspace: ${SPACE_NAME}
       argocd.argoproj.io/managed-by: gitops-service-argocd
+      #billing labels ref: https://github.com/redhat-appstudio/book/blob/main/ADR/0010-namespace-metadata.md
+      appstudio.redhat.com/workspace_name: ${SPACE_NAME}
     name: ${SPACE_NAME}-tenant
 
 # Built-n developer environment is available for all users OOTB

--- a/test/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/test/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -13,6 +13,7 @@ objects:
     labels:
       name: ${SPACE_NAME}-tenant
       toolchain.dev.openshift.com/workspace: ${SPACE_NAME}
+      appstudio.redhat.com/workspace_name: ${SPACE_NAME}
     name: ${SPACE_NAME}-tenant
 
 parameters:


### PR DESCRIPTION
This PR adds all workspace_name label to all the appstudio namespaces.

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/721
