### PR TITLE
Add "community" on line 56

### DIFF
--- a/deploy/templates/notificationtemplates/appstudio/userprovisioned/notification.html
+++ b/deploy/templates/notificationtemplates/appstudio/userprovisioned/notification.html
@@ -53,7 +53,7 @@
   </p>
 
   <p>
-    If you’d rather access Red Hat Trusted Application Pipeline through your CLI, or if you have any questions that are not answered in the web UI, you can also visit our documentation at https://redhat-appstudio.github.io/appstudio.docs.ui.io/.
+    If you’d rather access Red Hat Trusted Application Pipeline through your CLI, or if you have any questions that are not answered in the web UI, you can also visit our community documentation at https://redhat-appstudio.github.io/appstudio.docs.ui.io/.
   </p>
 
   <p>


### PR DESCRIPTION
Our users might be confused, because our documentation has to use "App Studio" right now, not the actual product name. This PR is meant to help with that.