### PR TITLE
fix: add revision check component to status metadata for email notification

### DIFF
--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -92,7 +92,7 @@ const (
 {{end}}
 
 {{range .components}}
-<h4>{{.ComponentType}} {{.ComponentName}} not ready</h4>
+<h4>{{.ComponentName}} {{.ComponentType}} not ready</h4>
 
 <div style="padding-left: 40px">
 <div><span style="font-weight:bold;padding-right:10px">Reason:</span>{{.Reason}}</div>
@@ -657,7 +657,7 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.RegistrationService.Deployment.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentName: "Registration service",
+				ComponentName: "Registration Service",
 				ComponentType: "Deployment",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
@@ -667,7 +667,7 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.RegistrationService.Health.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentName: "Registration service",
+				ComponentName: "Registration Service",
 				ComponentType: "Health",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
@@ -677,7 +677,7 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.RegistrationService.RevisionCheck.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentName: "Registration service",
+				ComponentName: "Registration Service",
 				ComponentType: "Revision",
 				Reason:        cond.Reason,
 				Message:       cond.Message,

--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -593,8 +593,18 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.HostOperator.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentType: "",
-				ComponentName: "Host Operator",
+				ComponentType: "Host Operator",
+				ComponentName: "Deployment",
+				Reason:        cond.Reason,
+				Message:       cond.Message,
+			})
+		}
+
+		cond, found = condition.FindConditionByType(instance.Status.HostOperator.RevisionCheck.Conditions, toolchainv1alpha1.ConditionReady)
+		if found && cond.Status != corev1.ConditionTrue {
+			result = append(result, &ComponentNotReadyStatus{
+				ComponentType: "Host Operator",
+				ComponentName: "Revision Check",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
 			})
@@ -628,6 +638,18 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 					})
 				}
 			}
+
+			if member.MemberStatus.MemberOperator != nil {
+				cond, found = condition.FindConditionByType(member.MemberStatus.MemberOperator.RevisionCheck.Conditions, toolchainv1alpha1.ConditionReady)
+				if found && cond.Status != corev1.ConditionTrue {
+					result = append(result, &ComponentNotReadyStatus{
+						ComponentType: "Member Revision Check",
+						ComponentName: member.ClusterName,
+						Reason:        cond.Reason,
+						Message:       cond.Message,
+					})
+				}
+			}
 		}
 	}
 
@@ -647,6 +669,16 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 			result = append(result, &ComponentNotReadyStatus{
 				ComponentType: "Registration service",
 				ComponentName: "health",
+				Reason:        cond.Reason,
+				Message:       cond.Message,
+			})
+		}
+
+		cond, found = condition.FindConditionByType(instance.Status.RegistrationService.RevisionCheck.Conditions, toolchainv1alpha1.ConditionReady)
+		if found && cond.Status != corev1.ConditionTrue {
+			result = append(result, &ComponentNotReadyStatus{
+				ComponentType: "Registration service",
+				ComponentName: "Revision Check",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
 			})

--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -593,8 +593,8 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.HostOperator.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentType: "Host Operator",
-				ComponentName: "Deployment",
+				ComponentName: "Host Operator",
+				ComponentType: "Deployment",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
 			})
@@ -603,8 +603,8 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.HostOperator.RevisionCheck.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentType: "Host Operator",
-				ComponentName: "Revision Check",
+				ComponentName: "Host Operator",
+				ComponentType: "Revision",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
 			})
@@ -643,7 +643,7 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 				cond, found = condition.FindConditionByType(member.MemberStatus.MemberOperator.RevisionCheck.Conditions, toolchainv1alpha1.ConditionReady)
 				if found && cond.Status != corev1.ConditionTrue {
 					result = append(result, &ComponentNotReadyStatus{
-						ComponentType: "Member Revision Check",
+						ComponentType: "Member Operator Revision",
 						ComponentName: member.ClusterName,
 						Reason:        cond.Reason,
 						Message:       cond.Message,
@@ -657,8 +657,8 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.RegistrationService.Deployment.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentType: "Registration service",
-				ComponentName: "deployment",
+				ComponentName: "Registration service",
+				ComponentType: "Deployment",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
 			})
@@ -667,8 +667,8 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.RegistrationService.Health.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentType: "Registration service",
-				ComponentName: "health",
+				ComponentName: "Registration service",
+				ComponentType: "Health",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
 			})
@@ -677,8 +677,8 @@ func ExtractStatusMetadata(instance *toolchainv1alpha1.ToolchainStatus) []*Compo
 		cond, found = condition.FindConditionByType(instance.Status.RegistrationService.RevisionCheck.Conditions, toolchainv1alpha1.ConditionReady)
 		if found && cond.Status != corev1.ConditionTrue {
 			result = append(result, &ComponentNotReadyStatus{
-				ComponentType: "Registration service",
-				ComponentName: "Revision Check",
+				ComponentName: "Registration service",
+				ComponentType: "Revision",
 				Reason:        cond.Reason,
 				Message:       cond.Message,
 			})

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1655,7 +1655,10 @@ func TestExtractStatusMetadata(t *testing.T) {
 				Message: "Deployed commit and GitHub commit are not matching",
 			})))
 
