### PR TITLE
fix: drop label WorkspaceLabelKey

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio-env/ns_env.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio-env/ns_env.yaml
@@ -12,7 +12,6 @@ objects:
       openshift.io/requester: ${SPACE_NAME}
     labels:
       name: ${SPACE_NAME}-env
-      toolchain.dev.openshift.com/workspace: ${SPACE_NAME}
       argocd.argoproj.io/managed-by: gitops-service-argocd
       #billing labels ref: https://github.com/redhat-appstudio/book/blob/main/ADR/0010-namespace-metadata.md
       appstudio.redhat.com/workspace_name: ${SPACE_NAME}

--- a/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -12,7 +12,6 @@ objects:
       openshift.io/requester: ${SPACE_NAME}
     labels:
       name: ${SPACE_NAME}-tenant
-      toolchain.dev.openshift.com/workspace: ${SPACE_NAME}
       argocd.argoproj.io/managed-by: gitops-service-argocd
       #billing labels ref: https://github.com/redhat-appstudio/book/blob/main/ADR/0010-namespace-metadata.md
       appstudio.redhat.com/workspace_name: ${SPACE_NAME}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20230601085531-c1f5bdd73897
+	github.com/codeready-toolchain/api v0.0.0-20230614144201-7277430214c4
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20230530174133-baf8f8452b7a
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
@@ -109,5 +109,3 @@ require (
 )
 
 go 1.19
-
-replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230613141142-c0ae2437e06d

--- a/go.mod
+++ b/go.mod
@@ -109,3 +109,5 @@ require (
 )
 
 go 1.19
+
+replace github.com/codeready-toolchain/api => /Users/fmuntean/go/src/github.com/codeready-toolchain/api

--- a/go.mod
+++ b/go.mod
@@ -110,4 +110,4 @@ require (
 
 go 1.19
 
-replace github.com/codeready-toolchain/api => /Users/fmuntean/go/src/github.com/codeready-toolchain/api
+replace github.com/codeready-toolchain/api => github.com/mfrancisc/api v0.0.0-20230613141142-c0ae2437e06d

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mfrancisc/api v0.0.0-20230613141142-c0ae2437e06d h1:R0lLlmWzWJS9cA2xPnBER8UpcN9PpEOtaY0OdVa3b6Q=
+github.com/mfrancisc/api v0.0.0-20230613141142-c0ae2437e06d/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20230601085531-c1f5bdd73897 h1:MK7+wRjyWSFlGFqTgZ8JbwtTdFxdqcEHeTGenwzhhXM=
-github.com/codeready-toolchain/api v0.0.0-20230601085531-c1f5bdd73897/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230530174133-baf8f8452b7a h1:5cu6etGWnbyBL93c4dGewvMIR8ZQKD0q3G+pSRGLkaM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230530174133-baf8f8452b7a/go.mod h1:w/RJnfU6/qb3xuMHLmIohtF3cptImBROgHALJ2cv9ww=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20230614144201-7277430214c4 h1:IjsK6+c5QZCR7FFTMUdtINAfqWW/Y74UsivrIVgj/pc=
+github.com/codeready-toolchain/api v0.0.0-20230614144201-7277430214c4/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230530174133-baf8f8452b7a h1:5cu6etGWnbyBL93c4dGewvMIR8ZQKD0q3G+pSRGLkaM=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20230530174133-baf8f8452b7a/go.mod h1:w/RJnfU6/qb3xuMHLmIohtF3cptImBROgHALJ2cv9ww=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -421,8 +423,6 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mfrancisc/api v0.0.0-20230613141142-c0ae2437e06d h1:R0lLlmWzWJS9cA2xPnBER8UpcN9PpEOtaY0OdVa3b6Q=
-github.com/mfrancisc/api v0.0.0-20230613141142-c0ae2437e06d/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/test/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/test/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -12,7 +12,6 @@ objects:
       openshift.io/requester: ${SPACE_NAME}
     labels:
       name: ${SPACE_NAME}-tenant
-      toolchain.dev.openshift.com/workspace: ${SPACE_NAME}
       appstudio.redhat.com/workspace_name: ${SPACE_NAME}
     name: ${SPACE_NAME}-tenant
 


### PR DESCRIPTION
Drop unused `toolchain.dev.openshift.com/workspace` label

Part of Jira: https://issues.redhat.com/browse/SANDBOX-51

