### PR TITLE
fix: remove generation predicate from secrets watcher

### DIFF
--- a/controllers/toolchainconfig/toolchainconfig_controller.go
+++ b/controllers/toolchainconfig/toolchainconfig_controller.go
@@ -50,8 +50,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&toolchainv1alpha1.ToolchainConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &corev1.Secret{}},
-			handler.EnqueueRequestsFromMapFunc(MapSecretToToolchainConfig()),
-			builder.WithPredicates(&predicate.GenerationChangedPredicate{})).
+			handler.EnqueueRequestsFromMapFunc(MapSecretToToolchainConfig())).
 		Complete(r)
 }
 


### PR DESCRIPTION
see: https://redhat-internal.slack.com/archives/CHK0J6HT6/p1690446745059439