### PR TITLE
add accountID in properties as well

### DIFF
--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -44,9 +44,11 @@ const AccountActivated = "account activated"
 func (c *Client) TrackAccountActivation(username, userID, accountID string) {
 	logger.Info("sending event to Segment", "event", AccountActivated, "username_hash", Hash(username), "userid", userID, "accountid", accountID)
 	if err := c.client.Enqueue(analytics.Track{
-		Event:      AccountActivated,
-		UserId:     Hash(username),
-		Properties: analytics.NewProperties().Set("user_id", userID),
+		Event:  AccountActivated,
+		UserId: Hash(username),
+		Properties: analytics.NewProperties().
+			Set("user_id", userID).
+			Set("account_id", accountID),
 		Context: &analytics.Context{
 			Extra: map[string]interface{}{
 				"groupId": accountID,

--- a/test/segment/assertions.go
+++ b/test/segment/assertions.go
@@ -19,9 +19,12 @@ func assertMessageQueued(t *testing.T, cl *segment.Client, username, userID, acc
 	require.IsType(t, &MockClient{}, cl.Client())
 	require.Len(t, cl.Client().(*MockClient).Queue, 1)
 	assert.Equal(t, analytics.Track{
-		UserId:     segment.Hash(username),
-		Event:      event,
-		Properties: analytics.NewProperties().Set("user_id", userID),
+		UserId: segment.Hash(username),
+		Event:  event,
+		Properties: analytics.Properties{
+			"user_id":    userID,
+			"account_id": accountID,
+		},
 		Context: &analytics.Context{
 			Extra: map[string]interface{}{
 				"groupId": accountID,


### PR DESCRIPTION
fix wrt: https://issues.redhat.com/browse/SANDBOX-55

Instead of sending the activation to pendo directly from code, add accountId in properties to the data being sent to segment. Since data in context could not be used to send to pendo, moving it to properties is the alternate. This way segment can remain the single source of data, and the data can be relayed from amplitude to pendo via existing field mapping.