### PR TITLE
fix: invalid number of subSpaces issue

### DIFF
--- a/controllers/spacerequest/spacerequest_controller.go
+++ b/controllers/spacerequest/spacerequest_controller.go
@@ -109,16 +109,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, nil
 	}
 
+	// find parent space from namespace labels
+	parentSpace, err := r.getParentSpace(memberClusterWithSpaceRequest, spaceRequest)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// parentSpace is being deleted
+	if util.IsBeingDeleted(parentSpace) {
+		return ctrl.Result{}, errs.New("parentSpace is being deleted")
+	}
+
 	if util.IsBeingDeleted(spaceRequest) {
 		logger.Info("spaceRequest is being deleted")
-		return reconcile.Result{}, r.ensureSpaceDeletion(logger, memberClusterWithSpaceRequest, spaceRequest)
+		return reconcile.Result{}, r.ensureSpaceDeletion(logger, memberClusterWithSpaceRequest, spaceRequest, parentSpace)
 	}
 	// Add the finalizer if it is not present
 	if err := r.addFinalizer(logger, memberClusterWithSpaceRequest, spaceRequest); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	subSpace, createdOrUpdated, err := r.ensureSpace(logger, memberClusterWithSpaceRequest, spaceRequest)
+	subSpace, createdOrUpdated, err := r.ensureSpace(logger, memberClusterWithSpaceRequest, spaceRequest, parentSpace)
 	// if there was an error or if subSpace was just created or updated,
 	// let's just return.
 	if err != nil || createdOrUpdated {
@@ -173,74 +183,49 @@ func (r *Reconciler) addFinalizer(logger logr.Logger, memberCluster cluster.Clus
 	return nil
 }
 
-func (r *Reconciler) ensureSpace(logger logr.Logger, memberCluster cluster.Cluster, spaceRequest *toolchainv1alpha1.SpaceRequest) (*toolchainv1alpha1.Space, bool, error) {
-	logger.Info("ensuring Space")
-
-	// get subSpace resource
-	spaceList, err := r.listSubSpaces(spaceRequest)
-	if err != nil {
-		return nil, false, err
-	}
+func (r *Reconciler) ensureSpace(logger logr.Logger, memberCluster cluster.Cluster, spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *toolchainv1alpha1.Space) (*toolchainv1alpha1.Space, bool, error) {
+	logger.Info("ensuring subSpace")
 
 	// validate tierName
 	if err := r.validateNSTemplateTier(spaceRequest.Spec.TierName); err != nil {
 		return nil, false, err
 	}
 
-	var subSpace *toolchainv1alpha1.Space
-	switch {
-	case len(spaceList.Items) == 0:
-		// find parent space from namespace labels
-		parentSpace, err := r.getParentSpace(memberCluster, spaceRequest)
-		if err != nil {
-			return nil, false, err
+	// create if not found on the expected target cluster
+	subSpace := &toolchainv1alpha1.Space{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      spaceutil.SubSpaceName(spaceRequest, parentSpace),
+	}, subSpace); err != nil {
+		if errors.IsNotFound(err) {
+			// no spaces found, let's create it
+			logger.Info("creating subSpace")
+			if err := r.setStatusProvisioning(memberCluster, spaceRequest); err != nil {
+				return nil, false, errs.Wrap(err, "error updating status")
+			}
+			subSpace, err = r.createNewSubSpace(logger, spaceRequest, parentSpace)
+			if err != nil {
+				// failed to create subSpace
+				return nil, false, r.setStatusFailedToCreateSubSpace(logger, memberCluster, spaceRequest, err)
+			}
+			return subSpace, true, nil // a subSpace was created
 		}
-		// parentSpace is being deleted
-		if util.IsBeingDeleted(parentSpace) {
-			return nil, false, errs.New("parentSpace is being deleted")
-		}
-		// no spaces found, let's create it
-		subSpace, err = r.createNewSubSpace(logger, spaceRequest, parentSpace)
-		if err != nil {
-			// failed to create subSpace
-			return nil, false, r.setStatusFailedToCreateSubSpace(logger, memberCluster, spaceRequest, err)
-		}
-		if err := r.setStatusProvisioning(memberCluster, spaceRequest); err != nil {
-			return nil, false, errs.Wrap(err, "error updating status")
-		}
-		return subSpace, true, nil // a subSpace was created
-
-	case len(spaceList.Items) == 1:
-		subSpace = &spaceList.Items[0]
-		updated, err := r.updateExistingSubSpace(logger, spaceRequest, subSpace)
-		return subSpace, updated, err
-
-	default:
-		// some unexpected issue causing to many subspaces
-		return nil, false, fmt.Errorf("invalid number of subSpaces found. actual %d, expected %d", len(spaceList.Items), 1)
+		// failed to create subSpace
+		return nil, false, r.setStatusFailedToCreateSubSpace(logger, memberCluster, spaceRequest, err)
 	}
-}
-
-func (r *Reconciler) listSubSpaces(spaceRequest *toolchainv1alpha1.SpaceRequest) (*toolchainv1alpha1.SpaceList, error) {
-	spaceList := &toolchainv1alpha1.SpaceList{}
-	spaceRequestLabel := runtimeclient.MatchingLabels{
-		toolchainv1alpha1.SpaceRequestLabelKey:          spaceRequest.GetName(),
-		toolchainv1alpha1.SpaceRequestNamespaceLabelKey: spaceRequest.GetNamespace(),
-	}
-	if err := r.Client.List(context.TODO(), spaceList, spaceRequestLabel, runtimeclient.InNamespace(r.Namespace)); err != nil {
-		return nil, errs.Wrap(err, fmt.Sprintf(`attempt to list Spaces associated with spaceRequest %s in namespace %s failed`, spaceRequest.GetName(), spaceRequest.GetNamespace()))
-	}
-	return spaceList, nil
+	logger.Info("subSpace already exists")
+	updated, err := r.updateExistingSubSpace(logger, spaceRequest, subSpace)
+	return subSpace, updated, err
 }
 
 func (r *Reconciler) createNewSubSpace(logger logr.Logger, spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *toolchainv1alpha1.Space) (*toolchainv1alpha1.Space, error) {
 	subSpace := spaceutil.NewSubSpace(spaceRequest, parentSpace)
 	err := r.Client.Create(context.TODO(), subSpace)
-	if err != nil {
-		return subSpace, errs.Wrap(err, "unable to create space")
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return subSpace, errs.Wrap(err, "unable to create subSpace")
 	}
 
-	logger.Info("Created subSpace", "name", subSpace.Name, "target_cluster_roles", spaceRequest.Spec.TargetClusterRoles, "tierName", spaceRequest.Spec.TierName, "targetCluster", subSpace.Spec.TargetCluster)
+	logger.Info("created subSpace", "name", subSpace.Name, "target_cluster_roles", spaceRequest.Spec.TargetClusterRoles, "tierName", spaceRequest.Spec.TierName, "targetCluster", subSpace.Spec.TargetCluster)
 	return subSpace, nil
 }
 
@@ -336,14 +321,14 @@ func (r *Reconciler) getParentSpace(memberCluster cluster.Cluster, spaceRequest 
 	return parentSpace, nil // all good
 }
 
-func (r *Reconciler) ensureSpaceDeletion(logger logr.Logger, memberClusterWithSpaceRequest cluster.Cluster, spaceRequest *toolchainv1alpha1.SpaceRequest) error {
-	logger.Info("ensure Space deletion")
+func (r *Reconciler) ensureSpaceDeletion(logger logr.Logger, memberClusterWithSpaceRequest cluster.Cluster, spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *toolchainv1alpha1.Space) error {
+	logger.Info("ensure subSpace deletion")
 	if !util.HasFinalizer(spaceRequest, toolchainv1alpha1.FinalizerName) {
 		// finalizer was already removed, nothing to delete anymore...
 		return nil
 	}
 
-	if isBeingDeleted, err := r.deleteSubSpace(logger, spaceRequest); err != nil {
+	if isBeingDeleted, err := r.deleteSubSpace(logger, spaceRequest, parentSpace); err != nil {
 		return r.setStatusTerminatingFailed(logger, memberClusterWithSpaceRequest, spaceRequest, err)
 	} else if isBeingDeleted {
 		if err := r.setStatusTerminating(memberClusterWithSpaceRequest, spaceRequest); err != nil {
@@ -365,26 +350,21 @@ func (r *Reconciler) ensureSpaceDeletion(logger logr.Logger, memberClusterWithSp
 // returns true/nil if the deletion of the subSpace was triggered
 // returns false/nil if the subSpace was already deleted
 // return false/err if something went wrong
-func (r *Reconciler) deleteSubSpace(logger logr.Logger, spaceRequest *toolchainv1alpha1.SpaceRequest) (bool, error) {
-	subSpaces, err := r.listSubSpaces(spaceRequest)
-	if err != nil {
+func (r *Reconciler) deleteSubSpace(logger logr.Logger, spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *toolchainv1alpha1.Space) (bool, error) {
+	subSpace := &toolchainv1alpha1.Space{}
+	if err := r.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      spaceutil.SubSpaceName(spaceRequest, parentSpace),
+	}, subSpace); err != nil {
+		if errors.IsNotFound(err) {
+			// no spaces found, already deleted
+			return false, nil
+		}
+		// failed to get subSpace
 		return false, err
 	}
-
-	switch {
-	case len(subSpaces.Items) == 0:
-		// subSpace was already deleted
-		return false, nil
-
-	case len(subSpaces.Items) == 1:
-		// deleting subSpace
-		return r.deleteExistingSubSpace(logger, &subSpaces.Items[0])
-
-	default:
-		// something went wrong and there are too many subspaces
-		return false, fmt.Errorf("invalid number of subSpaces found. actual %d, expected %d", len(subSpaces.Items), 1)
-	}
-
+	// deleting subSpace
+	return r.deleteExistingSubSpace(logger, subSpace)
 }
 
 // deleteExistingSubSpace deletes a given space object in case deletion was not issued already.

--- a/controllers/spacerequest/spacerequest_controller_test.go
+++ b/controllers/spacerequest/spacerequest_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/spacerequest"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
 	"github.com/codeready-toolchain/host-operator/pkg/cluster"
+	spaceutil "github.com/codeready-toolchain/host-operator/pkg/space"
 	. "github.com/codeready-toolchain/host-operator/test"
 	tiertest "github.com/codeready-toolchain/host-operator/test/nstemplatetier"
 	spacetest "github.com/codeready-toolchain/host-operator/test/space"
@@ -44,7 +45,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			spacerequesttest.WithTierName("appstudio"),
 			spacerequesttest.WithTargetClusterRoles(srClusterRoles))
 
-		t.Run("space doesn't exists it should be created", func(t *testing.T) {
+		t.Run("subSpace doesn't exists it should be created", func(t *testing.T) {
 			// given
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-1", corev1.ConditionTrue)
 			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
@@ -61,13 +62,13 @@ func TestCreateSpaceRequest(t *testing.T) {
 				HasSpecTierName("appstudio").
 				HasConditions(spacetest.Provisioning()).
 				HasFinalizer()
-			// there should be 1 space that was created from the spacerequest
+			// there should be 1 subSpace that was created from the spacerequest
 			spacetest.AssertThatSubSpace(t, hostClient, sr, parentSpace).
 				HasTier("appstudio").
 				HasSpecTargetClusterRoles(srClusterRoles)
 		})
 
-		t.Run("space exists but is not ready yet", func(t *testing.T) {
+		t.Run("subSpace exists but is not ready yet", func(t *testing.T) {
 			// given
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-1", corev1.ConditionTrue)
 			subSpace := spacetest.NewSpace("jane-subs",
@@ -100,14 +101,14 @@ func TestCreateSpaceRequest(t *testing.T) {
 				HasParentSpace("jane") // the parent space is set as expected
 		})
 
-		t.Run("space is provisioned", func(t *testing.T) {
+		t.Run("subSpace is provisioned", func(t *testing.T) {
 			// given
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-1", corev1.ConditionTrue)
 			commontest.SetupGockForServiceAccounts(t, member1.APIEndpoint, types.NamespacedName{
 				Name:      toolchainv1alpha1.AdminServiceAccountName,
 				Namespace: "jane-env",
 			})
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.ParentSpaceLabelKey, "jane"),
@@ -136,14 +137,14 @@ func TestCreateSpaceRequest(t *testing.T) {
 				HasNamespaceAccess([]toolchainv1alpha1.NamespaceAccess{{Name: "jane-env"}}). // has access details for the provisioned namespace
 				HasFinalizer()
 			// a subspace is created with the tierName and cluster roles from the spacerequest
-			spacetest.AssertThatSpace(t, test.HostOperatorNs, "jane-subs", hostClient).
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, spaceutil.SubSpaceName(sr, parentSpace), hostClient).
 				HasSpecTargetClusterRoles(srClusterRoles).
 				HasConditions(spacetest.Ready()).
 				HasTier(sr.Spec.TierName).
 				HasParentSpace("jane") // the parent space is set as expected
 		})
 
-		t.Run("space has multiple provisioned namespaces", func(t *testing.T) {
+		t.Run("subSpace has multiple provisioned namespaces", func(t *testing.T) {
 			// given
 			// the default namespace has already an access secret provisioned
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-1", corev1.ConditionTrue)
@@ -157,7 +158,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 				},
 			)
 			// this space has multiple namespaces provisioned
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.ParentSpaceLabelKey, "jane"),
@@ -192,7 +193,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 				HasNamespaceAccess([]toolchainv1alpha1.NamespaceAccess{{Name: "jane-env1", SecretRef: "existingDevSecret"}, {Name: "jane-env2"}}). // expected secrets are there.
 				HasFinalizer()
 			// a subspace is created with the tierName and cluster roles from the spacerequest
-			spacetest.AssertThatSpace(t, test.HostOperatorNs, "jane-subs", hostClient).
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, spaceutil.SubSpaceName(sr, parentSpace), hostClient).
 				HasSpecTargetClusterRoles(srClusterRoles).
 				HasConditions(spacetest.Ready()).
 				HasTier(sr.Spec.TierName).
@@ -245,7 +246,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 				HasSpecTargetCluster("member-2")          // subSpace has same target cluster as parentSpace
 		})
 
-		t.Run("space request has already an existing secret", func(t *testing.T) {
+		t.Run("spacerequest has already an existing secret", func(t *testing.T) {
 			// given
 			kubeconfigSecret1 := test.CreateSecret("jane-xyz1", sr.Namespace, map[string][]byte{
 				"kubeconfig": []byte(fakeKubeConfigSecret()),
@@ -268,7 +269,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 				},
 			)
 			// this space has multiple namespaces provisioned
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.ParentSpaceLabelKey, "jane"),
@@ -303,7 +304,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 				HasNamespaceAccess([]toolchainv1alpha1.NamespaceAccess{{Name: "jane-env1", SecretRef: "jane-xyz1"}, {Name: "jane-env2"}}). // first secret was already there while second one just newly created.
 				HasFinalizer()
 			// a subspace is created with the tierName and cluster roles from the spacerequest
-			spacetest.AssertThatSpace(t, test.HostOperatorNs, "jane-subs", hostClient).
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, spaceutil.SubSpaceName(sr, parentSpace), hostClient).
 				HasSpecTargetClusterRoles(srClusterRoles).
 				HasConditions(spacetest.Ready()).
 				HasTier(sr.Spec.TierName).
@@ -346,30 +347,11 @@ func TestCreateSpaceRequest(t *testing.T) {
 			require.EqualError(t, err, "unable to get the current SpaceRequest: mock error")
 		})
 
-		t.Run("unable to list subSpaces", func(t *testing.T) {
-			member1Client := test.NewFakeClient(t, sr, srNamespace)
-			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
-			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
-			hostClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
-				if _, ok := list.(*toolchainv1alpha1.SpaceList); ok {
-					return fmt.Errorf("mock error")
-				}
-				return member1Client.List(ctx, list, opts...)
-			}
-			ctrl := newReconciler(t, hostClient, member1)
-
-			// when
-			_, err := ctrl.Reconcile(context.TODO(), requestFor(sr))
-
-			// then
-			require.EqualError(t, err, "attempt to list Spaces associated with spaceRequest jane in namespace jane-tenant failed: mock error")
-		})
-
 		t.Run("error while adding finalizer", func(t *testing.T) {
-			member1Client := test.NewFakeClient(t, sr)
+			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1Client.MockUpdate = mockUpdateSpaceRequestFail(member1Client)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
-			hostClient := test.NewFakeClient(t, appstudioTier)
+			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
 			ctrl := newReconciler(t, hostClient, member1)
 
 			// when
@@ -413,7 +395,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 		t.Run("unable to update space since it's being deleted", func(t *testing.T) {
 			// given
 			member1 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-1", corev1.ConditionTrue)
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithDeletionTimestamp(),                                                       // space is being deleted ...
@@ -455,7 +437,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 				spacerequesttest.WithTargetClusterRoles(srClusterRoles))
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
-			hostClient := test.NewFakeClient(t, appstudioTier)
+			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
 			ctrl := newReconciler(t, hostClient, member1)
 
 			// when
@@ -485,7 +467,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			require.EqualError(t, err, "unable to get the current NSTemplateTier: mock error")
 		})
 
-		t.Run("error creating space", func(t *testing.T) {
+		t.Run("error creating subSpace", func(t *testing.T) {
 			// given
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
@@ -502,7 +484,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			_, err := ctrl.Reconcile(context.TODO(), requestFor(sr))
 
 			// then
-			require.EqualError(t, err, "unable to create space: mock error")
+			require.EqualError(t, err, "unable to create subSpace: mock error")
 		})
 		t.Run("parent space is being deleted", func(t *testing.T) {
 			// given
@@ -535,28 +517,6 @@ func TestCreateSpaceRequest(t *testing.T) {
 			require.EqualError(t, err, "unable to get parentSpace: spaces.toolchain.dev.openshift.com \"jane\" not found")
 		})
 
-		t.Run("invalid number of subSpaces found", func(t *testing.T) {
-			// given
-			subSpace1 := spacetest.NewSpace("jane-subs",
-				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
-				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
-				spacetest.WithSpecParentSpace("jane"))
-			subSpace2 := spacetest.NewSpace("jane-subs2",
-				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
-				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
-				spacetest.WithSpecParentSpace("jane"))
-			member1Client := test.NewFakeClient(t, sr, srNamespace)
-			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
-			hostClient := test.NewFakeClient(t, appstudioTier, subSpace1, subSpace2, parentSpace)
-			ctrl := newReconciler(t, hostClient, member1)
-
-			// when
-			_, err := ctrl.Reconcile(context.TODO(), requestFor(sr))
-
-			// then
-			require.EqualError(t, err, "invalid number of subSpaces found. actual 2, expected 1")
-		})
-
 		t.Run("invalid number of secrets found", func(t *testing.T) {
 			// given
 			kubeconfigSecret1 := test.CreateSecret("jane-xyz1", sr.Namespace, map[string][]byte{
@@ -573,7 +533,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 			kubeconfigSecret2.Labels[toolchainv1alpha1.SpaceRequestLabelKey] = sr.GetName()
 			kubeconfigSecret2.Labels[toolchainv1alpha1.SpaceRequestNamespaceLabelKey] = sr.GetNamespace()
 			kubeconfigSecret2.Labels[toolchainv1alpha1.SpaceRequestProvisionedNamespaceLabelKey] = "jane-env"
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithSpecTargetClusterRoles(srClusterRoles),
@@ -659,7 +619,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 				spacerequesttest.WithTierName(newTier.Name), // space request uses new tier
 				spacerequesttest.WithTargetClusterRoles(srClusterRoles),
 				spacerequesttest.WithFinalizer())
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.ParentSpaceLabelKey, parentSpace.GetName()),
@@ -682,7 +642,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 				HasSpecTierName(newTier.Name). // space request still has the new tier
 				HasFinalizer()
 			// the subspace is updated with tierName and cluster roles from the spacerequests
-			spacetest.AssertThatSpace(t, test.HostOperatorNs, "jane-subs", hostClient).
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, spaceutil.SubSpaceName(sr, parentSpace), hostClient).
 				HasSpecTargetClusterRoles(srClusterRoles).
 				HasTier(newTier.Name). // now also the subSpace reflects same tier
 				HasParentSpace("jane")
@@ -696,7 +656,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 				spacerequesttest.WithTierName("appstudio"),
 				spacerequesttest.WithTargetClusterRoles(updatedSRClusterRoles), // add a new cluster role label to check if it's reflected on the subSpace
 				spacerequesttest.WithFinalizer())
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.ParentSpaceLabelKey, parentSpace.GetName()),
@@ -720,7 +680,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 				HasSpecTierName("appstudio").
 				HasFinalizer()
 			// the subspace is updated with the tierName and new cluster roles from the spacerequest
-			spacetest.AssertThatSpace(t, test.HostOperatorNs, "jane-subs", hostClient).
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, spaceutil.SubSpaceName(sr, parentSpace), hostClient).
 				HasSpecTargetClusterRoles(updatedSRClusterRoles). // now also subSpace has the updated cluster roles
 				HasTier("appstudio").
 				HasParentSpace("jane")
@@ -736,7 +696,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 					SecretRef: "jane-qwerty", // secret doesn't exist and name of the secret will change when it will be created
 				}),
 				spacerequesttest.WithFinalizer())
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.ParentSpaceLabelKey, parentSpace.GetName()),
@@ -778,7 +738,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 				srNamespace.GetName(),
 				spacerequesttest.WithTierName("appstudio"),
 				spacerequesttest.WithFinalizer())
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()),
 				spacetest.WithSpecTargetCluster("member-1"),
@@ -811,7 +771,7 @@ func TestUpdateSpaceRequest(t *testing.T) {
 				spacerequesttest.WithTargetClusterRoles(srClusterRoles),
 				spacerequesttest.WithStatusTargetClusterURL(""), // target cluster URL is empty
 				spacerequesttest.WithFinalizer())
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithStatusTargetCluster("invalid"),                                            // let's force an invalid name in the subSpace
@@ -850,7 +810,7 @@ func TestDeleteSpaceRequest(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Run("spaceRequest should be in terminating while subSpace is deleted", func(t *testing.T) {
 			// given
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),               // subSpace was created from spaceRequest
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()), // subSpace was created from spaceRequest
 				spacetest.WithSpecTargetCluster("member-1"),
@@ -872,7 +832,7 @@ func TestDeleteSpaceRequest(t *testing.T) {
 				HasConditions(spacetest.Terminating()).
 				HasFinalizer() // finalizer is still there until subSpace is gone
 			// subSpace is deleted
-			spacetest.AssertThatSpace(t, test.HostOperatorNs, "jane-subs", hostClient).
+			spacetest.AssertThatSpace(t, test.HostOperatorNs, spaceutil.SubSpaceName(sr, parentSpace), hostClient).
 				DoesNotExist() // subSpace is gone
 
 			t.Run("spaceRequest is deleted when subSpace is gone", func(t *testing.T) {
@@ -897,7 +857,7 @@ func TestDeleteSpaceRequest(t *testing.T) {
 				spacerequesttest.WithDeletionTimestamp()) // spaceRequest was deleted
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
-			hostClient := test.NewFakeClient(t, appstudioTier)
+			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
 			ctrl := newReconciler(t, hostClient, member1)
 
 			// when
@@ -912,31 +872,9 @@ func TestDeleteSpaceRequest(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
-		t.Run("unexpected number of subSpaces", func(t *testing.T) {
-			// given
-			subSpace1 := spacetest.NewSpace("jane-subs",
-				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),
-				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()),
-				spacetest.WithSpecParentSpace("jane"))
-			subSpace2 := spacetest.NewSpace("jane-subs2",
-				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),
-				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()),
-				spacetest.WithSpecParentSpace("jane"))
-			member1Client := test.NewFakeClient(t, sr, srNamespace)
-			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
-			hostClient := test.NewFakeClient(t, appstudioTier, subSpace1, subSpace2, parentSpace)
-			ctrl := newReconciler(t, hostClient, member1)
-
-			// when
-			_, err := ctrl.Reconcile(context.TODO(), requestFor(sr))
-
-			// then
-			require.EqualError(t, err, "invalid number of subSpaces found. actual 2, expected 1")
-		})
-
 		t.Run("unable to set status terminating", func(t *testing.T) {
 			// given
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()),
 				spacetest.WithSpecParentSpace("jane"))
@@ -978,35 +916,15 @@ func TestDeleteSpaceRequest(t *testing.T) {
 			require.EqualError(t, err, "failed to remove finalizer: mock error")
 		})
 
-		t.Run("unable to list subSpaces", func(t *testing.T) {
-			// given
-			member1Client := test.NewFakeClient(t, sr, srNamespace)
-			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
-			hostClient := test.NewFakeClient(t, appstudioTier)
-			hostClient.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
-				if _, ok := list.(*toolchainv1alpha1.SpaceList); ok {
-					return fmt.Errorf("mock error")
-				}
-				return hostClient.Client.List(ctx, list, opts...)
-			}
-			ctrl := newReconciler(t, hostClient, member1)
-
-			// when
-			_, err := ctrl.Reconcile(context.TODO(), requestFor(sr))
-
-			// then
-			require.EqualError(t, err, "attempt to list Spaces associated with spaceRequest jane in namespace jane-tenant failed: mock error")
-		})
-
 		t.Run("unable to delete subSpace", func(t *testing.T) {
 			// given
-			subSpace := spacetest.NewSpace("jane-subs",
+			subSpace := spacetest.NewSpace(spaceutil.SubSpaceName(sr, parentSpace),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),
 				spacetest.WithLabel(toolchainv1alpha1.SpaceRequestNamespaceLabelKey, sr.GetNamespace()),
 				spacetest.WithSpecParentSpace("jane"))
 			member1Client := test.NewFakeClient(t, sr, srNamespace)
 			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
-			hostClient := test.NewFakeClient(t, appstudioTier, subSpace)
+			hostClient := test.NewFakeClient(t, appstudioTier, subSpace, parentSpace)
 			hostClient.MockDelete = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.DeleteOption) error {
 				if _, ok := obj.(*toolchainv1alpha1.Space); ok {
 					return fmt.Errorf("mock error")

--- a/pkg/space/space.go
+++ b/pkg/space/space.go
@@ -37,9 +37,9 @@ func NewSubSpace(spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *tool
 
 	space := &toolchainv1alpha1.Space{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    parentSpace.GetNamespace(),
-			GenerateName: parentSpace.GetName() + "-",
-			Labels:       labels,
+			Namespace: parentSpace.GetNamespace(),
+			Name:      SubSpaceName(spaceRequest, parentSpace),
+			Labels:    labels,
 		},
 		Spec: toolchainv1alpha1.SpaceSpec{
 			TargetClusterRoles: spaceRequest.Spec.TargetClusterRoles,
@@ -55,4 +55,8 @@ func NewSubSpace(spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *tool
 	}
 
 	return space
+}
+
+func SubSpaceName(spaceRequest *toolchainv1alpha1.SpaceRequest, parentSpace *toolchainv1alpha1.Space) string {
+	return parentSpace.GetName() + "-" + spaceRequest.GetName()
 }

--- a/pkg/space/space_test.go
+++ b/pkg/space/space_test.go
@@ -43,9 +43,8 @@ func TestNewSubSpace(t *testing.T) {
 	subSpace := NewSubSpace(sr, parentSpace)
 
 	// then
-	expectedSubSpace := spacetest.NewSpace("",
+	expectedSubSpace := spacetest.NewSpace(parentSpace.GetName()+"-"+sr.GetName(),
 		spacetest.WithSpecParentSpace(parentSpace.GetName()),
-		spacetest.WithGenerateName(parentSpace.GetName()),
 		spacetest.WithTierName("appstudio"),
 		spacetest.WithSpecTargetClusterRoles([]string{cluster.RoleLabel(cluster.Tenant)}),
 		spacetest.WithLabel(toolchainv1alpha1.SpaceRequestLabelKey, sr.GetName()),

--- a/pkg/space/space_test.go
+++ b/pkg/space/space_test.go
@@ -43,7 +43,7 @@ func TestNewSubSpace(t *testing.T) {
 	subSpace := NewSubSpace(sr, parentSpace)
 
 	// then
-	expectedSubSpace := spacetest.NewSpace(parentSpace.GetName()+"-"+sr.GetName(),
+	expectedSubSpace := spacetest.NewSpace(SubSpaceName(sr, parentSpace),
 		spacetest.WithSpecParentSpace(parentSpace.GetName()),
 		spacetest.WithTierName("appstudio"),
 		spacetest.WithSpecTargetClusterRoles([]string{cluster.RoleLabel(cluster.Tenant)}),


### PR DESCRIPTION
e2e test failed with multiple subSpaces found for a single spacerequest.

This PR replaces the subSpace name generation logic from using `GenerateName: parentSpace.Name-` to `Name: parentSpace.Name-spaceRequest.Name`. 
In this way the name of the subSpace is predetermined and trying to create it more than once will fail. Also getting the subSpace now is simpler since we don't need to rely on listing the subSpaces by label anymore. 

Jira bug: https://issues.redhat.com/browse/SANDBOX-52

host-operator logs:
```
{"level":"info","ts":"2023-05-16T16:52:17.553Z","msg":"Created subSpace","controller":"spacerequest","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"SpaceRequest","SpaceRequest":{"name":"testcreatespacerequestsubspacehasparents-2wtkd","namespace":"testcreatespacerequestsubspacehasparents-755hk-tenant"},"namespace":"testcreatespacerequestsubspacehasparents-755hk-tenant","name":"testcreatespacerequestsubspacehasparents-2wtkd","reconcileID":"afd4ed73-7b5d-497d-9ad9-b257d6b39e54","name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","target_cluster_roles":[],"tierName":"appstudio-env","targetCluster":"member-ci-op-wm0dmztf-ceea8.origin-ci-int-aws.dev.rhcloud.com"} {"level":"info","ts":"2023-05-16T16:52:17.563Z","msg":"reconciling SpaceRequest","controller":"spacerequest","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"SpaceRequest","SpaceRequest":

{"name":"testcreatespacerequestsubspacehasparents-2wtkd","namespace":"testcreatespacerequestsubspacehasparents-755hk-tenant"}
,"namespace":"testcreatespacerequestsubspacehasparents-755hk-tenant","name":"testcreatespacerequestsubspacehasparents-2wtkd","reconcileID":"f78e019f-17e9-4c9e-b22c-c5ac50025602"} {"level":"info","ts":"2023-05-16T16:52:17.563Z","msg":"ensuring Space","controller":"spacerequest","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"SpaceRequest","SpaceRequest":

{"name":"testcreatespacerequestsubspacehasparents-2wtkd","namespace":"testcreatespacerequestsubspacehasparents-755hk-tenant"}
,"namespace":"testcreatespacerequestsubspacehasparents-755hk-tenant","name":"testcreatespacerequestsubspacehasparents-2wtkd","reconcileID":"f78e019f-17e9-4c9e-b22c-c5ac50025602"} {"level":"info","ts":"2023-05-16T16:52:17.564Z","msg":"reconciling Space","controller":"spacecompletion","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"Space","Space":

{"name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","namespace":"toolchain-host-16163946"}
,"namespace":"toolchain-host-16163946","name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","reconcileID":"598b39b3-1770-45fe-b2ee-93decd0d7272","namespace":"toolchain-host-16163946"} {"level":"info","ts":"2023-05-16T16:52:17.564Z","msg":"reconciling Space","controller":"spacecleanup","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"Space","Space":

{"name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","namespace":"toolchain-host-16163946"}
,"namespace":"toolchain-host-16163946","name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","reconcileID":"8b1ecef5-f001-4b16-bdd7-a7b3585d7164"} {"level":"info","ts":"2023-05-16T16:52:17.564Z","msg":"reconciling Space","controller":"space","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"Space","Space":

{"name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","namespace":"toolchain-host-16163946"}
,"namespace":"toolchain-host-16163946","name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","reconcileID":"e67b66c1-12ed-498d-91f2-13229422a272"} {"level":"info","ts":"2023-05-16T16:52:17.564Z","msg":"adding finalizer on Space","controller":"space","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"Space","Space":

{"name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","namespace":"toolchain-host-16163946"}
,"namespace":"toolchain-host-16163946","name":"testcreatespacerequestsubspacehasparents-755hk-nb88v","reconcileID":"e67b66c1-12ed-498d-91f2-13229422a272"} {"level":"info","ts":"2023-05-16T16:52:17.570Z","msg":"reconciling Space","controller":"spacecompletion","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"Space","Space":

{"name":"testcreatespacerequestsubspacehasparents-755hk-pgx94","namespace":"toolchain-host-16163946"}
,"namespace":"toolchain-host-16163946","name":"testcreatespacerequestsubspacehasparents-755hk-pgx94","reconcileID":"2f9050db-0237-44ff-8472-0dc7bb446575","namespace":"toolchain-host-16163946"} {"level":"info","ts":"2023-05-16T16:52:17.570Z","msg":"reconciling Space","controller":"spacecleanup","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"Space","Space":

{"name":"testcreatespacerequestsubspacehasparents-755hk-pgx94","namespace":"toolchain-host-16163946"}
,"namespace":"toolchain-host-16163946","name":"testcreatespacerequestsubspacehasparents-755hk-pgx94","reconcileID":"5aea3c77-868a-4999-bfab-69b77766841a"} {"level":"info","ts":"2023-05-16T16:52:17.570Z","msg":"Created subSpace","controller":"spacerequest","controllerGroup":"toolchain.dev.openshift.com","controllerKind":"SpaceRequest","SpaceRequest":{"name":"testcreatespacerequestsubspacehasparents-2wtkd","namespace":"testcreatespacerequestsubspacehasparents-755hk-tenant"},"namespace":"testcreatespacerequestsubspacehasparents-755hk-tenant","name":"testcreatespacerequestsubspacehasparents-2wtkd","reconcileID":"f78e019f-17e9-4c9e-b22c-c5ac50025602","name":"testcreatespacerequestsubspacehasparents-755hk-pgx94","target_cluster_roles":[],"tierName":"appstudio-env","targetCluster":"member-ci-op-wm0dmztf-ceea8.origin-ci-int-aws.dev.rhcloud.com"}
```