### PR TITLE
resources: increase the PVC claim limit to 30

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -66,7 +66,7 @@ objects:
       limits.ephemeral-storage: 50Gi
       requests.storage: 50Gi
       requests.ephemeral-storage: 50Gi
-      count/persistentvolumeclaims: "12"
+      count/persistentvolumeclaims: "30"
 - apiVersion: v1
   kind: ResourceQuota
   metadata:


### PR DESCRIPTION
During efforts to onboard product components to RHTAP, the PVC resource utilization limit has resulted in regular PipelineRun failures.

This is a brute-force attempt to address the problem in the near term to satisfy onboarding needs, while allowing time to consider alternative solutions.

Paired e2e tests PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/794