### PR TITLE
Send epoch time in segment properties

### DIFF
--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -2,6 +2,7 @@ package segment
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/segmentio/analytics-go/v3"
@@ -48,7 +49,8 @@ func (c *Client) TrackAccountActivation(username, userID, accountID string) {
 		UserId: Hash(username),
 		Properties: analytics.NewProperties().
 			Set("user_id", userID).
-			Set("account_id", accountID),
+			Set("account_id", accountID).
+			Set("epoch_time", time.Now()),
 		Context: &analytics.Context{
 			Extra: map[string]interface{}{
 				"groupId": accountID,

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -50,7 +50,7 @@ func (c *Client) TrackAccountActivation(username, userID, accountID string) {
 		Properties: analytics.NewProperties().
 			Set("user_id", userID).
 			Set("account_id", accountID).
-			Set("epoch_time", time.Now()),
+			Set("epoch_time", time.Now().UnixMilli()),
 		Context: &analytics.Context{
 			Extra: map[string]interface{}{
 				"groupId": accountID,

--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -44,9 +44,11 @@ const AccountActivated = "account activated"
 func (c *Client) TrackAccountActivation(username, userID, accountID string) {
 	logger.Info("sending event to Segment", "event", AccountActivated, "username_hash", Hash(username), "userid", userID, "accountid", accountID)
 	if err := c.client.Enqueue(analytics.Track{
-		Event:      AccountActivated,
-		UserId:     Hash(username),
-		Properties: analytics.NewProperties().Set("user_id", userID),
+		Event:  AccountActivated,
+		UserId: Hash(username),
+		Properties: analytics.NewProperties().
+			Set("user_id", userID).
+			Set("account_id", accountID),
 		Context: &analytics.Context{
 			Extra: map[string]interface{}{
 				"groupId": accountID,

--- a/test/segment/assertions.go
+++ b/test/segment/assertions.go
@@ -18,7 +18,7 @@ func AssertMessageQueuedForProvisionedMur(t *testing.T, cl *segment.Client, us *
 func assertMessageQueued(t *testing.T, cl *segment.Client, username, userID, accountID string, event string) {
 	require.IsType(t, &MockClient{}, cl.Client())
 	require.Len(t, cl.Client().(*MockClient).Queue, 1)
-	assert.Equal(t, analytics.Track{
+	expectedTrackEvent := analytics.Track{
 		UserId: segment.Hash(username),
 		Event:  event,
 		Properties: analytics.Properties{
@@ -30,7 +30,16 @@ func assertMessageQueued(t *testing.T, cl *segment.Client, username, userID, acc
 				"groupId": accountID,
 			},
 		},
-	}, cl.Client().(*MockClient).Queue[0])
+	}
+	actualMessage := cl.Client().(*MockClient).Queue[0]
+	actualTrackEvent, ok := actualMessage.(analytics.Track)
+	require.True(t, ok)
+	assert.Equal(t, expectedTrackEvent.UserId, actualTrackEvent.UserId)
+	assert.Equal(t, expectedTrackEvent.Event, actualTrackEvent.Event)
+	assert.Equal(t, expectedTrackEvent.Context, actualTrackEvent.Context)
+	assert.Equal(t, expectedTrackEvent.Properties["user_id"], actualTrackEvent.Properties["user_id"])
+	assert.Equal(t, expectedTrackEvent.Properties["account_id"], actualTrackEvent.Properties["account_id"])
+	assert.NotEmpty(t, actualTrackEvent.Properties["epoch_time"])
 }
 
 func AssertNoMessageQueued(t *testing.T, cl *segment.Client) {

--- a/test/segment/assertions.go
+++ b/test/segment/assertions.go
@@ -39,7 +39,7 @@ func assertMessageQueued(t *testing.T, cl *segment.Client, username, userID, acc
 	assert.Equal(t, expectedTrackEvent.Context, actualTrackEvent.Context)
 	assert.Equal(t, expectedTrackEvent.Properties["user_id"], actualTrackEvent.Properties["user_id"])
 	assert.Equal(t, expectedTrackEvent.Properties["account_id"], actualTrackEvent.Properties["account_id"])
-	assert.NotEmpty(t, actualTrackEvent.Properties["epoch_time"])
+	assert.NotEmpty(t, actualTrackEvent.Properties["epoch_time"]) // not comparing the timestamp in test
 }
 
 func AssertNoMessageQueued(t *testing.T, cl *segment.Client) {

--- a/test/segment/assertions.go
+++ b/test/segment/assertions.go
@@ -19,9 +19,12 @@ func assertMessageQueued(t *testing.T, cl *segment.Client, username, userID, acc
 	require.IsType(t, &MockClient{}, cl.Client())
 	require.Len(t, cl.Client().(*MockClient).Queue, 1)
 	assert.Equal(t, analytics.Track{
-		UserId:     segment.Hash(username),
-		Event:      event,
-		Properties: analytics.NewProperties().Set("user_id", userID),
+		UserId: segment.Hash(username),
+		Event:  event,
+		Properties: analytics.Properties{
+			"user_id":    userID,
+			"account_id": accountID,
+		},
 		Context: &analytics.Context{
 			Extra: map[string]interface{}{
 				"groupId": accountID,


### PR DESCRIPTION
sending data from Amplitude -> pendo is failing due to incompatible timestamp formats. Thus sending the epoch time as part of properties to segment to propagate the field forward to pendo.

fix wrt: https://issues.redhat.com/browse/SANDBOX-55