### PR TITLE
pendo track key added

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
@@ -189,6 +189,10 @@ spec:
                                   write key
                                 type: string
                             type: object
+                          pendoTrackEventKey:
+                            description: PendoTrackEventKey specifies the pendo track
+                              event key for tracking events
+                            type: string
                           segmentWriteKey:
                             description: SegmentWriteKey specifies the segment write
                               key for sandbox


### PR DESCRIPTION
toolchainconfig updated by running `make generate` in api

related PR: https://github.com/codeready-toolchain/api/pull/363/