### PR TITLE
fix: refactor toolchain status test for revision check and copy revision check object 

### DIFF
--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -288,7 +288,7 @@ func (r *Reconciler) hostOperatorHandleStatus(reqLogger logr.Logger, toolchainSt
 		Version:        version.Version,
 		Revision:       version.Commit,
 		BuildTimestamp: version.BuildTime,
-		RevisionCheck:  toolchainv1alpha1.RevisionCheck{},
+		RevisionCheck:  toolchainStatus.Status.HostOperator.RevisionCheck, // let's copy the last revision check object if any
 	}
 	// look up name of the host operator deployment
 	hostOperatorName, errDeploy := commonconfig.GetOperatorName()


### PR DESCRIPTION
This PR's moves the unit test that covers the happy path of the revision check from it's own unit test to the existing one _"All components ready"_. 

Also copying the revisionCheck object so that it doesn't get lost in case an error occurs in the host operator status check prior to the execution of the `CheckDeployedVersionIsUpToDate` function.   