### PR TITLE
Let appstudio admins exec (rsh) to pods

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -193,6 +193,13 @@ objects:
     - watch
     - update
     - patch
+  # Allow to exec (rsh) to pods
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
 
 # RoleBinding that grants limited CRUD permissions to the User
 - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
See https://github.com/redhat-appstudio/book/pull/124

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/783