### PR TITLE
Add UserSignupVerificationRequiredTotal metric

### DIFF
--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -321,6 +321,56 @@ func TestDeletingUserSignupShouldNotUpdateMetrics(t *testing.T) {
 
 }
 
+func TestUserSignupVerificationRequiredMetric(t *testing.T) {
+	// given
+	member := NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue)
+	defer counter.Reset()
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+	userSignup := commonsignup.NewUserSignup(
+		commonsignup.ApprovedManually(),
+	)
+	// set verification required to true in spec only, status will be added during reconcile
+	states.SetVerificationRequired(userSignup, true)
+	r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(member), userSignup, baseNSTemplateTier)
+	AssertMetricsCounterEquals(t, 0, metrics.UserSignupVerificationRequiredTotal)
+
+	// when
+	_, err := r.Reconcile(context.TODO(), req)
+
+	// then
+	require.NoError(t, err)
+
+	// Verify the metric
+	AssertMetricsCounterEquals(t, 1, metrics.UserSignupVerificationRequiredTotal)
+
+	// assert that usersignup status has verification required condition
+	updatedUserSignup := &toolchainv1alpha1.UserSignup{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: test.HostOperatorNs,
+		Name:      userSignup.Name,
+	}, updatedUserSignup)
+	require.NoError(t, err)
+
+	// verify that the status has the verification required condition
+	test.AssertContainsCondition(t, updatedUserSignup.Status.Conditions, toolchainv1alpha1.Condition{
+		Type:   toolchainv1alpha1.UserSignupComplete,
+		Status: corev1.ConditionFalse,
+		Reason: toolchainv1alpha1.UserSignupVerificationRequiredReason,
+	})
+
+	// metrics counter still equals 1 after second reconcile
+	t.Run("second reconcile", func(t *testing.T) {
+		// when
+		_, err := r.Reconcile(context.TODO(), req)
+
+		// then
+		require.NoError(t, err)
+
+		// Verify the metric
+		AssertMetricsCounterEquals(t, 1, metrics.UserSignupVerificationRequiredTotal)
+	})
+}
+
 func TestUserSignupWithAutoApprovalWithoutTargetCluster(t *testing.T) {
 	// given
 	userSignup := commonsignup.NewUserSignup()

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -33,6 +33,9 @@ var (
 
 	// UserSignupDeletedWithoutInitiatingVerificationTotal is incremented each time a user signup is deleted due to verification time trial expired, and verification was NOT initiated
 	UserSignupDeletedWithoutInitiatingVerificationTotal prometheus.Counter
+
+	// UserSignupVerificationRequiredTotal is incremented only the first time a user signup requires verification, can be multiple times per user if they reactivate multiple times
+	UserSignupVerificationRequiredTotal prometheus.Counter
 )
 
 // gauge with labels
@@ -70,6 +73,7 @@ func initMetrics() {
 	UserSignupAutoDeactivatedTotal = newCounter("user_signups_auto_deactivated_total", "Total number of automatically deactivated UserSignups")
 	UserSignupDeletedWithInitiatingVerificationTotal = newCounter("user_signups_deleted_with_initiating_verification_total", "Total number of UserSignups deleted after verification time trial and with verification initiated")
 	UserSignupDeletedWithoutInitiatingVerificationTotal = newCounter("user_signups_deleted_without_initiating_verification_total", "Total number of deleted UserSignups after verification time trial but without verification initiated")
+	UserSignupVerificationRequiredTotal = newCounter("user_signups_verification_required_total", "Total number of UserSignups that require verification, does not count verification attempts")
 	// Gauges with labels
 	SpaceGaugeVec = newGaugeVec("spaces_current", "Current number of Spaces (per member cluster)", "cluster_name")
 	UserSignupsPerActivationAndDomainGaugeVec = newGaugeVec("users_per_activations_and_domain", "Number of UserSignups per activations and domain", []string{"activations", "domain"}...)


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1790

```
# HELP sandbox_user_signups_verification_required_total Total number of UserSignups that require verification, does not count verification attempts
# TYPE sandbox_user_signups_verification_required_total counter
sandbox_user_signups_verification_required_total 14
```

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/734