+		// when
 		meta := ExtractStatusMetadata(toolchainStatus)
+		
+		// then
 		require.Len(t, meta, 1)
 		require.Equal(t, "Registration service", meta[0].ComponentType)
 		require.Equal(t, toolchainv1alpha1.ToolchainStatusDeploymentNotUpToDateReason, meta[0].Reason)

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1621,7 +1621,7 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		meta := ExtractStatusMetadata(toolchainStatus)
 		require.Len(t, meta, 1)
-		require.Equal(t, "Registration service", meta[0].ComponentName)
+		require.Equal(t, "Registration Service", meta[0].ComponentName)
 		require.Equal(t, "DeploymentNotReadyReason", meta[0].Reason)
 		require.Equal(t, "Deployment error message", meta[0].Message)
 		require.Equal(t, "Deployment", meta[0].ComponentType)
@@ -1639,7 +1639,7 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		meta := ExtractStatusMetadata(toolchainStatus)
 		require.Len(t, meta, 1)
-		require.Equal(t, "Registration service", meta[0].ComponentName)
+		require.Equal(t, "Registration Service", meta[0].ComponentName)
 		require.Equal(t, "HealthNotReadyReason", meta[0].Reason)
 		require.Equal(t, "Health error message", meta[0].Message)
 		require.Equal(t, "Health", meta[0].ComponentType)
@@ -1660,7 +1660,7 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		// then
 		require.Len(t, meta, 1)
-		require.Equal(t, "Registration service", meta[0].ComponentName)
+		require.Equal(t, "Registration Service", meta[0].ComponentName)
 		require.Equal(t, toolchainv1alpha1.ToolchainStatusDeploymentNotUpToDateReason, meta[0].Reason)
 		require.Equal(t, "Deployed commit and GitHub commit are not matching", meta[0].Message)
 		require.Equal(t, "Revision", meta[0].ComponentType)
@@ -1709,10 +1709,10 @@ func TestGenerateUnreadyNotificationContent(t *testing.T) {
 		content, err := GenerateUnreadyNotificationContent(ClusterURLs(toolchainStatus), meta)
 		require.NoError(t, err)
 		require.NotEmpty(t, content)
-		assert.Contains(t, content, "<h4> ToolchainStatus not ready</h4>")
-		assert.Contains(t, content, "<h4>Deployment Host Operator not ready</h4>")
-		assert.Contains(t, content, "<h4>Member Routes member-sandbox.ccc.openshiftapps.com not ready</h4>")
-		assert.Contains(t, content, "<h4>Deployment Registration service not ready</h4>")
+		assert.Contains(t, content, "<h4>ToolchainStatus  not ready</h4>")
+		assert.Contains(t, content, "<h4>Host Operator Deployment not ready</h4>")
+		assert.Contains(t, content, "<h4>member-sandbox.ccc.openshiftapps.com Member Routes not ready</h4>")
+		assert.Contains(t, content, "<h4>Registration Service Deployment not ready</h4>")
 	})
 }
 

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1520,7 +1520,10 @@ func TestExtractStatusMetadata(t *testing.T) {
 				Message: "Deployed commit and GitHub commit are not matching",
 			})
 
+		// when
 		meta := ExtractStatusMetadata(toolchainStatus)
+		
+		// then
 		require.Len(t, meta, 1)
 		require.Equal(t, "Host Operator", meta[0].ComponentType)
 		require.Equal(t, toolchainv1alpha1.ToolchainStatusDeploymentNotUpToDateReason, meta[0].Reason)

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1598,7 +1598,10 @@ func TestExtractStatusMetadata(t *testing.T) {
 				Message: "Deployed commit and GitHub commit are not matching",
 			})
 
+		// when
 		meta := ExtractStatusMetadata(toolchainStatus)
+		
+		// then
 		require.Len(t, meta, 1)
 		require.Equal(t, "Member Revision Check", meta[0].ComponentType)
 		require.Equal(t, toolchainv1alpha1.ToolchainStatusDeploymentNotUpToDateReason, meta[0].Reason)

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1503,10 +1503,10 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		meta := ExtractStatusMetadata(toolchainStatus)
 		require.Len(t, meta, 1)
-		require.Equal(t, "Host Operator", meta[0].ComponentType)
+		require.Equal(t, "Host Operator", meta[0].ComponentName)
 		require.Equal(t, "HostNotReadyReason", meta[0].Reason)
 		require.Equal(t, "Host error message", meta[0].Message)
