### PR TITLE
feat: Implement public API that will open SpaceBindings to end users through proxy part 1

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -38,6 +38,7 @@ objects:
           - toolchainconfigs
           - toolchainstatuses
           - proxyplugins
+          - nstemplatetiers
         verbs:
           - get
           - list


### PR DESCRIPTION
add nstemplatetiers to registration-service Role.

This is required in order to add a new informer to registration service that will cache the `NSTemplateTiers` for populating the `workspace.Status.AvailableRoles` for the new workspace sharing API.

Jira: https://issues.redhat.com/browse/ASC-410

Related PRs:
- https://github.com/codeready-toolchain/registration-service/pull/348