### PR TITLE
use annotations user ID for using SSO User_Id

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -589,7 +589,7 @@ func (r *Reconciler) provisionMasterUserRecord(logger logr.Logger, config toolch
 
 	// track the MUR creation as an account activation event in Segment
 	if r.SegmentClient != nil {
-		r.SegmentClient.TrackAccountActivation(compliantUsername, userSignup.Spec.Userid, userSignup.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey])
+		r.SegmentClient.TrackAccountActivation(compliantUsername, userSignup.Annotations[toolchainv1alpha1.SSOUserIDAnnotationKey], userSignup.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey])
 	} else {
 		logger.Info("segment client not configured to track account activations")
 	}

--- a/test/segment/assertions.go
+++ b/test/segment/assertions.go
@@ -12,7 +12,7 @@ import (
 )
 
 func AssertMessageQueuedForProvisionedMur(t *testing.T, cl *segment.Client, us *toolchainv1alpha1.UserSignup, murName string) {
-	assertMessageQueued(t, cl, murName, us.Spec.Userid, us.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey], "account activated")
+	assertMessageQueued(t, cl, murName, us.Annotations[toolchainv1alpha1.SSOUserIDAnnotationKey], us.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey], "account activated")
 }
 
 func assertMessageQueued(t *testing.T, cl *segment.Client, username, userID, accountID string, event string) {


### PR DESCRIPTION
Use Annotations[SSOUserIDAnnotationKey] instead of usersignup.Spec.userId to reflect Red Hat SSO ID being sent to segment.