### PR TITLE
refactor: introduce LookupMember cluster function

### DIFF
--- a/controllers/spacebindingrequest/spacebindingrequest_controller.go
+++ b/controllers/spacebindingrequest/spacebindingrequest_controller.go
@@ -70,9 +70,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// search on all member clusters
 	spaceBindingRequest := &toolchainv1alpha1.SpaceBindingRequest{}
 	memberClusterWithSpaceBindingRequest, found, err := cluster.LookupMember(r.MemberClusters, request, spaceBindingRequest)
-	if err != nil && !found {
-		// got error while searching for SpaceBindingRequest CR
-		return reconcile.Result{}, err
+	if err != nil {
+		if !found {
+			// got error while searching for SpaceBindingRequest CR
+			return reconcile.Result{}, err
+		}
+		// Just log the error but proceed because we did find the member anyway
+		logger.Error(err, "error while searching for SpaceBindingRequest")
 	} else if !found {
 		logger.Info("unable to find SpaceBindingRequest")
 		return reconcile.Result{}, nil

--- a/controllers/spacebindingrequest/spacebindingrequest_controller_test.go
+++ b/controllers/spacebindingrequest/spacebindingrequest_controller_test.go
@@ -149,7 +149,7 @@ func TestCreateSpaceBindingRequest(t *testing.T) {
 
 			// then
 			// space binding request should not be there
-			require.EqualError(t, err, "unable to get the current SpaceBindingRequest: mock error")
+			require.EqualError(t, err, "unable to get the current *v1alpha1.SpaceBindingRequest: mock error")
 		})
 
 		t.Run("MasterUserRecord cannot be blank", func(t *testing.T) {

--- a/controllers/spacerequest/spacerequest_controller.go
+++ b/controllers/spacerequest/spacerequest_controller.go
@@ -81,9 +81,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// search on all member clusters
 	spaceRequest := &toolchainv1alpha1.SpaceRequest{}
 	memberClusterWithSpaceRequest, found, err := cluster.LookupMember(r.MemberClusters, request, spaceRequest)
-	if err != nil && !found {
-		// got error while searching for SpaceRequest CR
-		return reconcile.Result{}, err
+	if err != nil {
+		if !found {
+			// got error while searching for SpaceRequest CR
+			return reconcile.Result{}, err
+		}
+		// Just log the error but proceed because we did find the member anyway
+		logger.Error(err, "error while searching for SpaceRequest")
 	} else if !found {
 		logger.Info("unable to find SpaceRequest")
 		return reconcile.Result{}, nil

--- a/controllers/spacerequest/spacerequest_controller.go
+++ b/controllers/spacerequest/spacerequest_controller.go
@@ -80,31 +80,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	// Fetch the SpaceRequest
 	// search on all member clusters
 	spaceRequest := &toolchainv1alpha1.SpaceRequest{}
-	var memberClusterWithSpaceRequest cluster.Cluster
-	var err error
-	for _, memberCluster := range r.MemberClusters {
-		err = memberCluster.Client.Get(context.TODO(), types.NamespacedName{
-			Namespace: request.Namespace,
-			Name:      request.Name,
-		}, spaceRequest)
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				// Error reading the object - requeue the request.
-				return reconcile.Result{}, errs.Wrap(err, "unable to get the current SpaceRequest")
-			}
-
-			//  spacerequest CR not found on current membercluster
-			continue
-		}
-
-		// save the member cluster on which the SpaceRequest CR was found
-		memberClusterWithSpaceRequest = memberCluster
-		break // exit once found
-	}
-	// if we exited with a notFound error
-	// it means that we couldn't find the spacerequest object on any of the given member clusters
-	if err != nil && errors.IsNotFound(err) {
-		// let's just log the info
+	memberClusterWithSpaceRequest, found, err := cluster.LookupMember(r.MemberClusters, request, spaceRequest)
+	if err != nil && !found {
+		// got error while searching for SpaceRequest CR
+		return reconcile.Result{}, err
+	} else if !found {
 		logger.Info("unable to find SpaceRequest")
 		return reconcile.Result{}, nil
 	}

--- a/controllers/spacerequest/spacerequest_controller_test.go
+++ b/controllers/spacerequest/spacerequest_controller_test.go
@@ -364,6 +364,32 @@ func TestCreateSpaceRequest(t *testing.T) {
 				HasTier(spaceRequest.Spec.TierName).
 				HasParentSpace("jane")
 		})
+
+		t.Run("member1 GET request fails, member2 GET returns not found but SpaceRequest is on member3", func(t *testing.T) {
+			member1Client := test.NewFakeClient(t)
+			member1Client.MockGet = mockGetSpaceRequestFail(member1Client)
+			member1 := NewMemberClusterWithClient(member1Client, "member-1", corev1.ConditionTrue)
+			member2 := NewMemberClusterWithClient(test.NewFakeClient(t), "member-2", corev1.ConditionTrue)
+			member3 := NewMemberClusterWithClient(test.NewFakeClient(t, sr, srNamespace), "member-3", corev1.ConditionTrue)
+			hostClient := test.NewFakeClient(t, appstudioTier, parentSpace)
+			ctrl := newReconciler(t, hostClient, member1, member2, member3)
+
+			// when
+			_, err = ctrl.Reconcile(context.TODO(), requestFor(sr))
+
+			// then
+			require.NoError(t, err)
+			// spacerequest exists with expected cluster roles and finalizer
+			spacerequesttest.AssertThatSpaceRequest(t, srNamespace.Name, sr.GetName(), member3.Client).
+				HasSpecTargetClusterRoles(srClusterRoles).
+				HasSpecTierName("appstudio").
+				HasConditions(spacetest.Provisioning()).
+				HasFinalizer()
+			// there should be 1 subSpace that was created from the spacerequest
+			spacetest.AssertThatSubSpace(t, hostClient, sr, parentSpace).
+				HasTier("appstudio").
+				HasSpecTargetClusterRoles(srClusterRoles)
+		})
 	})
 
 	t.Run("failure", func(t *testing.T) {
@@ -398,7 +424,7 @@ func TestCreateSpaceRequest(t *testing.T) {
 
 			// then
 			// space request should not be there
-			require.EqualError(t, err, "unable to get the current SpaceRequest: mock error")
+			require.EqualError(t, err, "unable to get the current *v1alpha1.SpaceRequest: mock error")
 		})
 
 		t.Run("error while adding finalizer", func(t *testing.T) {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	errs "github.com/pkg/errors"
@@ -25,15 +24,17 @@ type Cluster struct {
 
 // LookupMember takes in a list of member clusters and a Request, it then searches for the member cluster that triggered the request.
 // returns memberCluster/true/nil in case the Object was found on one of the given member clusters
+// returns memberCluster/true/error in case the Object was found on one of the given member clusters but there was also an error while searching it
 // returns nil/false/nil in case the Object was NOT found on any of the given member clusters
 // returns nil/false/error in case the Object was NOT found on any of the given member clusters and there was an error while trying to read one or more of the memberclusters
 //
 // CAVEAT: if the object was not found and there is an error reading from more than one member cluster, only the last read error will be returned.
-func LookupMember(MemberClusters map[string]Cluster, request ctrl.Request, object runtimeclient.Object) (Cluster, bool, error) {
+func LookupMember(memberClusters map[string]Cluster, request ctrl.Request, object runtimeclient.Object) (Cluster, bool, error) {
 	var memberClusterWithObject Cluster
-	var err, getError error
-	for _, memberCluster := range MemberClusters {
-		err = memberCluster.Client.Get(context.TODO(), types.NamespacedName{
+	var getError error
+	var found bool
+	for _, memberCluster := range memberClusters {
+		err := memberCluster.Client.Get(context.TODO(), types.NamespacedName{
 			Namespace: request.Namespace,
 			Name:      request.Name,
 		}, object)
@@ -42,31 +43,23 @@ func LookupMember(MemberClusters map[string]Cluster, request ctrl.Request, objec
 				// Error reading the object
 				getError = err // save the error and return it only later in case the Object was not found on any of the clusters
 			}
-
 			//  Object not found on current member cluster
 			continue
 		}
-
 		// save the member cluster on which the Object was found
 		memberClusterWithObject = memberCluster
+		found = true
 		break // exit once found
 	}
-
-	// if we haven't found the Object, the memberCluster is an empty struct,
-	// we can't do the same check on the runtimeclient.Object since for some reason it has the TypeMeta field on it
-	// and the check fails.
-	if reflect.ValueOf(memberClusterWithObject).IsZero() {
+	if !found {
 		if getError != nil {
 			// if we haven't found the Object, and we got an error while trying to retrieve it
 			// then let's return the error
-			return memberClusterWithObject, false, errs.Wrap(getError, fmt.Sprintf("unable to get the current %T", object))
-		} else if err != nil && errors.IsNotFound(err) {
-			// if we exited with a notFound error
-			// it means that we couldn't find the Object on any of the given member clusters
-			// let's just return false (as not found) and no error
-			return memberClusterWithObject, false, nil
+			return memberClusterWithObject, found, errs.Wrap(getError, fmt.Sprintf("unable to get the current %T", object))
 		}
+		// Not found. No Error.
+		return memberClusterWithObject, found, nil
 	}
-	// Object found, return the member cluster that has it
-	return memberClusterWithObject, true, nil
+	// Object found, return the member cluster that has it. Also, if we got an error when trying to connect to at least one of them member then return it too.
+	return memberClusterWithObject, found, getError
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -1,7 +1,15 @@
 package cluster
 
 import (
+	"context"
+	"fmt"
+	"reflect"
+
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	errs "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -13,4 +21,52 @@ type Cluster struct {
 	Client     runtimeclient.Client
 	RESTClient *rest.RESTClient
 	Cache      cache.Cache
+}
+
+// LookupMember takes in a list of member cluster and Request and searches for the member cluster that triggered the request.
+// returns memberCluster/true/nil in case the Object was found on one of the given member clusters
+// returns nil/false/nil in case the Object was NOT found on any of the given member clusters
+// returns nil/false/error in case the Object was NOT found on any of the given member clusters and there was an error while trying to read one or more of the memberclusters
+//
+// CAVEAT: if the object was not found and there is an error reading from more than one member cluster, only the last read error will be returned.
+func LookupMember(MemberClusters map[string]Cluster, request ctrl.Request, object runtimeclient.Object) (Cluster, bool, error) {
+	var memberClusterWithObject Cluster
+	var err, getError error
+	for _, memberCluster := range MemberClusters {
+		err = memberCluster.Client.Get(context.TODO(), types.NamespacedName{
+			Namespace: request.Namespace,
+			Name:      request.Name,
+		}, object)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				// Error reading the object - requeue the request.
+				getError = err // save the error and return it only later in case the CR was not found on any of the cluster
+			}
+
+			//  Object not found on current membercluster
+			continue
+		}
+
+		// save the member cluster on which the SpaceRequest CR was found
+		memberClusterWithObject = memberCluster
+		break // exit once found
+	}
+
+	// if we haven't found the Object the memberCluster is an empty struct,
+	// we can't do the same check on the Object since for some reason it has the TypeMeta field on it
+	// and the check would fail.
+	if reflect.ValueOf(memberClusterWithObject).IsZero() {
+		if getError != nil {
+			// if we haven't found the Object, and we got an error while trying to retrieve it
+			// then let's return the error
+			return memberClusterWithObject, false, errs.Wrap(getError, fmt.Sprintf("unable to get the current %T", object))
+		} else if err != nil && errors.IsNotFound(err) {
+			// if we exited with a notFound error
+			// it means that we couldn't find the Object on any of the given member clusters
+			// let's just return not found and no error
+			return memberClusterWithObject, false, nil
+		}
+	}
+	// Object found return the member cluster that has it
+	return memberClusterWithObject, true, nil
 }

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -25,8 +25,8 @@ type Cluster struct {
 // LookupMember takes in a list of member clusters and a Request, it then searches for the member cluster that triggered the request.
 // returns memberCluster/true/nil in case the Object was found on one of the given member clusters
 // returns memberCluster/true/error in case the Object was found on one of the given member clusters but there was also an error while searching it
-// returns nil/false/nil in case the Object was NOT found on any of the given member clusters
-// returns nil/false/error in case the Object was NOT found on any of the given member clusters and there was an error while trying to read one or more of the memberclusters
+// returns memberCluster/false/nil in case the Object was NOT found on any of the given member clusters
+// returns memberCluster/false/error in case the Object was NOT found on any of the given member clusters and there was an error while trying to read one or more of the memberclusters
 //
 // CAVEAT: if the object was not found and there is an error reading from more than one member cluster, only the last read error will be returned.
 func LookupMember(memberClusters map[string]Cluster, request ctrl.Request, object runtimeclient.Object) (Cluster, bool, error) {


### PR DESCRIPTION
- address comment from https://github.com/codeready-toolchain/host-operator/pull/848#discussion_r1294048180 
- extract the member lookup logic to function that is now reused in both spacerequest and sapacebindingrequest controllers.

