### PR TITLE
Update admin spacerole role and rolebinding to indicate level

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -9,7 +9,7 @@ objects:
   kind: Role
   metadata:
     namespace: ${NAMESPACE}
-    name: appstudio-user-actions
+    name: appstudio-admin-user-actions
   rules:
   - apiGroups:
     - appstudio.redhat.com
@@ -199,11 +199,11 @@ objects:
   kind: RoleBinding
   metadata:
     namespace: ${NAMESPACE}
-    name: appstudio-${USERNAME}-actions-user
+    name: appstudio-admin-${USERNAME}-actions-user
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role
-    name: appstudio-user-actions
+    name: appstudio-admin-user-actions
   subjects:
   - kind: User
     name: ${USERNAME}


### PR DESCRIPTION
When a cluster admin inspects a namespace, it would be helpful if the names of the roles and rolebindings consistently reflected their level.

Both the contributor and maintainer roles and rolebindings indicate their level in their names (contributor and maintainer respectively).

Here, do the same with admin for parity.