### PR TITLE
Update docs link in app studio welcome email

### DIFF
--- a/deploy/templates/notificationtemplates/appstudio/userprovisioned/notification.html
+++ b/deploy/templates/notificationtemplates/appstudio/userprovisioned/notification.html
@@ -53,7 +53,7 @@
   </p>
 
   <p>
-    If you’d rather access Red Hat Trusted Application Pipeline through your CLI, or if you have any questions that are not answered in the web UI, you can also visit our documentation at https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/index.html.
+    If you’d rather access Red Hat Trusted Application Pipeline through your CLI, or if you have any questions that are not answered in the web UI, you can also visit our documentation at https://redhat-appstudio.github.io/appstudio.docs.ui.io/.
   </p>
 
   <p>


### PR DESCRIPTION
On line 56, I replaced the old URL for the docs with the new URL