### PR TITLE
fix(RHTAPBUGS-587): increase ResourceQuota for Snapshots

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -105,7 +105,7 @@ objects:
   spec:
     hard:
       count/integrationtestscenarios.appstudio.redhat.com: "512"
-      count/snapshots.appstudio.redhat.com: "512"
+      count/snapshots.appstudio.redhat.com: "1024"
       count/snapshotenvironmentbindings.appstudio.redhat.com: "512"
 - apiVersion: v1
   kind: ResourceQuota


### PR DESCRIPTION
* Snapshots are high-traffic CRs that are created for each version of the application
* The limit of 512 has been too low in practice

See https://github.com/codeready-toolchain/toolchain-e2e/pull/781