-		require.Equal(t, "Deployment", meta[0].ComponentName)
+		require.Equal(t, "Deployment", meta[0].ComponentType)
 	})
 
 	t.Run("test status metadata for host operator revision check not ready", func(t *testing.T) {
@@ -1522,13 +1522,13 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		// when
 		meta := ExtractStatusMetadata(toolchainStatus)
-		
+
 		// then
 		require.Len(t, meta, 1)
-		require.Equal(t, "Host Operator", meta[0].ComponentType)
+		require.Equal(t, "Host Operator", meta[0].ComponentName)
 		require.Equal(t, toolchainv1alpha1.ToolchainStatusDeploymentNotUpToDateReason, meta[0].Reason)
 		require.Equal(t, "Deployed commit and GitHub commit are not matching", meta[0].Message)
-		require.Equal(t, "Revision Check", meta[0].ComponentName)
+		require.Equal(t, "Revision", meta[0].ComponentType)
 	})
 
 	t.Run("test status metadata for one of two members not ready", func(t *testing.T) {
@@ -1600,10 +1600,10 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		// when
 		meta := ExtractStatusMetadata(toolchainStatus)
-		
+
 		// then
 		require.Len(t, meta, 1)
-		require.Equal(t, "Member Revision Check", meta[0].ComponentType)
+		require.Equal(t, "Member Operator Revision", meta[0].ComponentType)
 		require.Equal(t, toolchainv1alpha1.ToolchainStatusDeploymentNotUpToDateReason, meta[0].Reason)
 		require.Equal(t, "Deployed commit and GitHub commit are not matching", meta[0].Message)
 		require.Equal(t, "member-sandbox.ccc.openshiftapps.com", meta[0].ComponentName)
@@ -1621,10 +1621,10 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		meta := ExtractStatusMetadata(toolchainStatus)
 		require.Len(t, meta, 1)
-		require.Equal(t, "Registration service", meta[0].ComponentType)
+		require.Equal(t, "Registration service", meta[0].ComponentName)
 		require.Equal(t, "DeploymentNotReadyReason", meta[0].Reason)
 		require.Equal(t, "Deployment error message", meta[0].Message)
-		require.Equal(t, "deployment", meta[0].ComponentName)
+		require.Equal(t, "Deployment", meta[0].ComponentType)
 	})
 
 	t.Run("test status metadata for registration service health not ready", func(t *testing.T) {
@@ -1639,10 +1639,10 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		meta := ExtractStatusMetadata(toolchainStatus)
 		require.Len(t, meta, 1)
-		require.Equal(t, "Registration service", meta[0].ComponentType)
+		require.Equal(t, "Registration service", meta[0].ComponentName)
 		require.Equal(t, "HealthNotReadyReason", meta[0].Reason)
 		require.Equal(t, "Health error message", meta[0].Message)
-		require.Equal(t, "health", meta[0].ComponentName)
+		require.Equal(t, "Health", meta[0].ComponentType)
 	})
 
 	t.Run("test status metadata for registration service revision check not ready", func(t *testing.T) {
@@ -1657,13 +1657,13 @@ func TestExtractStatusMetadata(t *testing.T) {
 
 		// when
 		meta := ExtractStatusMetadata(toolchainStatus)
-		
+
 		// then
 		require.Len(t, meta, 1)
-		require.Equal(t, "Registration service", meta[0].ComponentType)
+		require.Equal(t, "Registration service", meta[0].ComponentName)
 		require.Equal(t, toolchainv1alpha1.ToolchainStatusDeploymentNotUpToDateReason, meta[0].Reason)
 		require.Equal(t, "Deployed commit and GitHub commit are not matching", meta[0].Message)
-		require.Equal(t, "Revision Check", meta[0].ComponentName)
+		require.Equal(t, "Revision", meta[0].ComponentType)
 	})
 }
 
@@ -1708,7 +1708,11 @@ func TestGenerateUnreadyNotificationContent(t *testing.T) {
 		require.Len(t, meta, 4)
 		content, err := GenerateUnreadyNotificationContent(ClusterURLs(toolchainStatus), meta)
 		require.NoError(t, err)
-		require.Len(t, content, 1522)
+		require.NotEmpty(t, content)
+		assert.Contains(t, content, "<h4> ToolchainStatus not ready</h4>")
+		assert.Contains(t, content, "<h4>Deployment Host Operator not ready</h4>")
+		assert.Contains(t, content, "<h4>Member Routes member-sandbox.ccc.openshiftapps.com not ready</h4>")
+		assert.Contains(t, content, "<h4>Deployment Registration service not ready</h4>")
 	})
 }
 

--- a/test/toolchainstatus.go
+++ b/test/toolchainstatus.go
@@ -67,6 +67,12 @@ func WithHealthCondition(condition toolchainv1alpha1.Condition) RegistrationServ
 	}
 }
 
+func WithRevisionCheckCondition(condition toolchainv1alpha1.Condition) RegistrationServiceToolchainStatusOption {
+	return func(status *toolchainv1alpha1.HostRegistrationServiceStatus) {
+		status.RevisionCheck.Conditions, _ = condition2.AddOrUpdateStatusConditions(status.RevisionCheck.Conditions, condition)
+	}
+}
+
 func WithMember(name string, options ...MemberToolchainStatusOption) ToolchainStatusOption {
 	return func(status *toolchainv1alpha1.ToolchainStatus) {
 		member := toolchainv1alpha1.Member{


### PR DESCRIPTION
Adding revision check conditions handling to the `ExtractStatusMetadata` function, so that it can be reported in the unready notification email.  