### PR TITLE
refactor: use 'runtimeclient'

### DIFF
--- a/controllers/deactivation/deactivation_controller.go
+++ b/controllers/deactivation/deactivation_controller.go
@@ -6,30 +6,27 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
-	errs "github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
-	"github.com/codeready-toolchain/toolchain-common/pkg/states"
-
-	coputil "github.com/redhat-cop/operator-utils/pkg/util"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
+	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 
+	"github.com/go-logr/logr"
+	errs "github.com/pkg/errors"
+	coputil "github.com/redhat-cop/operator-utils/pkg/util"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // SetupWithManager sets up the controller with the Manager.
@@ -44,7 +41,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 // Reconciler reconciles a Deactivation object
 type Reconciler struct {
-	Client client.Client
+	Client runtimeclient.Client
 	Scheme *runtime.Scheme
 }
 

--- a/controllers/deactivation/mapper.go
+++ b/controllers/deactivation/mapper.go
@@ -3,18 +3,18 @@ package deactivation
 import (
 	"errors"
 
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var mapperLog = ctrl.Log.WithName("UserSignupToMasterUserRecordMapper")
 
-func MapUserSignupToMasterUserRecord() func(object client.Object) []reconcile.Request {
-	return func(obj client.Object) []reconcile.Request {
+func MapUserSignupToMasterUserRecord() func(object runtimeclient.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
 		if userSignup, ok := obj.(*toolchainv1alpha1.UserSignup); ok {
 
 			if userSignup.Status.CompliantUsername != "" {

--- a/controllers/deactivation/mapper_test.go
+++ b/controllers/deactivation/mapper_test.go
@@ -1,15 +1,14 @@
 package deactivation
 
 import (
-	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"github.com/stretchr/testify/require"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -61,7 +60,7 @@ func TestUserSignupToMasterUserRecordMapper(t *testing.T) {
 		mur := &toolchainv1alpha1.MasterUserRecord{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "echo",
-				Namespace:         test.HostOperatorNs,
+				Namespace:         commontest.HostOperatorNs,
 				CreationTimestamp: metav1.Now(),
 			},
 			Spec: toolchainv1alpha1.MasterUserRecordSpec{

--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -26,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -51,7 +51,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager, memberClusters map[st
 
 // Reconciler reconciles a MasterUserRecord object
 type Reconciler struct {
-	Client         client.Client
+	Client         runtimeclient.Client
 	Scheme         *runtime.Scheme
 	Namespace      string
 	MemberClusters map[string]cluster.Cluster
@@ -283,7 +283,7 @@ func (r *Reconciler) deleteUserAccount(logger logr.Logger, targetCluster, name s
 		return requeueTime, nil
 	}
 	propagationPolicy := metav1.DeletePropagationForeground
-	err := memberCluster.Client.Delete(context.TODO(), userAcc, &client.DeleteOptions{
+	err := memberCluster.Client.Delete(context.TODO(), userAcc, &runtimeclient.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
 	})
 	if err != nil {
@@ -327,7 +327,7 @@ func toBeProvisionedNotificationCreated() toolchainv1alpha1.Condition {
 }
 
 // updateStatusConditions updates user account status conditions with the new conditions
-func updateStatusConditions(logger logr.Logger, cl client.Client, mur *toolchainv1alpha1.MasterUserRecord, newConditions ...toolchainv1alpha1.Condition) error {
+func updateStatusConditions(logger logr.Logger, cl runtimeclient.Client, mur *toolchainv1alpha1.MasterUserRecord, newConditions ...toolchainv1alpha1.Condition) error {
 	var updated bool
 	mur.Status.Conditions, updated = condition.AddOrUpdateStatusConditions(mur.Status.Conditions, newConditions...)
 	if !updated {

--- a/controllers/masteruserrecord/sync_test.go
+++ b/controllers/masteruserrecord/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -15,13 +16,12 @@ import (
 	. "github.com/codeready-toolchain/host-operator/test/notification"
 	testusertier "github.com/codeready-toolchain/host-operator/test/usertier"
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	uatest "github.com/codeready-toolchain/toolchain-common/pkg/test/useraccount"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -239,7 +239,7 @@ func TestSynchronizeStatus(t *testing.T) {
 	t.Run("failed on the host side", func(t *testing.T) {
 		// given
 		hostClient := test.NewFakeClient(t, mur, readyToolchainStatus)
-		hostClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		hostClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			return fmt.Errorf("some error")
 		}
 		sync, _ := prepareSynchronizer(t, userAccount, mur, hostClient)
@@ -288,7 +288,7 @@ func TestSyncMurStatusWithUserAccountStatusWhenUpdated(t *testing.T) {
 	t.Run("failed on the host side", func(t *testing.T) {
 		// given
 		hostClient := test.NewFakeClient(t, mur)
-		hostClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		hostClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			return fmt.Errorf("some error")
 		}
 		sync, _ := prepareSynchronizer(t, userAccount, mur, hostClient)
@@ -336,7 +336,7 @@ func TestSyncMurStatusWithUserAccountStatusWhenDisabled(t *testing.T) {
 	t.Run("failed on the host side", func(t *testing.T) {
 		// given
 		hostClient := test.NewFakeClient(t, mur.DeepCopy())
-		hostClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		hostClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			return fmt.Errorf("some error")
 		}
 		sync, _ := prepareSynchronizer(t, userAccount, mur, hostClient)
@@ -465,7 +465,7 @@ func TestSyncMurStatusWithUserAccountStatusWhenCompleted(t *testing.T) {
 	t.Run("failed on the host side when doing update", func(t *testing.T) {
 		// given
 		hostClient := test.NewFakeClient(t)
-		hostClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		hostClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			return fmt.Errorf("some error")
 		}
 		sync, _ := prepareSynchronizer(t, userAccount, mur, hostClient)
@@ -481,7 +481,7 @@ func TestSyncMurStatusWithUserAccountStatusWhenCompleted(t *testing.T) {
 	t.Run("failed on the host side when creating notification", func(t *testing.T) {
 		// given
 		hostClient := test.NewFakeClient(t, mur.DeepCopy())
-		hostClient.MockCreate = func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+		hostClient.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
 			return fmt.Errorf("some error")
 		}
 		sync, _ := prepareSynchronizer(t, userAccount, mur, hostClient)
@@ -506,7 +506,7 @@ func TestSynchronizeUserAccountFailed(t *testing.T) {
 		userAcc := uatest.NewUserAccountFromMur(mur)
 
 		memberClient := test.NewFakeClient(t, userAcc)
-		memberClient.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		memberClient.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			return fmt.Errorf("unable to update user account %s", mur.Name)
 		}
 		err := murtest.Modify(mur, murtest.UserID("abc123"))
@@ -539,7 +539,7 @@ func TestSynchronizeUserAccountFailed(t *testing.T) {
 			uatest.StatusCondition(toBeNotReady("somethingFailed", "")))
 		memberClient := test.NewFakeClient(t, userAcc)
 		hostClient := test.NewFakeClient(t, provisionedMur, readyToolchainStatus)
-		hostClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		hostClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			return fmt.Errorf("unable to update MUR %s", provisionedMur.Name)
 		}
 		sync := Synchronizer{
@@ -764,7 +764,7 @@ func TestRoutes(t *testing.T) {
 	})
 }
 
-func prepareSynchronizer(t *testing.T, userAccount *toolchainv1alpha1.UserAccount, mur *toolchainv1alpha1.MasterUserRecord, hostClient *test.FakeClient) (Synchronizer, client.Client) {
+func prepareSynchronizer(t *testing.T, userAccount *toolchainv1alpha1.UserAccount, mur *toolchainv1alpha1.MasterUserRecord, hostClient *test.FakeClient) (Synchronizer, runtimeclient.Client) {
 	require.NoError(t, os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs))
 	copiedMur := mur.DeepCopy()
 	toolchainStatus := NewToolchainStatus(
@@ -782,7 +782,7 @@ func prepareSynchronizer(t *testing.T, userAccount *toolchainv1alpha1.UserAccoun
 	}, memberClient
 }
 
-func verifySyncMurStatusWithUserAccountStatus(t *testing.T, memberClient, hostClient client.Client, userAccount *toolchainv1alpha1.UserAccount, mur *toolchainv1alpha1.MasterUserRecord, expMurCon ...toolchainv1alpha1.Condition) {
+func verifySyncMurStatusWithUserAccountStatus(t *testing.T, memberClient, hostClient runtimeclient.Client, userAccount *toolchainv1alpha1.UserAccount, mur *toolchainv1alpha1.MasterUserRecord, expMurCon ...toolchainv1alpha1.Condition) {
 	userAccountCondition := userAccount.Status.Conditions[0]
 	uatest.AssertThatUserAccount(t, "john", memberClient).
 		Exists().
@@ -800,7 +800,7 @@ func verifySyncMurStatusWithUserAccountStatus(t *testing.T, memberClient, hostCl
 		AllUserAccountsHaveCondition(userAccountCondition)
 }
 
-func newMemberCluster(cl client.Client) cluster.Cluster {
+func newMemberCluster(cl runtimeclient.Client) cluster.Cluster {
 	return cluster.Cluster{
 		Config: &commoncluster.Config{
 			Name:              test.MemberClusterName,

--- a/controllers/notification/notification_controller.go
+++ b/controllers/notification/notification_controller.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+
 	"github.com/go-logr/logr"
 	errs "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -38,7 +38,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager, config toolchainconfi
 
 // Reconciler reconciles a Notification object
 type Reconciler struct {
-	Client          client.Client
+	Client          runtimeclient.Client
 	Scheme          *runtime.Scheme
 	deliveryService DeliveryService
 }
@@ -124,7 +124,7 @@ func (r *Reconciler) checkTransitionTimeAndDelete(log logr.Logger, durationBefor
 	if timeSinceCompletion >= durationBeforeNotificationDeletion {
 		log.Info("the Notification has been sent for a longer time than the 'durationBeforeNotificationDeletion', so it's ready to be deleted",
 			"durationBeforeNotificationDeletion", durationBeforeNotificationDeletion.String())
-		if err := r.Client.Delete(context.TODO(), notification, &client.DeleteOptions{}); err != nil {
+		if err := r.Client.Delete(context.TODO(), notification, &runtimeclient.DeleteOptions{}); err != nil {
 			return false, 0, errs.Wrapf(err, "unable to delete Notification object '%s'", notification.Name)
 		}
 		return true, 0, nil

--- a/controllers/notification/notification_delivery_service.go
+++ b/controllers/notification/notification_delivery_service.go
@@ -9,8 +9,7 @@ import (
 
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/pkg/templates/notificationtemplates"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type notificationDeliveryServiceConfig interface {
@@ -32,7 +31,7 @@ type DeliveryService interface {
 }
 
 type DeliveryServiceFactory struct {
-	Client client.Client
+	Client runtimeclient.Client
 	Config DeliveryServiceFactoryConfig
 }
 
@@ -41,7 +40,7 @@ type DeliveryServiceFactoryConfig interface {
 	MailgunConfig
 }
 
-func NewNotificationDeliveryServiceFactory(client client.Client, config DeliveryServiceFactoryConfig) *DeliveryServiceFactory {
+func NewNotificationDeliveryServiceFactory(client runtimeclient.Client, config DeliveryServiceFactoryConfig) *DeliveryServiceFactory {
 	return &DeliveryServiceFactory{
 		Client: client,
 		Config: config,

--- a/controllers/nstemplatetier/label_selector.go
+++ b/controllers/nstemplatetier/label_selector.go
@@ -6,7 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // OutdatedTierSelector creates a label selector to find MasterUserRecords or Spaces which are not up-to-date with
@@ -20,24 +20,24 @@ import (
 // but with a template version (defined by `<hash>`) which is NOT to the expected value (the one provided by `instance`).
 //
 // Note: The `hash` value is computed from the TemplateRefs. See `computeTemplateRefsHash()`
-func OutdatedTierSelector(tier *toolchainv1alpha1.NSTemplateTier) (client.MatchingLabelsSelector, error) {
+func OutdatedTierSelector(tier *toolchainv1alpha1.NSTemplateTier) (runtimeclient.MatchingLabelsSelector, error) {
 	// compute the hash of the `.spec.namespaces[].templateRef` + `.spec.clusteResource.TemplateRef`
 	hash, err := tierutil.ComputeHashForNSTemplateTier(tier)
 	if err != nil {
-		return client.MatchingLabelsSelector{}, err
+		return runtimeclient.MatchingLabelsSelector{}, err
 	}
 	selector := labels.NewSelector()
 	tierLabel, err := labels.NewRequirement(tierutil.TemplateTierHashLabelKey(tier.Name), selection.Exists, []string{})
 	if err != nil {
-		return client.MatchingLabelsSelector{}, err
+		return runtimeclient.MatchingLabelsSelector{}, err
 	}
 	selector = selector.Add(*tierLabel)
 	templateHashLabel, err := labels.NewRequirement(tierutil.TemplateTierHashLabelKey(tier.Name), selection.NotEquals, []string{hash})
 	if err != nil {
-		return client.MatchingLabelsSelector{}, err
+		return runtimeclient.MatchingLabelsSelector{}, err
 	}
 	selector = selector.Add(*templateHashLabel)
-	return client.MatchingLabelsSelector{
+	return runtimeclient.MatchingLabelsSelector{
 		Selector: selector,
 	}, nil
 }

--- a/controllers/nstemplatetier/nstemplatetier_controller.go
+++ b/controllers/nstemplatetier/nstemplatetier_controller.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -36,7 +36,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 // Reconciler reconciles a NSTemplateTier object (only when this latter's specs were updated)
 type Reconciler struct {
-	Client client.Client
+	Client runtimeclient.Client
 	Scheme *runtime.Scheme
 }
 

--- a/controllers/nstemplatetier/nstemplatetier_controller_test.go
+++ b/controllers/nstemplatetier/nstemplatetier_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -115,7 +115,7 @@ func TestReconcile(t *testing.T) {
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates)
 				initObjs := []runtime.Object{basicTier}
 				r, req, cl := prepareReconcile(t, basicTier.Name, initObjs...)
-				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 					if _, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok {
 						return errors.NewNotFound(schema.GroupResource{}, key.Name)
 					}
@@ -133,7 +133,7 @@ func TestReconcile(t *testing.T) {
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates)
 				initObjs := []runtime.Object{basicTier}
 				r, req, cl := prepareReconcile(t, basicTier.Name, initObjs...)
-				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+				cl.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 					if _, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok {
 						return fmt.Errorf("mock error")
 					}
@@ -155,7 +155,7 @@ func TestReconcile(t *testing.T) {
 				basicTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates)
 				initObjs := []runtime.Object{basicTier}
 				r, req, cl := prepareReconcile(t, basicTier.Name, initObjs...)
-				cl.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+				cl.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 					if _, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok {
 						return fmt.Errorf("mock error")
 					}

--- a/controllers/socialevent/socialevent_controller.go
+++ b/controllers/socialevent/socialevent_controller.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -22,7 +22,7 @@ import (
 
 // Reconciler reconciles a SocialEvent object
 type Reconciler struct {
-	client.Client
+	runtimeclient.Client
 	Namespace     string
 	StatusUpdater *StatusUpdater
 }
@@ -68,8 +68,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// and update the SocialEvent.Status.ActivationCount accordingly
 	usersignups := &toolchainv1alpha1.UserSignupList{}
 	if err := r.Client.List(context.TODO(), usersignups,
-		client.InNamespace(r.Namespace),
-		client.MatchingLabels{
+		runtimeclient.InNamespace(r.Namespace),
+		runtimeclient.MatchingLabels{
 			toolchainv1alpha1.SocialEventUserSignupLabelKey: event.Name,
 			toolchainv1alpha1.UserSignupStateLabelKey:       toolchainv1alpha1.UserSignupStateLabelValueApproved,
 		}); err != nil {

--- a/controllers/socialevent/socialevent_controller_test.go
+++ b/controllers/socialevent/socialevent_controller_test.go
@@ -19,7 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -91,7 +91,7 @@ func TestReconcileSocialEvent(t *testing.T) {
 			// given
 			event := socialeventtest.NewSocialEvent("notfound", "basic")
 			hostClient := test.NewFakeClient(t, event, baseUserTier, baseSpaceTier)
-			hostClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			hostClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.UserTier); ok && key.Name == "notfound" {
 					return fmt.Errorf("mock error")
 				}
@@ -141,7 +141,7 @@ func TestReconcileSocialEvent(t *testing.T) {
 			// given
 			event := socialeventtest.NewSocialEvent("deactivate30", "notfound")
 			hostClient := test.NewFakeClient(t, event, baseUserTier, baseSpaceTier)
-			hostClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			hostClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok && key.Name == "notfound" {
 					return fmt.Errorf("mock error")
 				}
@@ -189,7 +189,7 @@ func TestReconcileSocialEvent(t *testing.T) {
 	})
 }
 
-func newReconciler(hostClient client.Client) *socialevent.Reconciler {
+func newReconciler(hostClient runtimeclient.Client) *socialevent.Reconciler {
 	return &socialevent.Reconciler{
 		Client:    hostClient,
 		Namespace: test.HostOperatorNs,

--- a/controllers/socialevent/status_updater.go
+++ b/controllers/socialevent/status_updater.go
@@ -10,11 +10,11 @@ import (
 	"github.com/go-logr/logr"
 	errs "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type StatusUpdater struct {
-	Client client.Client
+	Client runtimeclient.Client
 }
 
 func (u *StatusUpdater) ready(event *toolchainv1alpha1.SocialEvent) error {

--- a/controllers/socialevent/status_updater_test.go
+++ b/controllers/socialevent/status_updater_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestUpdateStatusCondition(t *testing.T) {
@@ -74,7 +74,7 @@ func TestUpdateStatusCondition(t *testing.T) {
 			socialeventtest.WithConditions(c1), // with pre-existing status condition
 		)
 		hostClient := test.NewFakeClient(t, event)
-		hostClient.MockStatusUpdate = func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+		hostClient.MockStatusUpdate = func(_ context.Context, _ runtimeclient.Object, _ ...runtimeclient.UpdateOption) error {
 			return fmt.Errorf("mock error")
 		}
 		statusUpdater := StatusUpdater{Client: hostClient}

--- a/controllers/space/mapper.go
+++ b/controllers/space/mapper.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -14,8 +15,8 @@ var mapperLog = ctrl.Log.WithName("MapToSubSpacesByParentObjectName")
 
 // MapToSubSpacesByParentObjectName maps the sup-spaces to the SpaceBinding of a given parent-space.
 // The correct Spaces are listed using the parent-label whose value should equal to the Space name from object's .
-func MapToSubSpacesByParentObjectName(cl client.Client) func(object client.Object) []reconcile.Request {
-	return func(obj client.Object) []reconcile.Request {
+func MapToSubSpacesByParentObjectName(cl runtimeclient.Client) func(object runtimeclient.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
 		logger := mapperLog.WithValues("object-name", obj.GetName(), "object-kind", obj.GetObjectKind())
 
 		// initialize request slice to be returned
@@ -45,8 +46,8 @@ func MapToSubSpacesByParentObjectName(cl client.Client) func(object client.Objec
 		// by setting the label value that each sub-space should have.
 		subSpaces := &toolchainv1alpha1.SpaceList{}
 		err := cl.List(context.TODO(), subSpaces,
-			client.InNamespace(obj.GetNamespace()),
-			client.MatchingLabels{toolchainv1alpha1.ParentSpaceLabelKey: parentSpaceName})
+			runtimeclient.InNamespace(obj.GetNamespace()),
+			runtimeclient.MatchingLabels{toolchainv1alpha1.ParentSpaceLabelKey: parentSpaceName})
 		if err != nil {
 			logger.Error(err, "unable to get sub-spaces for an object")
 			return []reconcile.Request{}

--- a/controllers/space/mapper_test.go
+++ b/controllers/space/mapper_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/codeready-toolchain/host-operator/test/space"
 	sb "github.com/codeready-toolchain/host-operator/test/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -61,7 +62,7 @@ func TestMapToSubSpacesByParentObjectName(t *testing.T) {
 	t.Run("should not return any Space requests when list fails", func(t *testing.T) {
 		// given
 		cl := test.NewFakeClient(t, parentSpace, subSpace, singleSpace)
-		cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+		cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 			return fmt.Errorf("some error")
 		}
 

--- a/controllers/space/nstemplatetier_spaces_mapper.go
+++ b/controllers/space/nstemplatetier_spaces_mapper.go
@@ -8,13 +8,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func MapNSTemplateTierToSpaces(namespace string, cl client.Client) func(object client.Object) []reconcile.Request {
+func MapNSTemplateTierToSpaces(namespace string, cl runtimeclient.Client) func(object runtimeclient.Object) []reconcile.Request {
 	mapperLog := ctrl.Log.WithName("NSTemplateTierToSpaceMapper")
-	return func(obj client.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
 		if tmplTier, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok {
 			matchOutdated, err := nstemplatetier.OutdatedTierSelector(tmplTier)
 			if err != nil {
@@ -23,7 +23,7 @@ func MapNSTemplateTierToSpaces(namespace string, cl client.Client) func(object c
 			}
 			// look-up all spaces associated with the NSTemplateTier
 			spaces := &toolchainv1alpha1.SpaceList{}
-			if err := cl.List(context.TODO(), spaces, client.InNamespace(namespace), matchOutdated); err != nil {
+			if err := cl.List(context.TODO(), spaces, runtimeclient.InNamespace(namespace), matchOutdated); err != nil {
 				mapperLog.Error(err, "cannot list outdated Spaces", "tierName", tmplTier.Name)
 				return []reconcile.Request{}
 			}

--- a/controllers/space/nstemplatetier_spaces_mapper_test.go
+++ b/controllers/space/nstemplatetier_spaces_mapper_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -108,7 +108,7 @@ func TestMapNSTemplateTierToSpaces(t *testing.T) {
 			// given
 			nsTmplTier := tiertest.BasicTier(t, tiertest.CurrentBasicTemplates)
 			hostClient := test.NewFakeClient(t, nsTmplTier)
-			hostClient.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			hostClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 				return fmt.Errorf("mock error")
 			}
 			mapFrom := space.MapNSTemplateTierToSpaces(test.HostOperatorNs, hostClient)

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -34,7 +34,7 @@ import (
 
 // Reconciler reconciles a Space object
 type Reconciler struct {
-	Client              client.Client
+	Client              runtimeclient.Client
 	Namespace           string
 	MemberClusters      map[string]cluster.Cluster
 	NextScheduledUpdate time.Time
@@ -264,8 +264,8 @@ func (r *Reconciler) listSpaceBindings(space *toolchainv1alpha1.Space) (toolchai
 	spaceBindings := toolchainv1alpha1.SpaceBindingList{}
 	if err := r.Client.List(context.TODO(),
 		&spaceBindings,
-		client.InNamespace(space.Namespace),
-		client.MatchingLabels{
+		runtimeclient.InNamespace(space.Namespace),
+		runtimeclient.MatchingLabels{
 			toolchainv1alpha1.SpaceBindingSpaceLabelKey: space.Name, // use current space name for the search
 		},
 	); err != nil {
@@ -282,8 +282,8 @@ func (r *Reconciler) listSpaceBindings(space *toolchainv1alpha1.Space) (toolchai
 	parentSpaceBindings := toolchainv1alpha1.SpaceBindingList{}
 	if err := r.Client.List(context.TODO(),
 		&parentSpaceBindings,
-		client.InNamespace(space.Namespace),
-		client.MatchingLabels{
+		runtimeclient.InNamespace(space.Namespace),
+		runtimeclient.MatchingLabels{
 			toolchainv1alpha1.SpaceBindingSpaceLabelKey: space.Spec.ParentSpace, // use parentSpace name for the search
 		},
 	); err != nil {

--- a/controllers/space/space_controller_test.go
+++ b/controllers/space/space_controller_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -292,7 +292,7 @@ func TestCreateSpace(t *testing.T) {
 			// given
 			s := spacetest.NewSpace("oddity")
 			hostClient := test.NewFakeClient(t, s)
-			hostClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			hostClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -319,7 +319,7 @@ func TestCreateSpace(t *testing.T) {
 			// given
 			s := spacetest.NewSpace("oddity")
 			hostClient := test.NewFakeClient(t, s)
-			hostClient.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			hostClient.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -373,7 +373,7 @@ func TestCreateSpace(t *testing.T) {
 				spacetest.WithSpecTargetCluster("member-1"),
 				spacetest.WithFinalizer())
 			hostClient := test.NewFakeClient(t, s)
-			hostClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			hostClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -407,7 +407,7 @@ func TestCreateSpace(t *testing.T) {
 				spacetest.WithFinalizer())
 			hostClient := test.NewFakeClient(t, s, basicTier)
 			member1Client := test.NewFakeClient(t)
-			member1Client.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			member1Client.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.NSTemplateSet); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -440,7 +440,7 @@ func TestCreateSpace(t *testing.T) {
 				spacetest.WithFinalizer())
 			hostClient := test.NewFakeClient(t, s, basicTier)
 			member1Client := test.NewFakeClient(t)
-			member1Client.MockCreate = func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+			member1Client.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.NSTemplateSet); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -472,7 +472,7 @@ func TestCreateSpace(t *testing.T) {
 				spacetest.WithSpecTargetCluster("member-1"),
 				spacetest.WithFinalizer())
 			hostClient := test.NewFakeClient(t, s, basicTier)
-			hostClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			hostClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -506,7 +506,7 @@ func TestCreateSpace(t *testing.T) {
 			hostClient := test.NewFakeClient(t, s, basicTier)
 			nsTmplSet := nstemplatetsettest.NewNSTemplateSet("john", nstemplatetsettest.WithReadyCondition(), nstemplatetsettest.WithReferencesFor(basicTier))
 			member1Client := test.NewFakeClient(t, nsTmplSet)
-			hostClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			hostClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				if space, ok := obj.(*toolchainv1alpha1.Space); ok {
 					if len(space.Status.ProvisionedNamespaces) > 0 {
 						return fmt.Errorf("update error")
@@ -790,7 +790,7 @@ func TestDeleteSpace(t *testing.T) {
 			)
 			hostClient := test.NewFakeClient(t, s)
 			member1Client := test.NewFakeClient(t)
-			member1Client.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			member1Client.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.NSTemplateSet); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -1317,7 +1317,7 @@ func TestUpdateSpaceTier(t *testing.T) {
 				spacetest.WithStatusTargetCluster("member-1"), // already provisioned on a target cluster
 				spacetest.WithFinalizer())
 			hostClient := test.NewFakeClient(t, s, basicTier, otherTier)
-			hostClient.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			hostClient.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok && obj.GetLabels()[tierutil.TemplateTierHashLabelKey(basicTier.Name)] != "" {
 					return fmt.Errorf("mock error")
 				}
@@ -1992,8 +1992,8 @@ func TestSubSpace(t *testing.T) {
 	})
 }
 
-func mockDeleteNSTemplateSetFail(cl client.Client) func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-	return func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+func mockDeleteNSTemplateSetFail(cl runtimeclient.Client) func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.DeleteOption) error {
+	return func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.DeleteOption) error {
 		if _, ok := obj.(*toolchainv1alpha1.NSTemplateSet); ok {
 			return fmt.Errorf("mock error")
 		}
@@ -2001,8 +2001,8 @@ func mockDeleteNSTemplateSetFail(cl client.Client) func(ctx context.Context, obj
 	}
 }
 
-func mockUpdateSpaceStatusFail(cl client.Client) func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	return func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+func mockUpdateSpaceStatusFail(cl runtimeclient.Client) func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
+	return func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 		if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 			return fmt.Errorf("mock error")
 		}
@@ -2010,8 +2010,8 @@ func mockUpdateSpaceStatusFail(cl client.Client) func(ctx context.Context, obj c
 	}
 }
 
-func mockUpdateNSTemplateSetFail(cl client.Client) func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	return func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+func mockUpdateNSTemplateSetFail(cl runtimeclient.Client) func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
+	return func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 		if _, ok := obj.(*toolchainv1alpha1.NSTemplateSet); ok {
 			return fmt.Errorf("mock error")
 		}
@@ -2019,7 +2019,7 @@ func mockUpdateNSTemplateSetFail(cl client.Client) func(ctx context.Context, obj
 	}
 }
 
-func newReconciler(hostCl client.Client, memberClusters ...*commoncluster.CachedToolchainCluster) *space.Reconciler {
+func newReconciler(hostCl runtimeclient.Client, memberClusters ...*commoncluster.CachedToolchainCluster) *space.Reconciler {
 	os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs)
 	clusters := map[string]cluster.Cluster{}
 	for _, c := range memberClusters {

--- a/controllers/spacebindingcleanup/mapper.go
+++ b/controllers/spacebindingcleanup/mapper.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -14,13 +15,13 @@ var mapperLog = ctrl.Log.WithName("MapToSpaceBindingByBoundObjectName")
 
 // MapToSpaceBindingByBoundObjectName maps the bound object (MUR or Space) to the associated SpaceBindings.
 // The correct SpaceBindings are listed using the given label whose value should equal to the object's name.
-func MapToSpaceBindingByBoundObjectName(cl client.Client, label string) func(object client.Object) []reconcile.Request {
-	return func(obj client.Object) []reconcile.Request {
+func MapToSpaceBindingByBoundObjectName(cl runtimeclient.Client, label string) func(object runtimeclient.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
 		logger := mapperLog.WithValues("object-name", obj.GetName(), "object-kind", obj.GetObjectKind())
 		spaceBindings := &toolchainv1alpha1.SpaceBindingList{}
 		err := cl.List(context.TODO(), spaceBindings,
-			client.InNamespace(obj.GetNamespace()),
-			client.MatchingLabels{label: obj.GetName()})
+			runtimeclient.InNamespace(obj.GetNamespace()),
+			runtimeclient.MatchingLabels{label: obj.GetName()})
 		if err != nil {
 			logger.Error(err, "unable to get SpaceBinding for an object")
 			return []reconcile.Request{}

--- a/controllers/spacebindingcleanup/mapper_test.go
+++ b/controllers/spacebindingcleanup/mapper_test.go
@@ -10,10 +10,11 @@ import (
 	sb "github.com/codeready-toolchain/host-operator/test/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -80,7 +81,7 @@ func TestMapToSpaceBindingByBoundObject(t *testing.T) {
 	t.Run("should not return any SpaceBinding requests when list fails", func(t *testing.T) {
 		// given
 		cl := test.NewFakeClient(t, sbLaraCompAdmin, sbJoeCompView, sbLaraOtherEdit)
-		cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+		cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 			return fmt.Errorf("some error")
 		}
 

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
 	"github.com/go-logr/logr"
 	errs "github.com/pkg/errors"
 	"github.com/redhat-cop/operator-utils/pkg/util"
@@ -12,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -35,7 +36,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconciler reconciles a SpaceBinding object
 type Reconciler struct {
-	client.Client
+	runtimeclient.Client
 	Scheme    *runtime.Scheme
 	Namespace string
 }

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
@@ -11,11 +11,12 @@ import (
 	sb "github.com/codeready-toolchain/host-operator/test/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
+
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -61,7 +62,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 	t.Run("lara-redhat SpaceBinding is being deleted, so no action needed", func(t *testing.T) {
 		sbLaraRedhatAdmin := sbLaraRedhatAdmin.DeepCopy()
-		now := v1.Now()
+		now := metav1.Now()
 		sbLaraRedhatAdmin.DeletionTimestamp = &now
 		reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, sbJoeRedhatView, sbLaraIbmEdit, laraMur, joeMur, ibmSpace)
 
@@ -93,7 +94,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 		for _, boundResourceName := range []string{"lara", "redhat"} {
 			reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, redhatSpace, laraMur)
-			fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if key.Name == boundResourceName {
 					return fmt.Errorf("some error")
 				}
@@ -112,7 +113,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 	t.Run("fails while deleting the SpaceBinding", func(t *testing.T) {
 
 		reconciler, request, fakeClient := prepareReconciler(t, sbLaraRedhatAdmin, redhatSpace)
-		fakeClient.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+		fakeClient.MockDelete = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.DeleteOption) error {
 			return fmt.Errorf("some error")
 		}
 

--- a/controllers/spacecleanup/space_cleanup_controller.go
+++ b/controllers/spacecleanup/space_cleanup_controller.go
@@ -6,23 +6,23 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	commoncontrollers "github.com/codeready-toolchain/toolchain-common/controllers"
-	"github.com/go-logr/logr"
-	"github.com/redhat-cop/operator-utils/pkg/util"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/go-logr/logr"
 	errs "github.com/pkg/errors"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // Reconciler reconciles a Space object
 type Reconciler struct {
-	Client    client.Client
+	Client    runtimeclient.Client
 	Namespace string
 }
 
@@ -82,8 +82,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 func (r *Reconciler) ensureDeletionIfNeeded(logger logr.Logger, space *toolchainv1alpha1.Space) (bool, time.Duration, error) {
 	bindings := &toolchainv1alpha1.SpaceBindingList{}
-	labelMatch := client.MatchingLabels{toolchainv1alpha1.SpaceBindingSpaceLabelKey: space.Name}
-	if err := r.Client.List(context.TODO(), bindings, client.InNamespace(space.Namespace), labelMatch); err != nil {
+	labelMatch := runtimeclient.MatchingLabels{toolchainv1alpha1.SpaceBindingSpaceLabelKey: space.Name}
+	if err := r.Client.List(context.TODO(), bindings, runtimeclient.InNamespace(space.Namespace), labelMatch); err != nil {
 		return false, 0, errs.Wrap(err, "unable to list SpaceBindings")
 	}
 

--- a/controllers/spacecleanup/space_cleanup_controller_test.go
+++ b/controllers/spacecleanup/space_cleanup_controller_test.go
@@ -13,12 +13,13 @@ import (
 	spacetest "github.com/codeready-toolchain/host-operator/test/space"
 	"github.com/codeready-toolchain/host-operator/test/spacebinding"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -91,7 +92,7 @@ func TestCleanupSpace(t *testing.T) {
 		space := spacetest.NewSpace("not-found") // will be disregarded, only included for call to prepareReconcile func
 		r, req, _ := prepareReconcile(t, space)
 		empty := test.NewFakeClient(t) // with space disregarded
-		empty.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+		empty.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 			return fmt.Errorf("shouldn't be called")
 		}
 		r.Client = empty
@@ -173,7 +174,7 @@ func TestCleanupSpace(t *testing.T) {
 			// given
 			space := spacetest.NewSpace("get-fails")
 			r, req, cl := prepareReconcile(t, space)
-			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				return fmt.Errorf("some error")
 			}
 
@@ -192,7 +193,7 @@ func TestCleanupSpace(t *testing.T) {
 			// given
 			space := spacetest.NewSpace("list-fails")
 			r, req, cl := prepareReconcile(t, space)
-			cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 				return fmt.Errorf("some error")
 			}
 
@@ -210,7 +211,7 @@ func TestCleanupSpace(t *testing.T) {
 			// given
 			space := spacetest.NewSpace("delete-fails", spacetest.WithCreationTimestamp(time.Now().Add(-time.Minute)))
 			r, req, cl := prepareReconcile(t, space)
-			cl.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+			cl.MockDelete = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.DeleteOption) error {
 				return fmt.Errorf("some error")
 			}
 

--- a/controllers/spacecompletion/space_completion_controller.go
+++ b/controllers/spacecompletion/space_completion_controller.go
@@ -7,15 +7,15 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/pkg/capacity"
 	"github.com/codeready-toolchain/host-operator/pkg/pending"
-	"github.com/go-logr/logr"
-	"github.com/redhat-cop/operator-utils/pkg/util"
 
+	"github.com/go-logr/logr"
 	errs "github.com/pkg/errors"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -25,7 +25,7 @@ import (
 
 // Reconciler reconciles a Space object
 type Reconciler struct {
-	Client         client.Client
+	Client         runtimeclient.Client
 	Namespace      string
 	ClusterManager *capacity.ClusterManager
 }

--- a/controllers/spacecompletion/space_completion_controller_test.go
+++ b/controllers/spacecompletion/space_completion_controller_test.go
@@ -16,11 +16,12 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -134,7 +135,7 @@ func TestCreateSpace(t *testing.T) {
 				spacetest.WithTierName("advanced"))
 			r, req, _ := prepareReconcile(t, space, NewGetMemberClusters())
 			empty := test.NewFakeClient(t)
-			empty.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			empty.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				return fmt.Errorf("shouldn't be called")
 			}
 			r.Client = empty
@@ -151,7 +152,7 @@ func TestCreateSpace(t *testing.T) {
 			space := spacetest.NewSpace("get-fails",
 				spacetest.WithTierName("advanced"))
 			r, req, cl := prepareReconcile(t, space, NewGetMemberClusters())
-			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				return fmt.Errorf("some error")
 			}
 
@@ -171,7 +172,7 @@ func TestCreateSpace(t *testing.T) {
 			space := spacetest.NewSpace("oddity",
 				spacetest.WithTierName(""))
 			r, req, cl := prepareReconcile(t, space, NewGetMemberClusters())
-			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if key.Name == "config" {
 					return fmt.Errorf("some error")
 				}
@@ -193,7 +194,7 @@ func TestCreateSpace(t *testing.T) {
 			space := spacetest.NewSpace("oddity",
 				spacetest.WithTierName("advanced"))
 			r, req, cl := prepareReconcile(t, space, NewGetMemberClusters())
-			cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if key.Name == "config" {
 					return fmt.Errorf("some error")
 				}

--- a/controllers/spacerequest/space_spacerequest_mapper.go
+++ b/controllers/spacerequest/space_spacerequest_mapper.go
@@ -2,15 +2,16 @@ package spacerequest
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // MapSubSpaceToSpaceRequest checks whether a space was created from a spacerequest, in case it finds the required labels,
 // triggers an event for the given spacerequest associated with the space.
-func MapSubSpaceToSpaceRequest() func(object client.Object) []reconcile.Request {
-	return func(obj client.Object) []reconcile.Request {
+func MapSubSpaceToSpaceRequest() func(object runtimeclient.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
 		// get eventual spaceRequest name and namespace associated with current Space
 		spaceRequestName, spaceRequestExists := obj.GetLabels()[toolchainv1alpha1.SpaceRequestLabelKey]
 		spaceRequestNamespace, spaceRequestNamespaceExists := obj.GetLabels()[toolchainv1alpha1.SpaceRequestNamespaceLabelKey]

--- a/controllers/spacerequest/spacerequest_controller_test.go
+++ b/controllers/spacerequest/spacerequest_controller_test.go
@@ -15,7 +15,8 @@ import (
 	spacerequesttest "github.com/codeready-toolchain/host-operator/test/spacerequest"
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	clienttest "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
+
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -102,7 +103,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 		t.Run("space is provisioned", func(t *testing.T) {
 			// given
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-1", corev1.ConditionTrue)
-			clienttest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
+			commontest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
 				Name:      toolchainv1alpha1.AdminServiceAccountName,
 				Namespace: "jane-env",
 			})
@@ -146,7 +147,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			// given
 			// the default namespace has already an access secret provisioned
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-1", corev1.ConditionTrue)
-			clienttest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
+			commontest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
 				Name:      toolchainv1alpha1.AdminServiceAccountName,
 				Namespace: "jane-env1",
 			},
@@ -257,7 +258,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			kubeconfigSecret1.Labels[toolchainv1alpha1.SpaceRequestNamespaceLabelKey] = sr.GetNamespace()
 			kubeconfigSecret1.Labels[toolchainv1alpha1.SpaceRequestProvisionedNamespaceLabelKey] = "jane-env1"
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace, kubeconfigSecret1), "member-1", corev1.ConditionTrue)
-			clienttest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
+			commontest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
 				Name:      toolchainv1alpha1.AdminServiceAccountName,
 				Namespace: "jane-env1",
 			},
@@ -349,7 +350,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
 			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
-			hostClient.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			hostClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 				if _, ok := list.(*toolchainv1alpha1.SpaceList); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -469,7 +470,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
 			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
-			hostClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			hostClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.NSTemplateTier); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -489,7 +490,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
 			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
-			hostClient.MockCreate = func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+			hostClient.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -600,7 +601,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
 			hostClient := test.NewFakeClient(t, appstudioTier)
-			hostClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			hostClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -750,7 +751,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 				}}),
 				spacetest.WithTierName("appstudio"))
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-1", corev1.ConditionTrue)
-			clienttest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
+			commontest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
 				Name:      toolchainv1alpha1.AdminServiceAccountName,
 				Namespace: "jane-env",
 			})
@@ -787,7 +788,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
 			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace, subSpace)
-			hostClient.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			hostClient.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -940,7 +941,7 @@ func TestDeleteSpaceRequest(t *testing.T) {
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()),
 				spacetest.WithSpecParentSpace("jane"))
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
-			member1Client.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			member1Client.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.SpaceRequest); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -960,7 +961,7 @@ func TestDeleteSpaceRequest(t *testing.T) {
 		t.Run("failed to remove finalizer", func(t *testing.T) {
 			// given
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
-			member1Client.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			member1Client.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.SpaceRequest); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -982,7 +983,7 @@ func TestDeleteSpaceRequest(t *testing.T) {
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
 			hostClient := test.NewFakeClient(t, appstudioTier)
-			hostClient.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			hostClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 				if _, ok := list.(*toolchainv1alpha1.SpaceList); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -1006,7 +1007,7 @@ func TestDeleteSpaceRequest(t *testing.T) {
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
 			hostClient := test.NewFakeClient(t, appstudioTier, subSpace)
-			hostClient.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+			hostClient.MockDelete = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.DeleteOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 					return fmt.Errorf("mock error")
 				}
@@ -1024,14 +1025,14 @@ func TestDeleteSpaceRequest(t *testing.T) {
 	})
 }
 
-func newReconciler(t *testing.T, hostCl client.Client, memberClusters ...*commoncluster.CachedToolchainCluster) *spacerequest.Reconciler {
+func newReconciler(t *testing.T, hostCl runtimeclient.Client, memberClusters ...*commoncluster.CachedToolchainCluster) *spacerequest.Reconciler {
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
 
 	clusters := map[string]cluster.Cluster{}
 	for _, c := range memberClusters {
-		restClient, err := clienttest.NewRESTClient("fake_secret", c.APIEndpoint)
+		restClient, err := commontest.NewRESTClient("fake_secret", c.APIEndpoint)
 		restClient.Client.Transport = gock.DefaultTransport // make sure that the underlying client's request are intercepted by Gock
 		require.NoError(t, err)
 		clusters[c.Name] = cluster.Cluster{
@@ -1094,8 +1095,8 @@ func newNamespace(owner string) *corev1.Namespace {
 	return ns
 }
 
-func mockGetSpaceRequestFail(cl client.Client) func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	return func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+func mockGetSpaceRequestFail(cl runtimeclient.Client) func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
+	return func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 		if _, ok := obj.(*toolchainv1alpha1.SpaceRequest); ok {
 			return fmt.Errorf("mock error")
 		}
@@ -1103,8 +1104,8 @@ func mockGetSpaceRequestFail(cl client.Client) func(ctx context.Context, key cli
 	}
 }
 
-func mockUpdateSpaceRequestFail(cl client.Client) func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	return func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+func mockUpdateSpaceRequestFail(cl runtimeclient.Client) func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
+	return func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 		if _, ok := obj.(*toolchainv1alpha1.SpaceRequest); ok {
 			return fmt.Errorf("mock error")
 		}

--- a/controllers/toolchainconfig/configuration.go
+++ b/controllers/toolchainconfig/configuration.go
@@ -9,7 +9,7 @@ import (
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -31,7 +31,7 @@ type ToolchainConfig struct {
 
 // GetToolchainConfig returns a ToolchainConfig using the cache, or if the cache was not initialized
 // then retrieves the latest config using the provided client and updates the cache
-func GetToolchainConfig(cl client.Client) (ToolchainConfig, error) {
+func GetToolchainConfig(cl runtimeclient.Client) (ToolchainConfig, error) {
 	config, secrets, err := commonconfig.GetConfig(cl, &toolchainv1alpha1.ToolchainConfig{})
 	if err != nil {
 		// return default config
@@ -48,7 +48,7 @@ func GetCachedToolchainConfig() ToolchainConfig {
 }
 
 // ForceLoadToolchainConfig updates the cache using the provided client and returns the latest ToolchainConfig
-func ForceLoadToolchainConfig(cl client.Client) (ToolchainConfig, error) {
+func ForceLoadToolchainConfig(cl runtimeclient.Client) (ToolchainConfig, error) {
 	config, secrets, err := commonconfig.LoadLatest(cl, &toolchainv1alpha1.ToolchainConfig{})
 	if err != nil {
 		// return default config

--- a/controllers/toolchainconfig/configuration_test.go
+++ b/controllers/toolchainconfig/configuration_test.go
@@ -10,10 +10,10 @@ import (
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestGetToolchainConfig(t *testing.T) {
@@ -82,7 +82,7 @@ func TestGetToolchainConfig(t *testing.T) {
 		commonconfig.ResetCache()
 		toolchainCfgObj := testconfig.NewToolchainConfigObj(t, testconfig.Environment("e2e-tests"))
 		cl := test.NewFakeClient(t, toolchainCfgObj)
-		cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+		cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 			return fmt.Errorf("get failed")
 		}
 
@@ -189,7 +189,7 @@ func TestForceLoadToolchainConfig(t *testing.T) {
 		commonconfig.ResetCache()
 		toolchainCfgObj := testconfig.NewToolchainConfigObj(t, testconfig.Environment("e2e-tests"))
 		cl := test.NewFakeClient(t, toolchainCfgObj)
-		cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+		cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 			return fmt.Errorf("get failed")
 		}
 

--- a/controllers/toolchainconfig/mapper.go
+++ b/controllers/toolchainconfig/mapper.go
@@ -4,7 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -13,8 +13,8 @@ type SecretToToolchainConfigMapper struct{}
 var mapperLog = ctrl.Log.WithName("SecretToToolchainConfigMapper")
 
 // MapSecretToToolchainConfig maps secrets to the singular instance of ToolchainConfig named "config"
-func MapSecretToToolchainConfig() func(object client.Object) []reconcile.Request {
-	return func(obj client.Object) []reconcile.Request {
+func MapSecretToToolchainConfig() func(object runtimeclient.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
 		if secret, ok := obj.(*corev1.Secret); ok {
 			mapperLog.Info("Secret mapped to ToolchainConfig", "name", secret.Name)
 			return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: secret.Namespace, Name: "config"}}}

--- a/controllers/toolchainconfig/mapper_test.go
+++ b/controllers/toolchainconfig/mapper_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/toolchainconfig/sync_test.go
+++ b/controllers/toolchainconfig/sync_test.go
@@ -11,13 +11,13 @@ import (
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestSyncMemberConfigs(t *testing.T) {
@@ -50,7 +50,7 @@ func TestSyncMemberConfigs(t *testing.T) {
 				testconfig.Members().SpecificPerMemberCluster("member2", specificMemberConfig.Spec))
 			s := toolchainconfig.NewSynchronizer(
 				ctrl.Log.WithName("controllers").WithName("ToolchainConfig"),
-				NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue)),
+				NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue)),
 			)
 
 			// when
@@ -66,7 +66,7 @@ func TestSyncMemberConfigs(t *testing.T) {
 		t.Run("sync to a member failed", func(t *testing.T) {
 			// given
 			memberCl := test.NewFakeClient(t)
-			memberCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+			memberCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				return fmt.Errorf("client error")
 			}
 			toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
@@ -74,7 +74,7 @@ func TestSyncMemberConfigs(t *testing.T) {
 				testconfig.Members().SpecificPerMemberCluster("member2", specificMemberConfig.Spec))
 			s := toolchainconfig.NewSynchronizer(
 				ctrl.Log.WithName("controllers").WithName("ToolchainConfig"),
-				NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithClient(memberCl, "member2", v1.ConditionTrue)),
+				NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithClient(memberCl, "member2", corev1.ConditionTrue)),
 			)
 
 			// when
@@ -88,11 +88,11 @@ func TestSyncMemberConfigs(t *testing.T) {
 		t.Run("sync to multiple members failed", func(t *testing.T) {
 			// given
 			memberCl := test.NewFakeClient(t)
-			memberCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+			memberCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				return fmt.Errorf("client error")
 			}
 			memberCl2 := test.NewFakeClient(t)
-			memberCl2.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+			memberCl2.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				return fmt.Errorf("client2 error")
 			}
 			toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
@@ -100,7 +100,7 @@ func TestSyncMemberConfigs(t *testing.T) {
 				testconfig.Members().SpecificPerMemberCluster("member2", specificMemberConfig.Spec))
 			s := toolchainconfig.NewSynchronizer(
 				ctrl.Log.WithName("controllers").WithName("ToolchainConfig"),
-				NewGetMemberClusters(NewMemberClusterWithClient(memberCl, "member1", v1.ConditionTrue), NewMemberClusterWithClient(memberCl2, "member2", v1.ConditionTrue)),
+				NewGetMemberClusters(NewMemberClusterWithClient(memberCl, "member1", corev1.ConditionTrue), NewMemberClusterWithClient(memberCl2, "member2", corev1.ConditionTrue)),
 			)
 
 			// when
@@ -120,7 +120,7 @@ func TestSyncMemberConfigs(t *testing.T) {
 				testconfig.Members().SpecificPerMemberCluster("member2", specificMemberConfig.Spec))
 			s := toolchainconfig.NewSynchronizer(
 				ctrl.Log.WithName("controllers").WithName("ToolchainConfig"),
-				NewGetMemberClusters(NewMemberClusterWithClient(memberCl, "member1", v1.ConditionTrue)),
+				NewGetMemberClusters(NewMemberClusterWithClient(memberCl, "member1", corev1.ConditionTrue)),
 			)
 
 			// when
@@ -139,7 +139,7 @@ func TestSyncMemberConfig(t *testing.T) {
 		t.Run("memberoperatorconfig created", func(t *testing.T) {
 			// given
 			memberCl := test.NewFakeClient(t)
-			memberCluster := NewMemberClusterWithClient(memberCl, "member1", v1.ConditionTrue)
+			memberCluster := NewMemberClusterWithClient(memberCl, "member1", corev1.ConditionTrue)
 			memberConfig := testconfig.NewMemberOperatorConfigObj(testconfig.MemberStatus().RefreshPeriod("5s"))
 
 			// when
@@ -157,7 +157,7 @@ func TestSyncMemberConfig(t *testing.T) {
 			// given
 			originalConfig := testconfig.NewMemberOperatorConfigObj(testconfig.MemberStatus().RefreshPeriod("10s"))
 			memberCl := test.NewFakeClient(t, originalConfig)
-			memberCluster := NewMemberClusterWithClient(memberCl, "member1", v1.ConditionTrue)
+			memberCluster := NewMemberClusterWithClient(memberCl, "member1", corev1.ConditionTrue)
 			memberConfig := testconfig.NewMemberOperatorConfigObj(testconfig.MemberStatus().RefreshPeriod("5s"))
 
 			// when
@@ -176,10 +176,10 @@ func TestSyncMemberConfig(t *testing.T) {
 		t.Run("client get error", func(t *testing.T) {
 			// given
 			memberCl := test.NewFakeClient(t)
-			memberCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+			memberCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				return fmt.Errorf("client error")
 			}
-			memberCluster := NewMemberClusterWithClient(memberCl, "member1", v1.ConditionTrue)
+			memberCluster := NewMemberClusterWithClient(memberCl, "member1", corev1.ConditionTrue)
 			memberConfig := testconfig.NewMemberOperatorConfigObj(testconfig.MemberStatus().RefreshPeriod("5s"))
 
 			// when
@@ -196,10 +196,10 @@ func TestSyncMemberConfig(t *testing.T) {
 			// given
 			originalConfig := testconfig.NewMemberOperatorConfigObj(testconfig.MemberStatus().RefreshPeriod("10s"))
 			memberCl := test.NewFakeClient(t, originalConfig)
-			memberCl.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+			memberCl.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 				return fmt.Errorf("client update error")
 			}
-			memberCluster := NewMemberClusterWithClient(memberCl, "member1", v1.ConditionTrue)
+			memberCluster := NewMemberClusterWithClient(memberCl, "member1", corev1.ConditionTrue)
 			memberConfig := testconfig.NewMemberOperatorConfigObj(testconfig.MemberStatus().RefreshPeriod("5s"))
 
 			// when

--- a/controllers/toolchainconfig/toolchainconfig_controller.go
+++ b/controllers/toolchainconfig/toolchainconfig_controller.go
@@ -6,29 +6,25 @@ import (
 	"os"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-
-	"github.com/go-logr/logr"
-	templatev1 "github.com/openshift/api/template/v1"
-	errs "github.com/pkg/errors"
-
-	"github.com/codeready-toolchain/host-operator/pkg/templates/registrationservice"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/templates/registrationservice"
 	applycl "github.com/codeready-toolchain/toolchain-common/pkg/client"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
+	"github.com/go-logr/logr"
+	templatev1 "github.com/openshift/api/template/v1"
+	errs "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -61,7 +57,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 // Reconciler reconciles a ToolchainConfig object
 type Reconciler struct {
-	Client             client.Client
+	Client             runtimeclient.Client
 	GetMembersFunc     cluster.GetMemberClustersFunc
 	Scheme             *runtime.Scheme
 	RegServiceTemplate *templatev1.Template

--- a/controllers/toolchainconfig/toolchainconfig_controller_test.go
+++ b/controllers/toolchainconfig/toolchainconfig_controller_test.go
@@ -18,11 +18,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -36,8 +36,8 @@ func TestReconcile(t *testing.T) {
 
 		t.Run("config not found", func(t *testing.T) {
 			hostCl := test.NewFakeClient(t)
-			member1 := NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue)
-			member2 := NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue)
+			member1 := NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue)
+			member2 := NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue)
 			members := NewGetMemberClusters(member1, member2)
 			controller := newController(t, hostCl, members)
 
@@ -71,8 +71,8 @@ func TestReconcile(t *testing.T) {
 				testconfig.Members().Default(defaultMemberConfig.Spec),
 				testconfig.Members().SpecificPerMemberCluster("member1", specificMemberConfig.Spec))
 			hostCl := test.NewFakeClient(t, config)
-			member1 := NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue)
-			member2 := NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue)
+			member1 := NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue)
+			member2 := NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue)
 			members := NewGetMemberClusters(member1, member2)
 			controller := newController(t, hostCl, members)
 
@@ -151,7 +151,7 @@ func TestReconcile(t *testing.T) {
 				config.Spec.Host.CapacityThresholds.ResourceCapacityThreshold.DefaultThreshold = &threshold
 				err = hostCl.Update(context.TODO(), config)
 				require.NoError(t, err)
-				hostCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+				hostCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 					return fmt.Errorf("client error")
 				}
 
@@ -190,9 +190,9 @@ func TestReconcile(t *testing.T) {
 				testconfig.Members().Default(defaultMemberConfig.Spec),
 				testconfig.Members().SpecificPerMemberCluster("member1", specificMemberConfig.Spec))
 			hostCl := test.NewFakeClient(t, config)
-			members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+			members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 			controller := newController(t, hostCl, members)
-			hostCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+			hostCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				_, ok := obj.(*toolchainv1alpha1.ToolchainConfig)
 				if ok {
 					return fmt.Errorf("client error")
@@ -219,10 +219,10 @@ func TestReconcile(t *testing.T) {
 				testconfig.Members().Default(defaultMemberConfig.Spec),
 				testconfig.Members().SpecificPerMemberCluster("member1", specificMemberConfig.Spec))
 			hostCl := test.NewFakeClient(t, config)
-			members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+			members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 			controller := newController(t, hostCl, members)
 			count := 0
-			hostCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+			hostCl.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.ToolchainConfig); ok {
 					count++
 					if count > 1 { // let the first get succeed and then return errors after that
@@ -249,10 +249,10 @@ func TestReconcile(t *testing.T) {
 				testconfig.AutomaticApproval().Enabled(true),
 				testconfig.CapacityThresholds().MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 321)))
 			hostCl := test.NewFakeClient(t, config)
-			hostCl.MockCreate = func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+			hostCl.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
 				return fmt.Errorf("create error")
 			}
-			members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+			members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 			controller := newController(t, hostCl, members)
 
 			// when
@@ -277,7 +277,7 @@ func TestReconcile(t *testing.T) {
 			config := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true), testconfig.Members().Default(defaultMemberConfig.Spec), testconfig.Members().SpecificPerMemberCluster("missing-member", specificMemberConfig.Spec),
 				testconfig.CapacityThresholds().MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 321)))
 			hostCl := test.NewFakeClient(t, config)
-			members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+			members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 			controller := newController(t, hostCl, members)
 
 			// when
@@ -306,7 +306,7 @@ func TestWrapErrorWithUpdateStatus(t *testing.T) {
 	config := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true),
 		testconfig.CapacityThresholds().MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 321)))
 	hostCl := test.NewFakeClient(t, config)
-	members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+	members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 	controller := newController(t, hostCl, members)
 	log := logf.Log.WithName("test")
 
@@ -361,7 +361,7 @@ func matchesDefaultConfig(t *testing.T, actual toolchainconfig.ToolchainConfig) 
 	assert.Equal(t, 3, actual.Deactivation().DeactivatingNotificationDays())
 }
 
-func newController(t *testing.T, hostCl client.Client, members cluster.GetMemberClustersFunc) toolchainconfig.Reconciler {
+func newController(t *testing.T, hostCl runtimeclient.Client, members cluster.GetMemberClustersFunc) toolchainconfig.Reconciler {
 	os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs)
 	s := clientgoscheme.Scheme
 	err := apis.AddToScheme(s)

--- a/controllers/toolchainstatus/creation.go
+++ b/controllers/toolchainstatus/creation.go
@@ -5,11 +5,11 @@ import (
 	commonclient "github.com/codeready-toolchain/toolchain-common/pkg/client"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // CreateOrUpdateResources creates a toolchainstatus resource with the given name in the given namespace
-func CreateOrUpdateResources(client client.Client, namespace, toolchainStatusName string) error {
+func CreateOrUpdateResources(client runtimeclient.Client, namespace, toolchainStatusName string) error {
 	toolchainStatus := &toolchainv1alpha1.ToolchainStatus{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,

--- a/controllers/toolchainstatus/creation_test.go
+++ b/controllers/toolchainstatus/creation_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	. "github.com/codeready-toolchain/host-operator/test"
-	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"github.com/stretchr/testify/require"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestCreateOrUpdateResources(t *testing.T) {
@@ -24,27 +24,27 @@ func TestCreateOrUpdateResources(t *testing.T) {
 
 	t.Run("creation", func(t *testing.T) {
 		// given
-		cl := NewFakeClient(t)
+		cl := commontest.NewFakeClient(t)
 
 		// when
-		err = CreateOrUpdateResources(cl, HostOperatorNs, name)
+		err = CreateOrUpdateResources(cl, commontest.HostOperatorNs, name)
 
 		// then
 		require.NoError(t, err)
 
 		// check that the MemberStatus exists now
-		AssertThatToolchainStatus(t, HostOperatorNs, name, cl).Exists()
+		AssertThatToolchainStatus(t, commontest.HostOperatorNs, name, cl).Exists()
 	})
 
 	t.Run("should return an error if creation fails ", func(t *testing.T) {
 		// given
-		cl := NewFakeClient(t)
-		cl.MockCreate = func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+		cl := commontest.NewFakeClient(t)
+		cl.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
 			return fmt.Errorf("creation failed")
 		}
 
 		// when
-		err = CreateOrUpdateResources(cl, HostOperatorNs, name)
+		err = CreateOrUpdateResources(cl, commontest.HostOperatorNs, name)
 
 		// then
 		require.Error(t, err)

--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -113,7 +113,7 @@ type HTTPClient interface {
 
 // Reconciler reconciles a ToolchainStatus object
 type Reconciler struct {
-	Client         client.Client
+	Client         runtimeclient.Client
 	Scheme         *runtime.Scheme
 	GetMembersFunc cluster.GetMemberClustersFunc
 	HTTPClientImpl HTTPClient
@@ -751,7 +751,7 @@ func customMemberStatus(conditions ...toolchainv1alpha1.Condition) toolchainv1al
 
 type regServiceSubstatusHandler struct {
 	httpClientImpl   HTTPClient
-	controllerClient client.Client
+	controllerClient runtimeclient.Client
 }
 
 // addRegistrationServiceDeploymentStatus handles the RegistrationService.Deployment part of the toolchainstatus

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/status"
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 
 	"github.com/stretchr/testify/assert"
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -138,7 +138,7 @@ func TestNoToolchainStatusFound(t *testing.T) {
 		// given
 		requestName := toolchainconfig.ToolchainStatusName
 		reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), []string{"member-1", "member-2"})
-		fakeClient.MockGet = func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+		fakeClient.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 			if _, ok := obj.(*toolchainv1alpha1.ToolchainStatus); ok {
 				return fmt.Errorf("get failed")
 			}
@@ -679,7 +679,7 @@ func TestToolchainStatusConditions(t *testing.T) {
 			memberStatus := newMemberStatus(ready())
 			reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), []string{"member-1", "member-2"},
 				hostOperatorDeployment, memberStatus, registrationServiceDeployment, emptyToolchainStatus, proxyRoute())
-			fakeClient.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			fakeClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 				return fmt.Errorf("some error")
 			}
 
@@ -1122,7 +1122,7 @@ func overrideLastTransitionTime(t *testing.T, toolchainStatus *toolchainv1alpha1
 
 func assertToolchainStatusNotificationCreated(t *testing.T, fakeClient *test.FakeClient) *toolchainv1alpha1.Notification {
 	notifications := &toolchainv1alpha1.NotificationList{}
-	err := fakeClient.List(context.Background(), notifications, &client.ListOptions{
+	err := fakeClient.List(context.Background(), notifications, &runtimeclient.ListOptions{
 		Namespace: test.HostOperatorNs,
 	})
 	require.NoError(t, err)
@@ -1132,7 +1132,7 @@ func assertToolchainStatusNotificationCreated(t *testing.T, fakeClient *test.Fak
 
 func assertToolchainStatusNotificationNotCreated(t *testing.T, fakeClient *test.FakeClient, notificationType string) {
 	notifications := &toolchainv1alpha1.NotificationList{}
-	err := fakeClient.List(context.Background(), notifications, &client.ListOptions{
+	err := fakeClient.List(context.Background(), notifications, &runtimeclient.ListOptions{
 		Namespace: test.HostOperatorNs,
 	})
 	require.NoError(t, err)
@@ -1472,7 +1472,7 @@ func newDeploymentWithConditions(deploymentName string, deploymentConditions ...
 	}
 }
 
-func cachedToolchainCluster(cl client.Client, name string, status corev1.ConditionStatus, lastProbeTime metav1.Time) *cluster.CachedToolchainCluster {
+func cachedToolchainCluster(cl runtimeclient.Client, name string, status corev1.ConditionStatus, lastProbeTime metav1.Time) *cluster.CachedToolchainCluster {
 	return &cluster.CachedToolchainCluster{
 		Config: &cluster.Config{
 			Name:              name,

--- a/controllers/usersignup/approval.go
+++ b/controllers/usersignup/approval.go
@@ -6,8 +6,9 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/capacity"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+
 	"github.com/pkg/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type targetCluster string
@@ -29,7 +30,7 @@ func (c targetCluster) getClusterName() string {
 // If the user is not approved manually, then it loads ToolchainConfig to check if automatic approval is enabled or not. If it is then it checks
 // capacity thresholds and the actual use if there is any suitable member cluster. If it is not then it returns false as the first value and
 // targetCluster unknown as the second value.
-func getClusterIfApproved(cl client.Client, userSignup *toolchainv1alpha1.UserSignup, clusterManager *capacity.ClusterManager) (bool, targetCluster, error) {
+func getClusterIfApproved(cl runtimeclient.Client, userSignup *toolchainv1alpha1.UserSignup, clusterManager *capacity.ClusterManager) (bool, targetCluster, error) {
 	config, err := toolchainconfig.GetToolchainConfig(cl)
 	if err != nil {
 		return false, unknown, errors.Wrapf(err, "unable to get ToolchainConfig")

--- a/controllers/usersignup/approval_test.go
+++ b/controllers/usersignup/approval_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	. "github.com/codeready-toolchain/host-operator/test"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
-	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestGetClusterIfApproved(t *testing.T) {
@@ -46,7 +47,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
@@ -66,7 +67,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 			testconfig.AutomaticApproval().
 				Enabled(true),
 		)
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(
 			NewMemberClusterWithoutClusterRoles(t, "member1", corev1.ConditionTrue), // no cluster-role label on this member
@@ -91,7 +92,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.AutomaticApproval().
 				Enabled(true))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(
 			// member1 doesn't have the cluster-role tenant but it's preferred one
@@ -113,7 +114,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.AutomaticApproval().
 				Enabled(true))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters()
 
@@ -128,7 +129,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 
 	t.Run("automatic approval not enabled and user not approved", func(t *testing.T) {
 		// given
-		fakeClient := NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t))
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t))
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
@@ -143,7 +144,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 
 	t.Run("ToolchainConfig not found and user not approved", func(t *testing.T) {
 		// given
-		fakeClient := NewFakeClient(t, toolchainStatus)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
@@ -158,7 +159,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 
 	t.Run("ToolchainConfig not found and user manually approved without target cluster", func(t *testing.T) {
 		// given
-		fakeClient := NewFakeClient(t, toolchainStatus)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
@@ -177,7 +178,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().ResourceCapacityThreshold(50),
 		)
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
@@ -197,7 +198,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 2000)).
 				ResourceCapacityThreshold(62))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
@@ -215,7 +216,7 @@ func TestGetClusterIfApproved(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually(), commonsignup.WithTargetCluster("member1"))
@@ -232,9 +233,9 @@ func TestGetClusterIfApproved(t *testing.T) {
 	t.Run("failures", func(t *testing.T) {
 		t.Run("unable to get ToolchainConfig", func(t *testing.T) {
 			// given
-			fakeClient := NewFakeClient(t, toolchainStatus)
+			fakeClient := commontest.NewFakeClient(t, toolchainStatus)
 			InitializeCounters(t, toolchainStatus)
-			fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				return fmt.Errorf("some error")
 			}
 			InitializeCounters(t, toolchainStatus)
@@ -251,8 +252,8 @@ func TestGetClusterIfApproved(t *testing.T) {
 
 		t.Run("unable to read ToolchainStatus", func(t *testing.T) {
 			// given
-			fakeClient := NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
-			fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			fakeClient := commontest.NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
+			fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.ToolchainStatus); ok {
 					return fmt.Errorf("some error")
 				}

--- a/controllers/usersignup/mapper.go
+++ b/controllers/usersignup/mapper.go
@@ -5,21 +5,22 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func MapBannedUserToUserSignup(cl client.Client) func(object client.Object) []reconcile.Request {
+func MapBannedUserToUserSignup(cl runtimeclient.Client) func(object runtimeclient.Object) []reconcile.Request {
 	var logger = ctrl.Log.WithName("BannedUserToUserSignupMapper")
-	return func(obj client.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
 		if bu, ok := obj.(*toolchainv1alpha1.BannedUser); ok {
 			// look-up any associated UserSignup using the BannedUser's "toolchain.dev.openshift.com/email-hash" label
 			if emailHashLbl, exists := bu.Labels[toolchainv1alpha1.BannedUserEmailHashLabelKey]; exists {
 
 				labels := map[string]string{toolchainv1alpha1.UserSignupUserEmailHashLabelKey: emailHashLbl}
-				opts := client.MatchingLabels(labels)
+				opts := runtimeclient.MatchingLabels(labels)
 				userSignupList := &toolchainv1alpha1.UserSignupList{}
 				if err := cl.List(context.TODO(), userSignupList, opts); err != nil {
 					logger.Error(err, "Could not list UserSignup resources with label value", toolchainv1alpha1.UserSignupUserEmailHashLabelKey, emailHashLbl)

--- a/controllers/usersignup/mapper_test.go
+++ b/controllers/usersignup/mapper_test.go
@@ -3,17 +3,17 @@ package usersignup
 import (
 	"context"
 	"errors"
-	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestBannedUserToUserSignupMapper(t *testing.T) {
@@ -63,7 +63,7 @@ func TestBannedUserToUserSignupMapper(t *testing.T) {
 
 	t.Run("test BannedUserToUserSignupMapper returns nil when client list fails", func(t *testing.T) {
 		c := test.NewFakeClient(t)
-		c.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+		c.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 			return errors.New("err happened")
 		}
 

--- a/controllers/usersignup/masteruserrecord_test.go
+++ b/controllers/usersignup/masteruserrecord_test.go
@@ -3,11 +3,11 @@ package usersignup
 import (
 	"testing"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	commonmur "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	testusertier "github.com/codeready-toolchain/host-operator/test/usertier"
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/controllers/usersignup/predicate.go
+++ b/controllers/usersignup/predicate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	runtimeevent "sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	controllerpredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -47,7 +47,7 @@ var configLog = logf.Log.WithName("automatic_approval_predicate")
 
 // OnlyWhenAutomaticApprovalIsEnabled let the reconcile to be triggered only when the automatic approval is enabled
 type OnlyWhenAutomaticApprovalIsEnabled struct {
-	client client.Client
+	client runtimeclient.Client
 }
 
 // Update implements default UpdateEvent filter for validating no generation change

--- a/controllers/usersignup/spacebinding_test.go
+++ b/controllers/usersignup/spacebinding_test.go
@@ -3,13 +3,13 @@ package usersignup
 import (
 	"testing"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	. "github.com/codeready-toolchain/host-operator/pkg/space"
 	tiertest "github.com/codeready-toolchain/host-operator/test/nstemplatetier"
 	"github.com/codeready-toolchain/toolchain-common/pkg/spacebinding"
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/controllers/usersignup/status_updater.go
+++ b/controllers/usersignup/status_updater.go
@@ -9,11 +9,11 @@ import (
 	"github.com/go-logr/logr"
 	errs "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type StatusUpdater struct {
-	Client client.Client
+	Client runtimeclient.Client
 }
 
 func (u *StatusUpdater) setStatusApprovedAutomatically(userSignup *toolchainv1alpha1.UserSignup, message string) error {

--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -241,7 +241,7 @@ func (r *Reconciler) isUserBanned(reqLogger logr.Logger, userSignup *toolchainv1
 		if emailHashLbl, exists := userSignup.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey]; exists {
 
 			labels := map[string]string{toolchainv1alpha1.BannedUserEmailHashLabelKey: emailHashLbl}
-			opts := client.MatchingLabels(labels)
+			opts := runtimeclient.MatchingLabels(labels)
 			bannedUserList := &toolchainv1alpha1.BannedUserList{}
 
 			// Query BannedUser for resources that match the same email hash
@@ -285,7 +285,7 @@ func (r *Reconciler) checkIfMurAlreadyExists(reqLogger logr.Logger, config toolc
 	// List all MasterUserRecord resources that have an owner label equal to the UserSignup.Name
 	murList := &toolchainv1alpha1.MasterUserRecordList{}
 	labels := map[string]string{toolchainv1alpha1.MasterUserRecordOwnerLabelKey: userSignup.Name}
-	opts := client.MatchingLabels(labels)
+	opts := runtimeclient.MatchingLabels(labels)
 	if err := r.Client.List(context.TODO(), murList, opts); err != nil {
 		return false, r.wrapErrorWithStatusUpdate(reqLogger, userSignup, r.setStatusInvalidMURState, err,
 			"Failed to list MasterUserRecords by owner")
@@ -651,7 +651,7 @@ func (r *Reconciler) ensureSpaceBinding(logger logr.Logger, userSignup *toolchai
 		toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: mur.Name,
 		toolchainv1alpha1.SpaceBindingSpaceLabelKey:            space.Name,
 	}
-	opts := client.MatchingLabels(labels)
+	opts := runtimeclient.MatchingLabels(labels)
 	if err := r.Client.List(context.TODO(), spaceBindings, opts); err != nil {
 		return errs.Wrap(err, fmt.Sprintf(`attempt to list SpaceBinding associated with mur '%s' and space '%s' failed`, mur.Name, space.Name))
 	}
@@ -725,7 +725,7 @@ func (r *Reconciler) sendDeactivatingNotification(logger logr.Logger, config too
 		toolchainv1alpha1.NotificationUserNameLabelKey: userSignup.Status.CompliantUsername,
 		toolchainv1alpha1.NotificationTypeLabelKey:     toolchainv1alpha1.NotificationTypeDeactivating,
 	}
-	opts := client.MatchingLabels(labels)
+	opts := runtimeclient.MatchingLabels(labels)
 	notificationList := &toolchainv1alpha1.NotificationList{}
 	if err := r.Client.List(context.TODO(), notificationList, opts); err != nil {
 		return err
@@ -761,7 +761,7 @@ func (r *Reconciler) sendDeactivatedNotification(logger logr.Logger, config tool
 		toolchainv1alpha1.NotificationUserNameLabelKey: userSignup.Status.CompliantUsername,
 		toolchainv1alpha1.NotificationTypeLabelKey:     toolchainv1alpha1.NotificationTypeDeactivated,
 	}
-	opts := client.MatchingLabels(labels)
+	opts := runtimeclient.MatchingLabels(labels)
 	notificationList := &toolchainv1alpha1.NotificationList{}
 	if err := r.Client.List(context.TODO(), notificationList, opts); err != nil {
 		return err

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/codeready-toolchain/host-operator/pkg/space"
 
 	"github.com/codeready-toolchain/host-operator/pkg/capacity"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -32,7 +33,6 @@ import (
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	commonsocialevent "github.com/codeready-toolchain/toolchain-common/pkg/socialevent"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
-	test "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	testsocialevent "github.com/codeready-toolchain/toolchain-common/pkg/test/socialevent"
@@ -40,12 +40,12 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -60,7 +60,7 @@ var event = testsocialevent.NewSocialEvent(test.HostOperatorNs, commonsocialeven
 	testsocialevent.WithSpaceTier(base2NSTemplateTier.Name))
 
 func TestUserSignupCreateMUROk(t *testing.T) {
-	member := NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue)
+	member := NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue)
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	for testname, userSignup := range map[string]*toolchainv1alpha1.UserSignup{
 		"manually approved with valid activation annotation": commonsignup.NewUserSignup(
@@ -191,7 +191,7 @@ func TestUserSignupCreateMUROk(t *testing.T) {
 }
 
 func TestUserSignupCreateSpaceAndSpaceBindingOk(t *testing.T) {
-	member := NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue)
+	member := NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue)
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	for testname, userSignup := range map[string]*toolchainv1alpha1.UserSignup{
 		"without skip space creation annotation": commonsignup.NewUserSignup(
@@ -282,7 +282,7 @@ func TestUserSignupCreateSpaceAndSpaceBindingOk(t *testing.T) {
 
 func TestDeletingUserSignupShouldNotUpdateMetrics(t *testing.T) {
 	// given
-	member := NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue)
+	member := NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue)
 	defer counter.Reset()
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	userSignup := commonsignup.NewUserSignup(
@@ -326,7 +326,7 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup()
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -369,17 +369,17 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedAutomatically",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 
@@ -433,21 +433,21 @@ func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserNotInPreDeactivation",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserIsActive",
 				})
 		})
@@ -465,7 +465,7 @@ func TestUserSignupWithMissingEmailAnnotationFails(t *testing.T) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	userSignup := commonsignup.NewUserSignup(commonsignup.WithoutAnnotations())
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup,
 		commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier)
 	InitializeCounters(t, NewToolchainStatus(
@@ -492,7 +492,7 @@ func TestUserSignupWithMissingEmailAnnotationFails(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  v1.ConditionFalse,
+			Status:  corev1.ConditionFalse,
 			Reason:  "MissingUserEmailAnnotation",
 			Message: "missing annotation at usersignup",
 		})
@@ -514,7 +514,7 @@ func TestUserSignupWithInvalidEmailHashLabelFails(t *testing.T) {
 		commonsignup.WithAnnotation(toolchainv1alpha1.UserSignupUserEmailAnnotationKey, "foo@redhat.com"),
 	)
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -540,7 +540,7 @@ func TestUserSignupWithInvalidEmailHashLabelFails(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  v1.ConditionFalse,
+			Status:  corev1.ConditionFalse,
 			Reason:  "InvalidEmailHashLabel",
 			Message: "hash is invalid",
 		})
@@ -557,9 +557,9 @@ func TestUpdateOfApprovedLabelFails(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup()
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, fakeClient := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier)
-	fakeClient.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	fakeClient.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 		return fmt.Errorf("some error")
 	}
 	InitializeCounters(t, NewToolchainStatus(
@@ -584,7 +584,7 @@ func TestUpdateOfApprovedLabelFails(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  v1.ConditionFalse,
+			Status:  corev1.ConditionFalse,
 			Reason:  "UnableToUpdateStateLabel",
 			Message: "some error",
 		})
@@ -607,7 +607,7 @@ func TestUserSignupWithMissingEmailHashLabelFails(t *testing.T) {
 	}
 	userSignup.Labels = map[string]string{"toolchain.dev.openshift.com/approved": "false"}
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -633,7 +633,7 @@ func TestUserSignupWithMissingEmailHashLabelFails(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  v1.ConditionFalse,
+			Status:  corev1.ConditionFalse,
 			Reason:  "MissingEmailHashLabel",
 			Message: "missing label at usersignup",
 		})
@@ -653,7 +653,7 @@ func TestNonDefaultNSTemplateTier(t *testing.T) {
 	customUserTier := testusertier.NewUserTier("custom", 120)
 	config := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true), testconfig.Tiers().DefaultUserTier("custom"), testconfig.Tiers().DefaultSpaceTier("custom"))
 	userSignup := commonsignup.NewUserSignup()
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, config, customNSTemplateTier, customUserTier) // use custom tier
 
 	commonconfig.ResetCache() // reset the config cache so that the update config is picked up
@@ -700,17 +700,17 @@ func TestNonDefaultNSTemplateTier(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedAutomatically",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 
@@ -779,10 +779,10 @@ func TestUserSignupFailedMissingTier(t *testing.T) {
 			userSignup.Status.Conditions = append(userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				})
-			ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+			ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 
 			objs := []runtime.Object{userSignup, v.config}
 			if strings.Contains(v.description, "spacetier") { // when testing missing spacetier then create mur and usertier so that the error is about space tier
@@ -813,23 +813,23 @@ func TestUserSignupFailedMissingTier(t *testing.T) {
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 				toolchainv1alpha1.Condition{
 					Type:    toolchainv1alpha1.UserSignupComplete,
-					Status:  v1.ConditionFalse,
+					Status:  corev1.ConditionFalse,
 					Reason:  v.expectedReason,
 					Message: v.expectedMsg,
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserNotInPreDeactivation",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserIsActive",
 				})
 			assert.Equal(t, "approved", userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey])
@@ -853,8 +853,8 @@ func TestUnapprovedUserSignupWhenNoClusterReady(t *testing.T) {
 	userSignup := commonsignup.NewUserSignup()
 
 	notReady := NewGetMemberClusters(
-		NewMemberClusterWithTenantRole(t, "member1", v1.ConditionFalse),
-		NewMemberClusterWithTenantRole(t, "member2", v1.ConditionFalse))
+		NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionFalse),
+		NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionFalse))
 	config := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true),
 		testconfig.CapacityThresholds().MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1)))
 	r, req, _ := prepareReconcile(t, userSignup.Name, notReady, userSignup, config, baseNSTemplateTier)
@@ -880,22 +880,22 @@ func TestUnapprovedUserSignupWhenNoClusterReady(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "PendingApproval",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "NoClusterAvailable",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 
@@ -916,8 +916,8 @@ func TestUserSignupFailedNoClusterWithCapacityAvailable(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup()
 	noCapacity := NewGetMemberClusters(
-		NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue),
-		NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+		NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
+		NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 	config := commonconfig.NewToolchainConfigObjWithReset(t,
 		testconfig.AutomaticApproval().Enabled(true),
 		testconfig.CapacityThresholds().ResourceCapacityThreshold(60))
@@ -944,22 +944,22 @@ func TestUserSignupFailedNoClusterWithCapacityAvailable(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "PendingApproval",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "NoClusterAvailable",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 
@@ -980,7 +980,7 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup(commonsignup.ApprovedManuallyAgo(time.Minute))
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -1013,17 +1013,17 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedByAdmin",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 	AssertThatCountersAndMetrics(t).
@@ -1078,21 +1078,21 @@ func TestUserSignupWithManualApprovalApproved(t *testing.T) {
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedByAdmin",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserNotInPreDeactivation",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserIsActive",
 				})
 			AssertThatCountersAndMetrics(t).
@@ -1114,7 +1114,7 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 
 	config := commonconfig.NewToolchainConfigObjWithReset(t)
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, baseNSTemplateTier, config, deactivate30Tier)
 	InitializeCounters(t, NewToolchainStatus(
@@ -1150,17 +1150,17 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedByAdmin",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 	AssertThatCountersAndMetrics(t).
@@ -1218,21 +1218,21 @@ func TestUserSignupWithNoApprovalPolicyTreatedAsManualApproved(t *testing.T) {
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedByAdmin",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserNotInPreDeactivation",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserIsActive",
 				})
 			AssertThatCountersAndMetrics(t).
@@ -1252,7 +1252,7 @@ func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup()
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t), baseNSTemplateTier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -1283,22 +1283,22 @@ func TestUserSignupWithManualApprovalNotApproved(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "PendingApproval",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "PendingApproval",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 	AssertThatCountersAndMetrics(t).
@@ -1314,7 +1314,7 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup(commonsignup.WithTargetCluster("east"))
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -1351,17 +1351,17 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedAutomatically",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 	AssertThatCountersAndMetrics(t).
@@ -1419,21 +1419,21 @@ func TestUserSignupWithAutoApprovalWithTargetCluster(t *testing.T) {
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserNotInPreDeactivation",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserIsActive",
 				})
 			AssertThatCountersAndMetrics(t).
@@ -1480,22 +1480,22 @@ func TestUserSignupWithMissingApprovalPolicyTreatedAsManual(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "PendingApproval",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "PendingApproval",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 	AssertThatCountersAndMetrics(t).
@@ -1538,7 +1538,7 @@ func TestUserSignupMUROrSpaceOrSpaceBindingCreateFails(t *testing.T) {
 
 			space := NewSpace(userSignup, "member1", "foo", "base")
 
-			ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+			ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 			initObjs := []runtime.Object{userSignup, baseNSTemplateTier, deactivate30Tier}
 			if testcase.testName == "create space error" {
 				// mur must exist first, space is created on the reconcile after the mur is created
@@ -1557,7 +1557,7 @@ func TestUserSignupMUROrSpaceOrSpaceBindingCreateFails(t *testing.T) {
 				}),
 			))
 
-			fakeClient.MockCreate = func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+			fakeClient.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
 				switch obj.(type) {
 				case *toolchainv1alpha1.MasterUserRecord:
 					if testcase.testName == "create mur error" {
@@ -1608,7 +1608,7 @@ func TestUserSignupMURReadFails(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, fakeClient := prepareReconcile(t, userSignup.Name, ready, userSignup)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -1619,7 +1619,7 @@ func TestUserSignupMURReadFails(t *testing.T) {
 		}),
 	))
 
-	fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 		switch obj.(type) {
 		case *toolchainv1alpha1.MasterUserRecord:
 			return errors.New("failed to lookup MUR")
@@ -1654,7 +1654,7 @@ func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
 	userSignup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
 	userSignup.Labels[toolchainv1alpha1.UserSignupStateLabelKey] = "approved"
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, fakeClient := prepareReconcile(t, userSignup.Name, ready, userSignup)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -1665,7 +1665,7 @@ func TestUserSignupSetStatusApprovedByAdminFails(t *testing.T) {
 		}),
 	))
 
-	fakeClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 		switch obj.(type) {
 		case *toolchainv1alpha1.UserSignup:
 			return errors.New("failed to update UserSignup status")
@@ -1700,7 +1700,7 @@ func TestUserSignupSetStatusApprovedAutomaticallyFails(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup()
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, fakeClient := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -1711,7 +1711,7 @@ func TestUserSignupSetStatusApprovedAutomaticallyFails(t *testing.T) {
 		}),
 	))
 
-	fakeClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 		switch obj.(type) {
 		case *toolchainv1alpha1.UserSignup:
 			return errors.New("failed to update UserSignup status")
@@ -1757,7 +1757,7 @@ func TestUserSignupSetStatusNoClustersAvailableFails(t *testing.T) {
 		}),
 	))
 
-	fakeClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 		switch obj := obj.(type) {
 		case *toolchainv1alpha1.UserSignup:
 			for _, cond := range obj.Status.Conditions {
@@ -1824,7 +1824,7 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 
 	spacebinding := spacebindingtest.NewSpaceBinding("foo", "foo", "admin", userSignup.Name)
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, mur, space, spacebinding, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -1874,7 +1874,7 @@ func TestUserSignupWithExistingMUROK(t *testing.T) {
 		require.Equal(t, mur.Name, instance.Status.CompliantUsername)
 		test.AssertContainsCondition(t, instance.Status.Conditions, toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 		})
 		AssertThatCountersAndMetrics(t).
 			HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
@@ -1904,7 +1904,7 @@ func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 		},
 	}
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, mur, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -1986,7 +1986,7 @@ func TestUserSignupWithExistingMURDifferentUserIDOK(t *testing.T) {
 			require.Equal(t, mur.Name, instance.Status.CompliantUsername)
 			cond, found := condition.FindConditionByType(instance.Status.Conditions, toolchainv1alpha1.UserSignupComplete)
 			require.True(t, found)
-			require.Equal(t, v1.ConditionTrue, cond.Status)
+			require.Equal(t, corev1.ConditionTrue, cond.Status)
 			AssertThatCountersAndMetrics(t).
 				HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
 					string(metrics.External): 1,
@@ -2004,7 +2004,7 @@ func TestUserSignupWithSpecialCharOK(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup(commonsignup.WithUsername("foo#$%^bar@redhat.com"))
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -2047,11 +2047,11 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 		Conditions: []toolchainv1alpha1.Condition{
 			{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 		},
@@ -2103,12 +2103,12 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "DeactivationInProgress",
 			})
 
@@ -2161,17 +2161,17 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Deactivated",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "NotificationCRCreated",
 			})
 		AssertThatCountersAndMetrics(t).
@@ -2202,11 +2202,11 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 			Conditions: []toolchainv1alpha1.Condition{
 				{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 				{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 			},
@@ -2244,17 +2244,17 @@ func TestUserSignupDeactivatedAfterMURCreated(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Deactivated",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "NotificationCRCreated",
 			})
 
@@ -2282,11 +2282,11 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 			Conditions: []toolchainv1alpha1.Condition{
 				{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 				{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 			},
@@ -2314,7 +2314,7 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 			}),
 		))
 
-		fakeClient.MockCreate = func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+		fakeClient.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
 			switch obj.(type) {
 			case *toolchainv1alpha1.Notification:
 				return errors.New("unable to create deactivation notification")
@@ -2338,16 +2338,16 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 			},
 			toolchainv1alpha1.Condition{
 				Type:    toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status:  v1.ConditionFalse,
+				Status:  corev1.ConditionFalse,
 				Reason:  "NotificationCRCreationFailed",
 				Message: "unable to create deactivation notification",
 			})
@@ -2395,21 +2395,21 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 		userSignup.Status.Conditions = []toolchainv1alpha1.Condition{
 			{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Deactivated",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "NotificationCRCreated",
 			},
 		}
-		ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+		ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 		r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 		InitializeCounters(t, NewToolchainStatus(
 			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -2435,22 +2435,22 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Deactivated",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserNotInPreDeactivation",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserIsActive",
 			})
 
@@ -2485,17 +2485,17 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 		userSignup.Status.Conditions = []toolchainv1alpha1.Condition{
 			{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Deactivated",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "NotificationCRCreated",
 			},
 		}
@@ -2509,7 +2509,7 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 			}),
 		))
 
-		fakeClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			switch obj.(type) {
 			case *toolchainv1alpha1.UserSignup:
 				return errors.New("failed to update UserSignup status")
@@ -2533,17 +2533,17 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Deactivated",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "NotificationCRCreated",
 			})
 		AssertThatCountersAndMetrics(t).
@@ -2578,12 +2578,12 @@ func TestUserSignupDeactivatedWhenMURAndSpaceAndSpaceBindingExists(t *testing.T)
 			Conditions: []toolchainv1alpha1.Condition{
 				{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "",
 				},
 				{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 			},
@@ -2624,22 +2624,22 @@ func TestUserSignupDeactivatedWhenMURAndSpaceAndSpaceBindingExists(t *testing.T)
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserIsActive",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserNotInPreDeactivation",
 			})
 
@@ -2684,22 +2684,22 @@ func TestUserSignupDeactivatedWhenMURAndSpaceAndSpaceBindingExists(t *testing.T)
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "DeactivationInProgress",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserNotInPreDeactivation",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserIsActive",
 				})
 
@@ -2735,22 +2735,22 @@ func TestUserSignupDeactivatedWhenMURAndSpaceAndSpaceBindingExists(t *testing.T)
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "Deactivated",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "NotificationCRCreated",
 				},
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-					Status: v1.ConditionFalse,
+					Status: corev1.ConditionFalse,
 					Reason: "UserNotInPreDeactivation",
 				})
 			// metrics should be the same after the 2nd reconcile
@@ -2777,11 +2777,11 @@ func TestUserSignupDeactivatingNotificationCreated(t *testing.T) {
 			Conditions: []toolchainv1alpha1.Condition{
 				{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 				{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 			},
@@ -2830,21 +2830,21 @@ func TestUserSignupDeactivatingNotificationCreated(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedAutomatically",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "NotificationCRCreated",
 		},
 	)
@@ -2854,11 +2854,11 @@ func TestUserSignupDeactivatingNotificationCreated(t *testing.T) {
 	userSignup.Status.Conditions = []toolchainv1alpha1.Condition{
 		{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 		},
 		{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedAutomatically",
 		},
 	}
@@ -2891,21 +2891,21 @@ func TestUserSignupDeactivatingNotificationCreated(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedAutomatically",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "NotificationCRCreated",
 		},
 	)
@@ -2955,7 +2955,7 @@ func TestUserSignupBannedWithoutMURAndSpace(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "Banned",
 		})
 
@@ -3006,17 +3006,17 @@ func TestUserSignupVerificationRequired(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "VerificationRequired",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 
@@ -3040,11 +3040,11 @@ func TestUserSignupBannedMURAndSpaceExists(t *testing.T) {
 		Conditions: []toolchainv1alpha1.Condition{
 			{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 		},
@@ -3103,12 +3103,12 @@ func TestUserSignupBannedMURAndSpaceExists(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "Banning",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedAutomatically",
 		})
 
@@ -3147,12 +3147,12 @@ func TestUserSignupBannedMURAndSpaceExists(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Banned",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			})
 
@@ -3188,7 +3188,7 @@ func TestUserSignupListBannedUsersFails(t *testing.T) {
 		}),
 	))
 
-	fakeClient.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	fakeClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 		return errors.New("err happened")
 	}
 
@@ -3220,11 +3220,11 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 				Conditions: []toolchainv1alpha1.Condition{
 					{
 						Type:   toolchainv1alpha1.UserSignupComplete,
-						Status: v1.ConditionTrue,
+						Status: corev1.ConditionTrue,
 					},
 					{
 						Type:   toolchainv1alpha1.UserSignupApproved,
-						Status: v1.ConditionTrue,
+						Status: corev1.ConditionTrue,
 						Reason: "ApprovedAutomatically",
 					},
 				},
@@ -3257,7 +3257,7 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 			}),
 		))
 
-		fakeClient.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+		fakeClient.MockDelete = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.DeleteOption) error {
 			switch obj.(type) {
 			case *toolchainv1alpha1.MasterUserRecord:
 				return errors.New("unable to delete mur")
@@ -3285,12 +3285,12 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 			test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 				toolchainv1alpha1.Condition{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 				toolchainv1alpha1.Condition{
 					Type:    toolchainv1alpha1.UserSignupComplete,
-					Status:  v1.ConditionFalse,
+					Status:  corev1.ConditionFalse,
 					Reason:  "UnableToDeleteMUR",
 					Message: "unable to delete mur",
 				})
@@ -3337,11 +3337,11 @@ func TestUserSignupDeactivatedButStatusUpdateFails(t *testing.T) {
 			Conditions: []toolchainv1alpha1.Condition{
 				{
 					Type:   toolchainv1alpha1.UserSignupComplete,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 				},
 				{
 					Type:   toolchainv1alpha1.UserSignupApproved,
-					Status: v1.ConditionTrue,
+					Status: corev1.ConditionTrue,
 					Reason: "ApprovedAutomatically",
 				},
 			},
@@ -3366,7 +3366,7 @@ func TestUserSignupDeactivatedButStatusUpdateFails(t *testing.T) {
 		}),
 	))
 
-	fakeClient.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	fakeClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 		switch obj.(type) {
 		case *toolchainv1alpha1.UserSignup:
 			return errors.New("mock error")
@@ -3393,12 +3393,12 @@ func TestUserSignupDeactivatedButStatusUpdateFails(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedAutomatically",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupComplete,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 		})
 	AssertThatCountersAndMetrics(t).
 		HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
@@ -3442,7 +3442,7 @@ func TestDeathBy100Signups(t *testing.T) {
 
 	initObjs = append(initObjs, baseNSTemplateTier)
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, initObjs...)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -3473,23 +3473,23 @@ func TestDeathBy100Signups(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  v1.ConditionFalse,
+			Status:  corev1.ConditionFalse,
 			Reason:  "UnableToCreateMUR",
 			Message: "unable to transform username [foo@redhat.com] even after 100 attempts",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedByAdmin",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		},
 	)
@@ -3525,7 +3525,7 @@ func TestUserSignupWithMultipleExistingMURNotOK(t *testing.T) {
 		},
 	}
 
-	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 	r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, mur, mur2, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -3553,18 +3553,18 @@ func TestUserSignupWithMultipleExistingMURNotOK(t *testing.T) {
 	test.AssertConditionsMatch(t, instance.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  v1.ConditionFalse,
+			Status:  corev1.ConditionFalse,
 			Reason:  "InvalidMURState",
 			Message: "multiple matching MasterUserRecord resources found",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		},
 	)
@@ -3617,23 +3617,23 @@ func TestApprovedManuallyUserSignupWhenNoMembersAvailable(t *testing.T) {
 	test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupApproved,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: "ApprovedByAdmin",
 		},
 		toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  v1.ConditionFalse,
+			Status:  corev1.ConditionFalse,
 			Reason:  "NoClusterAvailable",
 			Message: "no suitable member cluster found - capacity was reached",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserNotInPreDeactivation",
 		},
 		toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-			Status: v1.ConditionFalse,
+			Status: corev1.ConditionFalse,
 			Reason: "UserIsActive",
 		})
 
@@ -3647,12 +3647,12 @@ func prepareReconcile(t *testing.T, name string, getMemberClusters cluster.GetMe
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "secret",
 			Namespace: "test-namespace",
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			"token": []byte("mycooltoken"),
 		},
@@ -3786,17 +3786,17 @@ func TestChangedCompliantUsername(t *testing.T) {
 		Conditions: []toolchainv1alpha1.Condition{
 			{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Deactivated",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "NotificationCRCreated",
 			},
 		},
@@ -4069,8 +4069,8 @@ func TestUserSignupLastTargetClusterAnnotation(t *testing.T) {
 		// given
 		userSignup := commonsignup.NewUserSignup()
 		members := NewGetMemberClusters(
-			NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue),
-			NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 		r, req, _ := prepareReconcile(t, userSignup.Name, members, userSignup, baseNSTemplateTier, deactivate30Tier, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
 		InitializeCounters(t, NewToolchainStatus())
 
@@ -4092,9 +4092,9 @@ func TestUserSignupLastTargetClusterAnnotation(t *testing.T) {
 		userSignup := commonsignup.NewUserSignup()
 		userSignup.Annotations[toolchainv1alpha1.UserSignupLastTargetClusterAnnotationKey] = "member2"
 		members := NewGetMemberClusters(
-			NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue),
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
 			// member2 cluster lacks capacity because the prepareReconcile only sets up the resource consumption for member1 so member2 is automatically excluded
-			NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 		r, req, _ := prepareReconcile(t, userSignup.Name, members, userSignup, baseNSTemplateTier, deactivate30Tier, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
 		InitializeCounters(t, NewToolchainStatus())
 
@@ -4114,8 +4114,8 @@ func TestUserSignupLastTargetClusterAnnotation(t *testing.T) {
 		userSignup := commonsignup.NewUserSignup()
 		userSignup.Annotations[toolchainv1alpha1.UserSignupLastTargetClusterAnnotationKey] = "member2"
 		members := NewGetMemberClusters(
-			NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue),
-			NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 		r, req, _ := prepareReconcile(t, userSignup.Name, members, userSignup, baseNSTemplateTier, deactivate30Tier, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
 		InitializeCounters(t, NewToolchainStatus())
 
@@ -4144,7 +4144,7 @@ func TestUserSignupLastTargetClusterAnnotation(t *testing.T) {
 		// given
 		userSignup := commonsignup.NewUserSignup()
 		userSignup.Annotations[toolchainv1alpha1.UserSignupLastTargetClusterAnnotationKey] = "member2"
-		members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+		members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 		r, req, _ := prepareReconcile(t, userSignup.Name, members, userSignup, baseNSTemplateTier, deactivate30Tier, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
 		InitializeCounters(t, NewToolchainStatus())
 
@@ -4165,16 +4165,16 @@ func TestUserSignupLastTargetClusterAnnotation(t *testing.T) {
 		// given
 		userSignup := commonsignup.NewUserSignup()
 		userSignupName := userSignup.Name
-		members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+		members := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 		r, req, cl := prepareReconcile(t, userSignup.Name, members, userSignup, baseNSTemplateTier, deactivate30Tier, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
-		cl.MockUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		cl.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			s, ok := obj.(*toolchainv1alpha1.UserSignup)
 			if ok && s.Annotations[toolchainv1alpha1.UserSignupLastTargetClusterAnnotationKey] == "member1" {
 				return fmt.Errorf("error")
 			}
 			return nil
 		}
-		cl.MockStatusUpdate = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+		cl.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			s, ok := obj.(*toolchainv1alpha1.UserSignup)
 			if ok && s.Annotations[toolchainv1alpha1.UserSignupLastTargetClusterAnnotationKey] == "member1" {
 				return fmt.Errorf("some error")
@@ -4196,7 +4196,7 @@ func TestUserSignupLastTargetClusterAnnotation(t *testing.T) {
 }
 
 func TestUserSignupStatusNotReady(t *testing.T) {
-	member := NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue)
+	member := NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue)
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	userSignup := commonsignup.NewUserSignup(
 		commonsignup.ApprovedManually(),
@@ -4226,18 +4226,18 @@ func TestUserSignupStatusNotReady(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:    toolchainv1alpha1.UserSignupComplete,
-				Status:  v1.ConditionFalse,
+				Status:  corev1.ConditionFalse,
 				Reason:  toolchainv1alpha1.UserSignupProvisioningSpaceReason,
 				Message: "space foo was not ready",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserNotInPreDeactivation",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserIsActive",
 			})
 
@@ -4247,7 +4247,7 @@ func TestUserSignupStatusNotReady(t *testing.T) {
 		//given
 		space.Status.Conditions = append(space.Status.Conditions, toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.ConditionReady,
-			Status: v1.ConditionTrue,
+			Status: corev1.ConditionTrue,
 			Reason: toolchainv1alpha1.SpaceProvisionedReason,
 		})
 		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(member), userSignup, mur, space, spacebinding, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
@@ -4262,17 +4262,17 @@ func TestUserSignupStatusNotReady(t *testing.T) {
 		test.AssertConditionsMatch(t, userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserNotInPreDeactivation",
 			},
 			toolchainv1alpha1.Condition{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserIsActive",
 			})
 	})
@@ -4316,26 +4316,26 @@ func TestUserReactivatingWhileOldSpaceExists(t *testing.T) {
 		userSignup.Status.Conditions = []toolchainv1alpha1.Condition{
 			{
 				Type:   toolchainv1alpha1.UserSignupComplete,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "Deactivated",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupApproved,
-				Status: v1.ConditionTrue,
+				Status: corev1.ConditionTrue,
 				Reason: "ApprovedAutomatically",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatingNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserNotInPreDeactivation",
 			},
 			{
 				Type:   toolchainv1alpha1.UserSignupUserDeactivatedNotificationCreated,
-				Status: v1.ConditionFalse,
+				Status: corev1.ConditionFalse,
 				Reason: "UserIsActive",
 			},
 		}
-		ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+		ready := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 		r, req, _ := prepareReconcile(t, userSignup.Name, ready, userSignup, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier, mur, space)
 
 		// when
@@ -4351,7 +4351,7 @@ func TestUserReactivatingWhileOldSpaceExists(t *testing.T) {
 		// Confirm the status shows UserSignup Complete as false and the reason as unable to create space.
 		test.AssertContainsCondition(t, userSignup.Status.Conditions, toolchainv1alpha1.Condition{
 			Type:    toolchainv1alpha1.UserSignupComplete,
-			Status:  v1.ConditionFalse,
+			Status:  corev1.ConditionFalse,
 			Reason:  "UnableToCreateSpace",
 			Message: "cannot create space because it is currently being deleted",
 		})
@@ -4369,7 +4369,7 @@ func (r *Reconciler) setSpaceToReady(name string) error {
 	}
 	space.Status.Conditions = append(space.Status.Conditions, toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,
-		Status: v1.ConditionTrue,
+		Status: corev1.ConditionTrue,
 		Reason: toolchainv1alpha1.SpaceProvisionedReason,
 	})
 	err = r.Client.Update(context.TODO(), &space)

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller.go
@@ -4,19 +4,19 @@ import (
 	"context"
 	"time"
 
-	errs "github.com/pkg/errors"
-
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
+
 	"github.com/go-logr/logr"
+	errs "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -33,7 +33,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 
 // Reconciler cleans up old UserSignup resources
 type Reconciler struct {
-	Client client.Client
+	Client runtimeclient.Client
 	Scheme *runtime.Scheme
 }
 
@@ -156,7 +156,7 @@ func (r *Reconciler) DeleteUserSignup(userSignup *toolchainv1alpha1.UserSignup, 
 	_, phoneVerificationTriggered := userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]
 
 	propagationPolicy := metav1.DeletePropagationForeground
-	err := r.Client.Delete(context.TODO(), userSignup, &client.DeleteOptions{
+	err := r.Client.Delete(context.TODO(), userSignup, &runtimeclient.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
 	})
 	if err != nil {

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -237,14 +237,14 @@ func TestUserCleanup(t *testing.T) {
 
 		r, req, fakeClient := prepareReconcile(t, userSignup.Name, userSignup)
 		deleted := false
-		fakeClient.MockDelete = func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+		fakeClient.MockDelete = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.DeleteOption) error {
 			deleted = true
 			require.Len(t, opts, 1)
-			deleteOptions, ok := opts[0].(*client.DeleteOptions)
+			deleteOptions, ok := opts[0].(*runtimeclient.DeleteOptions)
 			require.True(t, ok)
 			require.NotNil(t, deleteOptions)
 			require.NotNil(t, deleteOptions.PropagationPolicy)
-			assert.Equal(t, v1.DeletePropagationForeground, *deleteOptions.PropagationPolicy)
+			assert.Equal(t, corev1.DeletePropagationForeground, *deleteOptions.PropagationPolicy)
 			return nil
 		}
 		_, err := r.Reconcile(context.TODO(), req)

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ import (
 	klogv1 "k8s.io/klog"
 	klogv2 "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	runtimecluster "sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -162,7 +162,7 @@ func main() { // nolint:gocyclo
 	}
 
 	// create client that will be used for retrieving the host operator secret & ToolchainCluster CRs
-	cl, err := client.New(cfg, client.Options{
+	cl, err := runtimeclient.New(cfg, runtimeclient.Options{
 		Scheme: scheme,
 	})
 	if err != nil {
@@ -400,7 +400,7 @@ func main() { // nolint:gocyclo
 	}
 }
 
-func addMemberClusters(mgr ctrl.Manager, cl client.Client, namespace string, namespacedCache bool) (map[string]cluster.Cluster, error) {
+func addMemberClusters(mgr ctrl.Manager, cl runtimeclient.Client, namespace string, namespacedCache bool) (map[string]cluster.Cluster, error) {
 	memberConfigs, err := commoncluster.ListToolchainClusterConfigs(cl, namespace, commoncluster.Member, memberClientTimeout)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get ToolchainCluster configs for members")

--- a/pkg/capacity/manager.go
+++ b/pkg/capacity/manager.go
@@ -8,9 +8,10 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/pkg/counter"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func hasNotReachedMaxNumberOfSpacesThreshold(config toolchainconfig.ToolchainConfig, counts counter.Counts) cluster.Condition {
@@ -51,7 +52,7 @@ func hasMemberREnoughResources(memberStatus toolchainv1alpha1.Member, threshold 
 	return false
 }
 
-func NewClusterManager(getMemberClusters cluster.GetMemberClustersFunc, cl client.Client) *ClusterManager {
+func NewClusterManager(getMemberClusters cluster.GetMemberClustersFunc, cl runtimeclient.Client) *ClusterManager {
 	return &ClusterManager{
 		getMemberClusters: getMemberClusters,
 		client:            cl,
@@ -60,7 +61,7 @@ func NewClusterManager(getMemberClusters cluster.GetMemberClustersFunc, cl clien
 
 type ClusterManager struct {
 	getMemberClusters cluster.GetMemberClustersFunc
-	client            client.Client
+	client            runtimeclient.Client
 	lastUsed          string
 }
 

--- a/pkg/capacity/manager_test.go
+++ b/pkg/capacity/manager_test.go
@@ -12,14 +12,14 @@ import (
 	. "github.com/codeready-toolchain/host-operator/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
-	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestGetOptimalTargetCluster(t *testing.T) {
@@ -43,15 +43,15 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -66,14 +66,14 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 10000), testconfig.PerMemberCluster("member2", 300), testconfig.PerMemberCluster("member3", 400)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -88,14 +88,14 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000), testconfig.PerMemberCluster("member3", 2000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			})
 
 		// then
@@ -109,15 +109,15 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
 				PreferredCluster:         "member2",
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -132,14 +132,14 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 60), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -154,15 +154,15 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 700), testconfig.PerMemberCluster("member2", 1000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 90), testconfig.PerMemberCluster("member2", 95)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
 				PreferredCluster:         "member1",
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -177,15 +177,15 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1), testconfig.PerMemberCluster("member2", 1)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 60), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
 				PreferredCluster:         "member2",
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -200,14 +200,14 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces().
 				ResourceCapacityThreshold(62))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -222,14 +222,14 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces().
 				ResourceCapacityThreshold(1))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -244,14 +244,14 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionFalse), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionFalse), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -266,17 +266,17 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(
-			NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue),
-			NewMemberClusterWithoutClusterRoles(t, "member2", v1.ConditionTrue), // member2 has capacity but doesn't have the required cluster role
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
+			NewMemberClusterWithoutClusterRoles(t, "member2", corev1.ConditionTrue), // member2 has capacity but doesn't have the required cluster role
 		)
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 				ClusterRoles:             []string{cluster.RoleLabel(cluster.Tenant)},
 			},
 		)
@@ -292,17 +292,17 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			testconfig.CapacityThresholds().
 				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1), testconfig.PerMemberCluster("member2", 1000)).
 				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 1), testconfig.PerMemberCluster("member2", 75)))
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(
-			NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue),
-			NewMemberClusterWithoutClusterRoles(t, "member2", v1.ConditionTrue), // member2 has capacity but doesn't have the required cluster role
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
+			NewMemberClusterWithoutClusterRoles(t, "member2", corev1.ConditionTrue), // member2 has capacity but doesn't have the required cluster role
 		)
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 				ClusterRoles:             []string{cluster.RoleLabel(cluster.Tenant)},
 			},
 		)
@@ -315,18 +315,18 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 	t.Run("with two clusters, the preferred one is returned if it has the required cluster-roles", func(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t)
-		fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 		clusters := NewGetMemberClusters(
-			NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue),
-			NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue)) // this is set as preferred
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue)) // this is set as preferred
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 			capacity.OptimalTargetClusterFilter{
 				PreferredCluster:         "member2",                                   // request specifically this member eve if it doesn't match the cluster-roles from below
 				ClusterRoles:             []string{cluster.RoleLabel(cluster.Tenant)}, // set
-				ToolchainStatusNamespace: HostOperatorNs,
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
 
@@ -338,18 +338,18 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 	t.Run("failures", func(t *testing.T) {
 		t.Run("unable to get ToolchainConfig", func(t *testing.T) {
 			// given
-			fakeClient := NewFakeClient(t, toolchainStatus)
+			fakeClient := commontest.NewFakeClient(t, toolchainStatus)
 			InitializeCounters(t, toolchainStatus)
-			fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				return fmt.Errorf("some error")
 			}
 			InitializeCounters(t, toolchainStatus)
-			clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+			clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 
 			// when
 			clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 				capacity.OptimalTargetClusterFilter{
-					ToolchainStatusNamespace: HostOperatorNs,
+					ToolchainStatusNamespace: commontest.HostOperatorNs,
 				},
 			)
 
@@ -360,20 +360,20 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 
 		t.Run("unable to read ToolchainStatus", func(t *testing.T) {
 			// given
-			fakeClient := NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
-			fakeClient.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			fakeClient := commontest.NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
+			fakeClient.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.ToolchainStatus); ok {
 					return fmt.Errorf("some error")
 				}
 				return fakeClient.Client.Get(ctx, key, obj, opts...)
 			}
 			InitializeCounters(t, toolchainStatus)
-			clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+			clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 
 			// when
 			clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 				capacity.OptimalTargetClusterFilter{
-					ToolchainStatusNamespace: HostOperatorNs,
+					ToolchainStatusNamespace: commontest.HostOperatorNs,
 				},
 			)
 
@@ -408,9 +408,9 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 						testconfig.CapacityThresholds().
 							MaxNumberOfSpaces(testconfig.PerMemberCluster("member2", limit), testconfig.PerMemberCluster("member3", limit)))
 
-					fakeClient := NewFakeClient(t, toolchainStatus, toolchainConfig)
+					fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 					InitializeCounters(t, toolchainStatus)
-					clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", v1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", v1.ConditionTrue))
+					clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue))
 					clusterBalancer := capacity.NewClusterManager(clusters, fakeClient)
 
 					// now run in 4 cycles and expect that the users will be provisioned in batches of 50
@@ -433,7 +433,7 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 								// when
 								clusterName, err := clusterBalancer.GetOptimalTargetCluster(
 									capacity.OptimalTargetClusterFilter{
-										ToolchainStatusNamespace: HostOperatorNs,
+										ToolchainStatusNamespace: commontest.HostOperatorNs,
 									},
 								)
 
@@ -447,7 +447,7 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 								// and when calling it with the other cluster as preferred
 								clusterName, err = clusterBalancer.GetOptimalTargetCluster(
 									capacity.OptimalTargetClusterFilter{
-										ToolchainStatusNamespace: HostOperatorNs,
+										ToolchainStatusNamespace: commontest.HostOperatorNs,
 										PreferredCluster:         "member3",
 									},
 								)
@@ -471,7 +471,7 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 								// when
 								clusterName, err := clusterBalancer.GetOptimalTargetCluster(
 									capacity.OptimalTargetClusterFilter{
-										ToolchainStatusNamespace: HostOperatorNs,
+										ToolchainStatusNamespace: commontest.HostOperatorNs,
 									},
 								)
 
@@ -485,7 +485,7 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 								// and when calling it with the other cluster as preferred
 								clusterName, err = clusterBalancer.GetOptimalTargetCluster(
 									capacity.OptimalTargetClusterFilter{
-										ToolchainStatusNamespace: HostOperatorNs,
+										ToolchainStatusNamespace: commontest.HostOperatorNs,
 										PreferredCluster:         "member2",
 									},
 								)
@@ -501,7 +501,7 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 					// when
 					clusterName, err := clusterBalancer.GetOptimalTargetCluster(
 						capacity.OptimalTargetClusterFilter{
-							ToolchainStatusNamespace: HostOperatorNs,
+							ToolchainStatusNamespace: commontest.HostOperatorNs,
 						},
 					)
 
@@ -519,13 +519,13 @@ func TestGetOptimalTargetClusterWhenCounterIsNotInitialized(t *testing.T) {
 	// given
 	toolchainStatus := NewToolchainStatus(
 		WithMember("member1", WithNodeRoleUsage("worker", 68), WithNodeRoleUsage("master", 65)))
-	fakeClient := NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
-	clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", v1.ConditionTrue))
+	fakeClient := commontest.NewFakeClient(t, toolchainStatus, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)))
+	clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
 
 	// when
 	clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
 		capacity.OptimalTargetClusterFilter{
-			ToolchainStatusNamespace: HostOperatorNs,
+			ToolchainStatusNamespace: commontest.HostOperatorNs,
 		},
 	)
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -2,14 +2,15 @@ package cluster
 
 import (
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Cluster struct {
 	*commoncluster.Config
-	Client     client.Client
+	Client     runtimeclient.Client
 	RESTClient *rest.RESTClient
 	Cache      cache.Cache
 }

--- a/pkg/counter/cache.go
+++ b/pkg/counter/cache.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -159,7 +159,7 @@ func GetCounts() (Counts, error) {
 //
 // If the cached counter is initialized and ToolchainStatus contains already some numbers
 // then it updates the ToolchainStatus numbers with the one taken from the cached counter
-func Synchronize(cl client.Client, toolchainStatus *toolchainv1alpha1.ToolchainStatus) error {
+func Synchronize(cl runtimeclient.Client, toolchainStatus *toolchainv1alpha1.ToolchainStatus) error {
 	cachedCounts.Lock()
 	defer cachedCounts.Unlock()
 
@@ -222,7 +222,7 @@ func indexOfMember(members []toolchainv1alpha1.Member, name string) int {
 	return -1
 }
 
-func initialize(cl client.Client, toolchainStatus *toolchainv1alpha1.ToolchainStatus) error {
+func initialize(cl runtimeclient.Client, toolchainStatus *toolchainv1alpha1.ToolchainStatus) error {
 	// skip if cached counters are already initialized
 	if cachedCounts.initialized {
 		return nil
@@ -246,18 +246,18 @@ func initialize(cl client.Client, toolchainStatus *toolchainv1alpha1.ToolchainSt
 
 // initialize the cached counters from the UserSignup and MasterUserRecord resources.
 // this func lists all UserSignup and MasterUserRecord resources
-func initializeFromResources(cl client.Client, namespace string) error {
+func initializeFromResources(cl runtimeclient.Client, namespace string) error {
 	log.Info("initializing counters from resources")
 	usersignups := &toolchainv1alpha1.UserSignupList{}
-	if err := cl.List(context.TODO(), usersignups, client.InNamespace(namespace)); err != nil {
+	if err := cl.List(context.TODO(), usersignups, runtimeclient.InNamespace(namespace)); err != nil {
 		return err
 	}
 	murs := &toolchainv1alpha1.MasterUserRecordList{}
-	if err := cl.List(context.TODO(), murs, client.InNamespace(namespace)); err != nil {
+	if err := cl.List(context.TODO(), murs, runtimeclient.InNamespace(namespace)); err != nil {
 		return err
 	}
 	spaces := &toolchainv1alpha1.SpaceList{}
-	if err := cl.List(context.TODO(), spaces, client.InNamespace(namespace)); err != nil {
+	if err := cl.List(context.TODO(), spaces, runtimeclient.InNamespace(namespace)); err != nil {
 		return err
 	}
 	reset()

--- a/pkg/mapper/by_resource_name.go
+++ b/pkg/mapper/by_resource_name.go
@@ -2,12 +2,12 @@ package mapper
 
 import (
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func MapByResourceName(hostNamespace string) func(object client.Object) []reconcile.Request {
-	return func(obj client.Object) []reconcile.Request {
+func MapByResourceName(hostNamespace string) func(object runtimeclient.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
 		return []reconcile.Request{{
 			NamespacedName: types.NamespacedName{Namespace: hostNamespace, Name: obj.GetName()},
 		}}

--- a/pkg/metrics/email_domain_test.go
+++ b/pkg/metrics/email_domain_test.go
@@ -5,7 +5,8 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,7 +23,7 @@ func TestGetEmailDomain(t *testing.T) {
 		{
 			name: "Red Hatter",
 			object: &toolchainv1alpha1.UserSignup{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "joe",
 					Annotations: map[string]string{
 						toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "joe@redhat.com",
@@ -34,7 +35,7 @@ func TestGetEmailDomain(t *testing.T) {
 		{
 			name: "IBMer",
 			object: &toolchainv1alpha1.UserSignup{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "joe",
 					Annotations: map[string]string{
 						toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "joe@ibm.com",
@@ -46,7 +47,7 @@ func TestGetEmailDomain(t *testing.T) {
 		{
 			name: "Another IBMer",
 			object: &toolchainv1alpha1.UserSignup{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "joe",
 					Annotations: map[string]string{
 						toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "joe@fr.ibm.com",
@@ -58,7 +59,7 @@ func TestGetEmailDomain(t *testing.T) {
 		{
 			name: "Not an IBMer",
 			object: &toolchainv1alpha1.UserSignup{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "joe",
 					Annotations: map[string]string{
 						toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "joe@fribm.com",
@@ -70,7 +71,7 @@ func TestGetEmailDomain(t *testing.T) {
 		{
 			name: "External",
 			object: &toolchainv1alpha1.UserSignup{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "joe",
 					Annotations: map[string]string{
 						toolchainv1alpha1.UserSignupUserEmailAnnotationKey: "joe@example.com",
@@ -82,7 +83,7 @@ func TestGetEmailDomain(t *testing.T) {
 		{
 			name: "Missing",
 			object: &toolchainv1alpha1.UserSignup{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:        "joe",
 					Annotations: map[string]string{
 						// no email

--- a/pkg/pending/cache.go
+++ b/pkg/pending/cache.go
@@ -7,26 +7,27 @@ import (
 	"sync"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
 	errs "github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var log = logf.Log.WithName("pending_object_cache")
 
-type ListPendingObjects func(cl client.Client, labelListOption client.ListOption) ([]client.Object, error)
+type ListPendingObjects func(cl runtimeclient.Client, labelListOption runtimeclient.ListOption) ([]runtimeclient.Object, error)
 
 type cache struct {
 	sync.RWMutex
 	sortedObjectNames  []string
-	client             client.Client
-	objectType         client.Object
+	client             runtimeclient.Client
+	objectType         runtimeclient.Object
 	listPendingObjects ListPendingObjects
 }
 
-func (c *cache) getOldestPendingObject(namespace string) client.Object {
+func (c *cache) getOldestPendingObject(namespace string) runtimeclient.Object {
 	c.Lock()
 	defer c.Unlock()
 	oldest := c.getFirstExisting(namespace)
@@ -39,7 +40,7 @@ func (c *cache) getOldestPendingObject(namespace string) client.Object {
 
 func (c *cache) loadLatest() { //nolint:unparam
 	labels := map[string]string{toolchainv1alpha1.StateLabelKey: toolchainv1alpha1.StateLabelValuePending}
-	opts := client.MatchingLabels(labels)
+	opts := runtimeclient.MatchingLabels(labels)
 
 	pendingObjects, err := c.listPendingObjects(c.client, opts)
 	if err != nil {
@@ -57,12 +58,12 @@ func (c *cache) loadLatest() { //nolint:unparam
 	}
 }
 
-func (c *cache) getFirstExisting(namespace string) client.Object {
+func (c *cache) getFirstExisting(namespace string) runtimeclient.Object {
 	if len(c.sortedObjectNames) == 0 {
 		return nil
 	}
 	name := c.sortedObjectNames[0]
-	firstExisting := c.objectType.DeepCopyObject().(client.Object)
+	firstExisting := c.objectType.DeepCopyObject().(runtimeclient.Object)
 	if err := c.client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, firstExisting); err != nil {
 		if apierrors.IsNotFound(err) {
 			c.sortedObjectNames = c.sortedObjectNames[1:]
@@ -79,12 +80,12 @@ func (c *cache) getFirstExisting(namespace string) client.Object {
 	return firstExisting
 }
 
-var listPendingUserSignups ListPendingObjects = func(cl client.Client, labelListOption client.ListOption) ([]client.Object, error) {
+var listPendingUserSignups ListPendingObjects = func(cl runtimeclient.Client, labelListOption runtimeclient.ListOption) ([]runtimeclient.Object, error) {
 	userSignupList := &toolchainv1alpha1.UserSignupList{}
 	if err := cl.List(context.TODO(), userSignupList, labelListOption); err != nil {
 		return nil, err
 	}
-	objects := make([]client.Object, len(userSignupList.Items))
+	objects := make([]runtimeclient.Object, len(userSignupList.Items))
 	for i := range userSignupList.Items {
 		userSignup := userSignupList.Items[i]
 		objects[i] = &userSignup
@@ -92,12 +93,12 @@ var listPendingUserSignups ListPendingObjects = func(cl client.Client, labelList
 	return objects, nil
 }
 
-var listPendingSpaces ListPendingObjects = func(cl client.Client, labelListOption client.ListOption) ([]client.Object, error) {
+var listPendingSpaces ListPendingObjects = func(cl runtimeclient.Client, labelListOption runtimeclient.ListOption) ([]runtimeclient.Object, error) {
 	spaceList := &toolchainv1alpha1.SpaceList{}
 	if err := cl.List(context.TODO(), spaceList, labelListOption); err != nil {
 		return nil, err
 	}
-	objects := make([]client.Object, len(spaceList.Items))
+	objects := make([]runtimeclient.Object, len(spaceList.Items))
 	for i := range spaceList.Items {
 		space := spaceList.Items[i]
 		objects[i] = &space

--- a/pkg/pending/cache_test.go
+++ b/pkg/pending/cache_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/codeready-toolchain/host-operator/test/space"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestGetOldestSignupPendingApproval(t *testing.T) {
@@ -286,7 +287,7 @@ func TestGetOldestPendingApprovalWithMultipleUserSignupsInParallel(t *testing.T)
 	assert.Nil(t, foundPending)
 }
 
-func newCache(t *testing.T, objectType client.Object, listPendingObjects ListPendingObjects, initObjects ...runtime.Object) (*cache, *test.FakeClient) {
+func newCache(t *testing.T, objectType runtimeclient.Object, listPendingObjects ListPendingObjects, initObjects ...runtime.Object) (*cache, *test.FakeClient) {
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)

--- a/pkg/pending/mapper.go
+++ b/pkg/pending/mapper.go
@@ -2,8 +2,9 @@ package pending
 
 import (
 	"github.com/codeready-toolchain/api/api/v1alpha1"
+
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -13,17 +14,17 @@ type ObjectsMapper struct {
 }
 
 // NewUserSignupMapper creates an instance of UserSignupMapper that maps any object to an oldest unapproved UserSignup
-func NewUserSignupMapper(client client.Client) ObjectsMapper {
+func NewUserSignupMapper(client runtimeclient.Client) ObjectsMapper {
 	return NewPendingObjectsMapper(client, &v1alpha1.UserSignup{}, listPendingUserSignups)
 }
 
 // NewSpaceMapper creates an instance of SpaceMapper that maps any object to an oldest unapproved Space
-func NewSpaceMapper(client client.Client) ObjectsMapper {
+func NewSpaceMapper(client runtimeclient.Client) ObjectsMapper {
 	return NewPendingObjectsMapper(client, &v1alpha1.Space{}, listPendingSpaces)
 }
 
 // NewPendingObjectsMapper creates an instance of ObjectsMapper that maps any object to an oldest pending object
-func NewPendingObjectsMapper(client client.Client, objectType client.Object, listPendingObjects ListPendingObjects) ObjectsMapper {
+func NewPendingObjectsMapper(client runtimeclient.Client, objectType runtimeclient.Object, listPendingObjects ListPendingObjects) ObjectsMapper {
 	return ObjectsMapper{
 		unapprovedCache: &cache{
 			client:             client,
@@ -33,7 +34,7 @@ func NewPendingObjectsMapper(client client.Client, objectType client.Object, lis
 	}
 }
 
-func (b ObjectsMapper) MapToOldestPending(obj client.Object) []reconcile.Request {
+func (b ObjectsMapper) MapToOldestPending(obj runtimeclient.Object) []reconcile.Request {
 	pendingObject := b.unapprovedCache.getOldestPendingObject(obj.GetNamespace())
 	if pendingObject == nil {
 		return []reconcile.Request{}

--- a/pkg/pending/mapper_test.go
+++ b/pkg/pending/mapper_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/codeready-toolchain/host-operator/test/space"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestMapperReturnsOldest(t *testing.T) {
@@ -70,7 +71,7 @@ func TestMapperReturnsEmptyRequestsWhenNoPendingIsFound(t *testing.T) {
 func TestMapperReturnsEmptyRequestsWhenClientReturnsError(t *testing.T) {
 	// given
 	cl := test.NewFakeClient(t)
-	cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 		return fmt.Errorf("some error")
 	}
 	mapper := NewUserSignupMapper(cl)

--- a/pkg/space/space_test.go
+++ b/pkg/space/space_test.go
@@ -7,11 +7,11 @@ import (
 	spacerequesttest "github.com/codeready-toolchain/host-operator/test/spacerequest"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
 
 	spacetest "github.com/codeready-toolchain/host-operator/test/space"
 
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -29,7 +29,7 @@ var log = logf.Log.WithName("templates")
 
 // CreateOrUpdateResources generates the NSTemplateTier resources from the cluster resource template and namespace templates,
 // then uses the manager's client to create or update the resources on the cluster.
-func CreateOrUpdateResources(s *runtime.Scheme, client client.Client, namespace string, assets assets.Assets) error {
+func CreateOrUpdateResources(s *runtime.Scheme, client runtimeclient.Client, namespace string, assets assets.Assets) error {
 
 	// initialize tier generator, loads templates from assets
 	generator, err := newNSTemplateTierGenerator(s, client, namespace, assets)
@@ -53,7 +53,7 @@ func CreateOrUpdateResources(s *runtime.Scheme, client client.Client, namespace 
 }
 
 type tierGenerator struct {
-	client          client.Client
+	client          runtimeclient.Client
 	namespace       string
 	scheme          *runtime.Scheme
 	templatesByTier map[string]*tierData
@@ -63,7 +63,7 @@ type tierData struct {
 	name          string
 	rawTemplates  *templates
 	tierTemplates []*toolchainv1alpha1.TierTemplate
-	objects       []client.Object
+	objects       []runtimeclient.Object
 	basedOnTier   *BasedOnTier
 }
 
@@ -83,7 +83,7 @@ type template struct {
 }
 
 // newNSTemplateTierGenerator loads templates from the provided assets and processes the tierTemplates and NSTemplateTiers
-func newNSTemplateTierGenerator(s *runtime.Scheme, client client.Client, namespace string, assets assets.Assets) (*tierGenerator, error) {
+func newNSTemplateTierGenerator(s *runtime.Scheme, client runtimeclient.Client, namespace string, assets assets.Assets) (*tierGenerator, error) {
 	// load templates from assets
 	templatesByTier, err := loadTemplatesByTiers(assets)
 	if err != nil {
@@ -453,7 +453,7 @@ func (t *tierGenerator) createNSTemplateTiers() error {
 //	      templateRef: appstudio-admin-ab12cd34-ab12cd34
 //
 // ------
-func (t *tierGenerator) newNSTemplateTier(sourceTierName, tierName string, nsTemplateTier template, tierTemplates []*toolchainv1alpha1.TierTemplate, parameters []templatev1.Parameter) ([]client.Object, error) {
+func (t *tierGenerator) newNSTemplateTier(sourceTierName, tierName string, nsTemplateTier template, tierTemplates []*toolchainv1alpha1.TierTemplate, parameters []templatev1.Parameter) ([]runtimeclient.Object, error) {
 	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer()
 	if reflect.DeepEqual(nsTemplateTier, template{}) {
 		return nil, fmt.Errorf("tier %s is missing a tier.yaml file", tierName)

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -7,8 +7,9 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type GetMemberClusterFunc func(clusters ...ClientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool)
@@ -47,7 +48,7 @@ func NewMemberClusterWithTenantRole(t *testing.T, name string, status corev1.Con
 	return NewMemberClusterWithClient(test.NewFakeClient(t), name, status, clusterRoleLabelModifier)
 }
 
-func NewMemberClusterWithClient(cl client.Client, name string, status corev1.ConditionStatus, modifiers ...Modifier) *cluster.CachedToolchainCluster {
+func NewMemberClusterWithClient(cl runtimeclient.Client, name string, status corev1.ConditionStatus, modifiers ...Modifier) *cluster.CachedToolchainCluster {
 	toolchainCluster, _ := NewGetMemberCluster(true, status, modifiers...)(ClusterClient(name, cl))(name)
 	return toolchainCluster
 }
@@ -66,7 +67,7 @@ func NewGetMemberCluster(ok bool, status corev1.ConditionStatus, modifiers ...Mo
 		}
 	}
 	return func(clusters ...ClientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool) {
-		mapping := map[string]client.Client{}
+		mapping := map[string]runtimeclient.Client{}
 		for _, clusterClient := range clusters {
 			n, cl := clusterClient()
 			mapping[n] = cl
@@ -103,10 +104,10 @@ func NewGetMemberCluster(ok bool, status corev1.ConditionStatus, modifiers ...Mo
 	}
 }
 
-type ClientForCluster func() (string, client.Client)
+type ClientForCluster func() (string, runtimeclient.Client)
 
-func ClusterClient(name string, cl client.Client) ClientForCluster {
-	return func() (string, client.Client) {
+func ClusterClient(name string, cl runtimeclient.Client) ClientForCluster {
+	return func() (string, runtimeclient.Client) {
 		return name, cl
 	}
 }

--- a/test/configmap_assertions.go
+++ b/test/configmap_assertions.go
@@ -4,18 +4,18 @@ import (
 	"context"
 
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ConfigMapAssertion struct {
 	configmap      *corev1.ConfigMap
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -30,7 +30,7 @@ func (a *ConfigMapAssertion) loadConfigMap() error {
 	return nil
 }
 
-func AssertThatConfigMap(t test.T, namespace, name string, client client.Client) *ConfigMapAssertion {
+func AssertThatConfigMap(t test.T, namespace, name string, client runtimeclient.Client) *ConfigMapAssertion {
 	return &ConfigMapAssertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),

--- a/test/notification/assertion.go
+++ b/test/notification/assertion.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Assertion struct {
 	notification   *toolchainv1alpha1.Notification
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -26,7 +26,7 @@ func (a *Assertion) loadNotificationAssertion() error {
 	return err
 }
 
-func AssertThatNotification(t test.T, name string, client client.Client) *Assertion {
+func AssertThatNotification(t test.T, name string, client runtimeclient.Client) *Assertion {
 	return &Assertion{
 		client:         client,
 		namespacedName: test.NamespacedName(test.HostOperatorNs, name),
@@ -41,7 +41,7 @@ func (a *Assertion) HasConditions(expected ...toolchainv1alpha1.Condition) *Asse
 	return a
 }
 
-func AssertNoNotificationsExist(t test.T, cl client.Client) {
+func AssertNoNotificationsExist(t test.T, cl runtimeclient.Client) {
 	notifications := &toolchainv1alpha1.NotificationList{}
 	err := cl.List(context.TODO(), notifications)
 	require.NoError(t, err)
@@ -50,14 +50,14 @@ func AssertNoNotificationsExist(t test.T, cl client.Client) {
 
 type Assert func(test.T, toolchainv1alpha1.Notification)
 
-func OnlyOneNotificationExists(t test.T, cl client.Client, userName, notificationType string, assertions ...Assert) {
+func OnlyOneNotificationExists(t test.T, cl runtimeclient.Client, userName, notificationType string, assertions ...Assert) {
 	notifications := &toolchainv1alpha1.NotificationList{}
 	labels := map[string]string{
 		toolchainv1alpha1.NotificationUserNameLabelKey: userName,
 		// NotificationTypeLabelKey is only used for easy lookup for debugging and e2e tests
 		toolchainv1alpha1.NotificationTypeLabelKey: notificationType,
 	}
-	err := cl.List(context.TODO(), notifications, client.MatchingLabels(labels))
+	err := cl.List(context.TODO(), notifications, runtimeclient.MatchingLabels(labels))
 	require.NoError(t, err)
 	require.Len(t, notifications.Items, 1)
 

--- a/test/nstemplatetier/assertion.go
+++ b/test/nstemplatetier/assertion.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Assertion an assertion helper for an NSTemplateTier
 type Assertion struct {
 	tier           *toolchainv1alpha1.NSTemplateTier
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -28,7 +28,7 @@ func (a *Assertion) loadResource() error {
 }
 
 // AssertThatNSTemplateTier helper func to begin with the assertions on an NSTemplateTier
-func AssertThatNSTemplateTier(t test.T, name string, client client.Client) *Assertion {
+func AssertThatNSTemplateTier(t test.T, name string, client runtimeclient.Client) *Assertion {
 	return &Assertion{
 		client:         client,
 		namespacedName: test.NamespacedName(test.HostOperatorNs, name),

--- a/test/serviceaccount_assertions.go
+++ b/test/serviceaccount_assertions.go
@@ -12,12 +12,12 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ServiceAccountAssertion struct {
 	serviceaccount *corev1.ServiceAccount
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -32,7 +32,7 @@ func (a *ServiceAccountAssertion) loadServiceAccount() error {
 	return nil
 }
 
-func AssertThatServiceAccount(t test.T, namespace, name string, client client.Client) *ServiceAccountAssertion {
+func AssertThatServiceAccount(t test.T, namespace, name string, client runtimeclient.Client) *ServiceAccountAssertion {
 	return &ServiceAccountAssertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),

--- a/test/socialevent/socialevent_assertion.go
+++ b/test/socialevent/socialevent_assertion.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Assertion struct {
 	socialevent    *toolchainv1alpha1.SocialEvent
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -27,7 +27,7 @@ func (a *Assertion) loadResource() error {
 }
 
 // AssertThatSocialEvent helper func to begin with the assertions on a SocialEvent
-func AssertThatSocialEvent(t test.T, namespace, name string, client client.Client) *Assertion {
+func AssertThatSocialEvent(t test.T, namespace, name string, client runtimeclient.Client) *Assertion {
 	return &Assertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),

--- a/test/space/space_assertions.go
+++ b/test/space/space_assertions.go
@@ -5,7 +5,6 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	tierutil "github.com/codeready-toolchain/host-operator/controllers/nstemplatetier/util"
-
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	"github.com/stretchr/testify/assert"
@@ -13,12 +12,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Assertion struct {
 	space          *toolchainv1alpha1.Space
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 	spaceRequest   *toolchainv1alpha1.SpaceRequest
@@ -39,7 +38,7 @@ func (a *Assertion) loadResource() error {
 }
 
 // AssertThatSpace helper func to begin with the assertions on a Space
-func AssertThatSpace(t test.T, namespace, name string, client client.Client) *Assertion {
+func AssertThatSpace(t test.T, namespace, name string, client runtimeclient.Client) *Assertion {
 	return &Assertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),
@@ -284,12 +283,12 @@ func TerminatingFailed(msg string) toolchainv1alpha1.Condition {
 // Assertions on multiple Spaces at once
 type SpacesAssertion struct {
 	spaces    *toolchainv1alpha1.SpaceList
-	client    client.Client
+	client    runtimeclient.Client
 	namespace string
 	t         test.T
 }
 
-func AssertThatSpaces(t test.T, client client.Client) *SpacesAssertion {
+func AssertThatSpaces(t test.T, client runtimeclient.Client) *SpacesAssertion {
 	return &SpacesAssertion{
 		client:    client,
 		namespace: test.HostOperatorNs,
@@ -299,7 +298,7 @@ func AssertThatSpaces(t test.T, client client.Client) *SpacesAssertion {
 
 func (a *SpacesAssertion) loadSpaces() error {
 	spaces := &toolchainv1alpha1.SpaceList{}
-	err := a.client.List(context.TODO(), spaces, client.InNamespace(a.namespace))
+	err := a.client.List(context.TODO(), spaces, runtimeclient.InNamespace(a.namespace))
 	a.spaces = spaces
 	return err
 }
@@ -311,7 +310,7 @@ func (a *SpacesAssertion) HaveCount(count int) *SpacesAssertion {
 	return a
 }
 
-func AssertThatSubSpace(t test.T, client client.Client, spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *toolchainv1alpha1.Space) *Assertion {
+func AssertThatSubSpace(t test.T, client runtimeclient.Client, spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *toolchainv1alpha1.Space) *Assertion {
 	return &Assertion{
 		t:            t,
 		client:       client,
@@ -322,12 +321,12 @@ func AssertThatSubSpace(t test.T, client client.Client, spaceRequest *toolchainv
 
 func (a *Assertion) loadSubSpace() error {
 	spaces := &toolchainv1alpha1.SpaceList{}
-	spaceRequestLabel := client.MatchingLabels{
+	spaceRequestLabel := runtimeclient.MatchingLabels{
 		toolchainv1alpha1.SpaceRequestLabelKey:          a.spaceRequest.GetName(),
 		toolchainv1alpha1.SpaceRequestNamespaceLabelKey: a.spaceRequest.GetNamespace(),
 		toolchainv1alpha1.ParentSpaceLabelKey:           a.parentSpace.GetName(),
 	}
-	err := a.client.List(context.TODO(), spaces, spaceRequestLabel, client.InNamespace(a.parentSpace.GetNamespace()))
+	err := a.client.List(context.TODO(), spaces, spaceRequestLabel, runtimeclient.InNamespace(a.parentSpace.GetNamespace()))
 	if len(spaces.Items) > 0 {
 		a.space = &spaces.Items[0]
 	}

--- a/test/spacebinding/spacebinding_assertions.go
+++ b/test/spacebinding/spacebinding_assertions.go
@@ -6,14 +6,15 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Assertion struct {
 	spaceBinding *toolchainv1alpha1.SpaceBinding
-	client       client.Client
+	client       runtimeclient.Client
 	namespace    string
 	murName      string
 	spaceName    string
@@ -26,8 +27,8 @@ func (a *Assertion) loadResource() error {
 		toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: a.murName,
 		toolchainv1alpha1.SpaceBindingSpaceLabelKey:            a.spaceName,
 	}
-	opts := client.MatchingLabels(labels)
-	err := a.client.List(context.TODO(), spacebindings, client.InNamespace(a.namespace), opts)
+	opts := runtimeclient.MatchingLabels(labels)
+	err := a.client.List(context.TODO(), spacebindings, runtimeclient.InNamespace(a.namespace), opts)
 
 	if err == nil && len(spacebindings.Items) == 0 {
 		return fmt.Errorf("no spacebinding found")
@@ -38,7 +39,7 @@ func (a *Assertion) loadResource() error {
 }
 
 // AssertThatSpaceBinding helper func to begin with the assertions on a SpaceBinding
-func AssertThatSpaceBinding(t test.T, namespace, murName, spaceName string, client client.Client) *Assertion {
+func AssertThatSpaceBinding(t test.T, namespace, murName, spaceName string, client runtimeclient.Client) *Assertion {
 	return &Assertion{
 		client:    client,
 		namespace: namespace,
@@ -87,12 +88,12 @@ func (a *Assertion) HasSpec(murName, spaceName, spaceRole string) *Assertion {
 // Assertions on multiple SpaceBindings at once
 type SpaceBindingsAssertion struct {
 	spacebindings *toolchainv1alpha1.SpaceBindingList
-	client        client.Client
+	client        runtimeclient.Client
 	namespace     string
 	t             test.T
 }
 
-func AssertThatSpaceBindings(t test.T, client client.Client) *SpaceBindingsAssertion {
+func AssertThatSpaceBindings(t test.T, client runtimeclient.Client) *SpaceBindingsAssertion {
 	return &SpaceBindingsAssertion{
 		client:    client,
 		namespace: test.HostOperatorNs,
@@ -102,7 +103,7 @@ func AssertThatSpaceBindings(t test.T, client client.Client) *SpaceBindingsAsser
 
 func (a *SpaceBindingsAssertion) loadSpaceBindings() error {
 	spacebindings := &toolchainv1alpha1.SpaceBindingList{}
-	err := a.client.List(context.TODO(), spacebindings, client.InNamespace(a.namespace))
+	err := a.client.List(context.TODO(), spacebindings, runtimeclient.InNamespace(a.namespace))
 	a.spacebindings = spacebindings
 	return err
 }

--- a/test/spacerequest/spacerequest_assertions.go
+++ b/test/spacerequest/spacerequest_assertions.go
@@ -5,6 +5,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -12,12 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Assertion struct {
 	spaceRequest   *toolchainv1alpha1.SpaceRequest
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -30,7 +31,7 @@ func (a *Assertion) loadResource() error {
 }
 
 // AssertThatSpaceRequest helper func to begin with the assertions on a SpaceRequests
-func AssertThatSpaceRequest(t test.T, namespace, name string, client client.Client) *Assertion {
+func AssertThatSpaceRequest(t test.T, namespace, name string, client runtimeclient.Client) *Assertion {
 	return &Assertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),

--- a/test/toolchainstatus.go
+++ b/test/toolchainstatus.go
@@ -5,7 +5,8 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	condition2 "github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	v1 "k8s.io/api/core/v1"
+
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -130,13 +131,13 @@ func WithEmptyMetrics() ToolchainStatusOption {
 func ToBeReady() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,
-		Status: v1.ConditionTrue,
+		Status: corev1.ConditionTrue,
 	}
 }
 
 func ToBeNotReady() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ConditionReady,
-		Status: v1.ConditionFalse,
+		Status: corev1.ConditionFalse,
 	}
 }

--- a/test/toolchainstatus_assertions.go
+++ b/test/toolchainstatus_assertions.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ToolchainStatusAssertion struct {
 	toolchainStatus *toolchainv1alpha1.ToolchainStatus
-	client          client.Client
+	client          runtimeclient.Client
 	namespacedName  types.NamespacedName
 	t               test.T
 }
@@ -32,7 +32,7 @@ func (a *ToolchainStatusAssertion) loadToolchainStatus() error {
 	return nil
 }
 
-func AssertThatToolchainStatus(t test.T, namespace, name string, client client.Client) *ToolchainStatusAssertion {
+func AssertThatToolchainStatus(t test.T, namespace, name string, client runtimeclient.Client) *ToolchainStatusAssertion {
 	return &ToolchainStatusAssertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),

--- a/test/usersignup_assertions.go
+++ b/test/usersignup_assertions.go
@@ -9,12 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type UserSignupAssertion struct {
 	usersignup     *toolchainv1alpha1.UserSignup
-	client         client.Client
+	client         runtimeclient.Client
 	namespacedName types.NamespacedName
 	t              test.T
 }
@@ -29,7 +29,7 @@ func (a *UserSignupAssertion) loadUserSignup() error {
 	return nil
 }
 
-func AssertThatUserSignup(t test.T, namespace, name string, client client.Client) *UserSignupAssertion {
+func AssertThatUserSignup(t test.T, namespace, name string, client runtimeclient.Client) *UserSignupAssertion {
 	return &UserSignupAssertion{
 		client:         client,
 		namespacedName: test.NamespacedName(namespace, name),


### PR DESCRIPTION
preparing for upcoming changes, using 'runtimeclient' as a package alias everywhere it is used

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
