### PR TITLE
SANDBOX-202: Differentiation between notification emails from different environments

### DIFF
--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -548,10 +548,10 @@ func ClusterURLs(logger logr.Logger, instance *toolchainv1alpha1.ToolchainStatus
 		var err error
 		if domain, err = removeSchemeFromURL(instance.Status.HostRoutes.ProxyURL); err != nil {
 			logger.Error(err, fmt.Sprintf("Error while parsing proxyUrl %v", instance.Status.HostRoutes.ProxyURL))
-			domain = instance.Status.HostRoutes.ProxyURL
-		}
-		return map[string]string{
-			"Cluster URL": domain,
+		} else {
+			return map[string]string{
+				"Cluster URL": domain,
+			}
 		}
 	}
 

--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -507,7 +507,6 @@ func (r *Reconciler) sendToolchainStatusNotification(ctx context.Context,
 	domain := ""
 	if domain, err = removeSchemeFromURL(toolchainStatus.Status.HostRoutes.ProxyURL); err != nil {
 		logger.Error(err, fmt.Sprintf("Error while parsing proxyUrl %v", toolchainStatus.Status.HostRoutes.ProxyURL))
-		domain = toolchainStatus.Status.HostRoutes.ProxyURL
 	}
 	switch status {
 	case unreadyStatus:

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1725,7 +1725,7 @@ func TestGenerateUnreadyNotificationContent(t *testing.T) {
 }
 
 func TestRemoveSchemeFromURL(t *testing.T) {
-	t.Run("test proxy url domain extraction", func(t *testing.T) {
+	t.Run("test proxy url domain extraction validURL", func(t *testing.T) {
 		// when
 		domain, err := removeSchemeFromURL("https://api-toolchain-host-operator.apps.stone-stg-host.qc0p.p1.openshiftapps.com")
 
@@ -1733,8 +1733,11 @@ func TestRemoveSchemeFromURL(t *testing.T) {
 		require.Equal(t, "api-toolchain-host-operator.apps.stone-stg-host.qc0p.p1.openshiftapps.com", domain)
 		require.Nil(t, err)
 
+	})
+
+	t.Run("test proxy url domain extraction incorrectURL", func(t *testing.T) {
 		// when
-		domain, err = removeSchemeFromURL("incorrect$%url")
+		domain, err := removeSchemeFromURL("incorrect$%url")
 
 		// then
 		require.Equal(t, "", domain)

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1219,7 +1219,7 @@ func TestToolchainStatusNotifications(t *testing.T) {
 						require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-unready-"))
 
 						require.NotNil(t, notification)
-						require.Equal(t, notification.Spec.Subject, "ToolchainStatus has been in an unready status for an extended period")
+						require.Equal(t, notification.Spec.Subject, "ToolchainStatus has been in an unready status for an extended period for api-toolchain-host-operator.host-cluster")
 						require.Equal(t, notification.Spec.Recipient, email)
 
 						t.Run("Toolchain status now ok again, notification should be removed", func(t *testing.T) {
@@ -1249,7 +1249,7 @@ func TestToolchainStatusNotifications(t *testing.T) {
 
 							fmt.Println(notification)
 							require.NotNil(t, notification)
-							require.Equal(t, "ToolchainStatus has now been restored to ready status", notification.Spec.Subject)
+							require.Equal(t, "ToolchainStatus has now been restored to ready status for api-toolchain-host-operator.host-cluster", notification.Spec.Subject)
 							require.Equal(t, email, notification.Spec.Recipient)
 
 							t.Run("Toolchain status not ready again for extended period, notification is created", func(t *testing.T) {
@@ -1297,7 +1297,7 @@ func TestToolchainStatusNotifications(t *testing.T) {
 								require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-unready-"))
 								require.Len(t, notification.ObjectMeta.Name, 38)
 								require.NotNil(t, notification)
-								assert.Equal(t, "ToolchainStatus has been in an unready status for an extended period", notification.Spec.Subject)
+								assert.Equal(t, "ToolchainStatus has been in an unready status for an extended period for api-toolchain-host-operator.host-cluster", notification.Spec.Subject)
 								assert.Equal(t, email, notification.Spec.Recipient)
 								assert.True(t, strings.HasPrefix(notification.Spec.Content, "<h3>The following issues"))
 								assert.True(t, strings.HasSuffix(strings.TrimSpace(notification.Spec.Content), "</div>"))
@@ -1714,7 +1714,7 @@ func TestGenerateUnreadyNotificationContent(t *testing.T) {
 
 		meta := ExtractStatusMetadata(toolchainStatus)
 		require.Len(t, meta, 4)
-		content, err := GenerateUnreadyNotificationContent(ClusterURLs(toolchainStatus), meta)
+		content, err := GenerateUnreadyNotificationContent(ClusterURLs(logger, toolchainStatus), meta)
 		require.NoError(t, err)
 		require.NotEmpty(t, content)
 		assert.Contains(t, content, "<h4>ToolchainStatus  not ready</h4>")
@@ -1722,6 +1722,18 @@ func TestGenerateUnreadyNotificationContent(t *testing.T) {
 		assert.Contains(t, content, "<h4>member-sandbox.ccc.openshiftapps.com Member Routes not ready</h4>")
 		assert.Contains(t, content, "<h4>Registration Service Deployment not ready</h4>")
 	})
+}
+
+func TestRemoveSchemeFromURL(t *testing.T) {
+	t.Run("test proxy url domain extraction", func(t *testing.T) {
+		// when
+		domain, err := removeSchemeFromURL("https://api-toolchain-host-operator.apps.stone-stg-host.qc0p.p1.openshiftapps.com")
+
+		// then
+		require.Equal(t, "api-toolchain-host-operator.apps.stone-stg-host.qc0p.p1.openshiftapps.com", domain)
+		require.Nil(t, err)
+	})
+
 }
 
 func newDeploymentWithConditions(deploymentName string, deploymentConditions ...appsv1.DeploymentCondition) *appsv1.Deployment {

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1732,6 +1732,14 @@ func TestRemoveSchemeFromURL(t *testing.T) {
 		// then
 		require.Equal(t, "api-toolchain-host-operator.apps.stone-stg-host.qc0p.p1.openshiftapps.com", domain)
 		require.Nil(t, err)
+
+		// when
+		domain, err = removeSchemeFromURL("incorrect$%url")
+
+		// then
+		require.Equal(t, "", domain)
+		require.NotNil(t, err)
+
 	})
 
 }

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1311,6 +1311,229 @@ func TestToolchainStatusNotifications(t *testing.T) {
 	})
 }
 
+func TestToolchainStatusNotificationsInvalidURL(t *testing.T) {
+	// set the operator name environment variable for all the tests which is used to get the host operator deployment name
+	restore := test.SetEnvVarsAndRestore(t, test.Env(commonconfig.OperatorNameEnvVar, defaultHostOperatorName))
+	defer restore()
+	defer counter.Reset()
+	requestName := toolchainconfig.ToolchainStatusName
+
+	toolchainStatus := NewToolchainStatus()
+	memberStatus := newMemberStatus(ready())
+	registrationServiceDeployment := newDeploymentWithConditions(registrationservice.ResourceName,
+		status.DeploymentAvailableCondition(), status.DeploymentProgressingCondition())
+
+	t.Run("Notification workflow", func(t *testing.T) {
+		// given
+		hostOperatorDeployment := newDeploymentWithConditions(defaultHostOperatorDeploymentName,
+			status.DeploymentAvailableCondition())
+
+		os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs)
+
+		t.Run("no notificaion created", func(t *testing.T) {
+			// given
+			toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.Notifications().AdminEmail("admin@dev.sandbox.com"))
+			reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), mockLastGitHubAPICall, defaultGitHubClient, []string{"member-1", "member-2"},
+				hostOperatorDeployment, memberStatus, registrationServiceDeployment, toolchainStatus, toolchainConfig, proxyRouteInvalid())
+
+			// when
+			res, err := reconciler.Reconcile(context.TODO(), req)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, requeueResult, res)
+
+			AssertThatToolchainStatus(t, req.Namespace, requestName, fakeClient).
+				HasConditions(componentsReady(), unreadyNotificationNotCreated()).
+				HasHostOperatorStatus(hostOperatorStatusReady()).
+				HasMemberClusterStatus(memberCluster("member-1", ready()), memberCluster("member-2", ready())).
+				HasRegistrationServiceStatus(registrationServiceReady(conditionReady(toolchainv1alpha1.ToolchainStatusRegServiceReadyReason), conditionReadyWithMessage(toolchainv1alpha1.ToolchainStatusDeploymentRevisionCheckDisabledReason, "access token key is not provided")))
+
+			// Confirm there is no notification
+			assertToolchainStatusNotificationNotCreated(t, fakeClient, unreadyStatusNotification)
+			assertToolchainStatusNotificationNotCreated(t, fakeClient, restoredStatusNotification)
+		})
+
+		t.Run("Notification not created when host operator deployment not ready within threshold", func(t *testing.T) {
+			// given
+			hostOperatorDeployment := newDeploymentWithConditions(defaultHostOperatorDeploymentName,
+				status.DeploymentNotAvailableCondition(), status.DeploymentProgressingCondition())
+			toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.Notifications().AdminEmail("admin@dev.sandbox.com"))
+
+			reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), mockLastGitHubAPICall, defaultGitHubClient, []string{"member-1", "member-2"},
+				hostOperatorDeployment, memberStatus, registrationServiceDeployment, toolchainStatus, toolchainConfig, proxyRouteInvalid())
+
+			// when
+			res, err := reconciler.Reconcile(context.TODO(), req)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, requeueResult, res)
+
+			// Confirm there is no notification
+			assertToolchainStatusNotificationNotCreated(t, fakeClient, unreadyStatusNotification)
+			assertToolchainStatusNotificationNotCreated(t, fakeClient, restoredStatusNotification)
+
+			t.Run("Notification not created when admin.email not configured", func(t *testing.T) {
+
+				assertInvalidEmailReturnErr := func(email string) {
+					commonconfig.ResetCache() // clear the config cache so that this invalid config will be picked up
+					invalidConfig := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.Notifications().AdminEmail(email))
+
+					// given
+					hostOperatorDeployment := newDeploymentWithConditions(defaultHostOperatorDeploymentName,
+						status.DeploymentNotAvailableCondition(), status.DeploymentProgressingCondition())
+
+					// Reload the toolchain status
+					require.NoError(t, fakeClient.Get(context.Background(), test.NamespacedName(test.HostOperatorNs,
+						toolchainStatus.Name), toolchainStatus))
+
+					overrideLastTransitionTime(t, toolchainStatus, metav1.Time{Time: time.Now().Add(-time.Duration(24) * time.Hour)})
+
+					reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), mockLastGitHubAPICall, defaultGitHubClient, []string{"member-1", "member-2"},
+						hostOperatorDeployment, memberStatus, registrationServiceDeployment, toolchainStatus, invalidConfig, proxyRouteInvalid())
+
+					// when
+					res, err := reconciler.Reconcile(context.TODO(), req)
+
+					// then
+					require.Error(t, err)
+					require.True(t, strings.HasPrefix(err.Error(), fmt.Sprintf("Failed to create toolchain status unready notification: The specified recipient [%s] is not a valid email address", email)))
+					assert.Equal(t, requeueResult, res)
+
+					// Confirm there is no notification
+					assertToolchainStatusNotificationNotCreated(t, fakeClient, unreadyStatusNotification)
+					assertToolchainStatusNotificationNotCreated(t, fakeClient, restoredStatusNotification)
+				}
+
+				assertInvalidEmailReturnErr("")
+				assertInvalidEmailReturnErr("   ")
+				assertInvalidEmailReturnErr("foo#bar.com")
+			})
+
+			t.Run("Notification created when host operator deployment not ready beyond threshold", func(t *testing.T) {
+				// given
+				hostOperatorDeployment := newDeploymentWithConditions(defaultHostOperatorDeploymentName,
+					status.DeploymentNotAvailableCondition(), status.DeploymentProgressingCondition())
+
+				// Reload the toolchain status
+				require.NoError(t, fakeClient.Get(context.Background(), test.NamespacedName(test.HostOperatorNs,
+					toolchainStatus.Name), toolchainStatus))
+
+				overrideLastTransitionTime(t, toolchainStatus, metav1.Time{Time: time.Now().Add(-time.Duration(24) * time.Hour)})
+
+				for _, email := range []string{"admin@dev.sandbox.com", "admin@dev.sandbox.com, another-admin@acme.com"} {
+					t.Run("for email "+email, func(t *testing.T) {
+						toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.Notifications().AdminEmail(email))
+
+						reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), mockLastGitHubAPICall, defaultGitHubClient, []string{"member-1", "member-2"},
+							hostOperatorDeployment, memberStatus, registrationServiceDeployment, toolchainStatus, toolchainConfig, proxyRouteInvalid())
+
+						// when
+						res, err := reconciler.Reconcile(context.TODO(), req)
+
+						// then
+						require.NoError(t, err)
+						assert.Equal(t, requeueResult, res)
+						// confirm restored notification has not been created
+						assertToolchainStatusNotificationNotCreated(t, fakeClient, restoredStatusNotification)
+						// Confirm the unready notification has been created
+						notification := assertToolchainStatusNotificationCreated(t, fakeClient)
+						require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-unready-"))
+
+						require.NotNil(t, notification)
+						require.Equal(t, notification.Spec.Subject, "ToolchainStatus has been in an unready status for an extended period for ")
+						require.Equal(t, notification.Spec.Recipient, email)
+
+						t.Run("Toolchain status now ok again, notification should be removed", func(t *testing.T) {
+							hostOperatorDeployment := newDeploymentWithConditions(defaultHostOperatorDeploymentName,
+								status.DeploymentAvailableCondition())
+
+							// Reload the toolchain status
+							require.NoError(t, fakeClient.Get(context.Background(), test.NamespacedName(test.HostOperatorNs,
+								toolchainStatus.Name), toolchainStatus))
+
+							reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), mockLastGitHubAPICall, defaultGitHubClient, []string{"member-1", "member-2"},
+								hostOperatorDeployment, memberStatus, registrationServiceDeployment, toolchainStatus, proxyRouteInvalid())
+
+							// when
+							res, err := reconciler.Reconcile(context.TODO(), req)
+
+							// then
+							require.NoError(t, err)
+							assert.Equal(t, requeueResult, res)
+
+							// Confirm there is no unready notification
+							assertToolchainStatusNotificationNotCreated(t, fakeClient, unreadyStatusNotification)
+
+							// Confirm restored notification has been created
+							notification := assertToolchainStatusNotificationCreated(t, fakeClient)
+							require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-restored-"))
+
+							fmt.Println(notification)
+							require.NotNil(t, notification)
+							require.Equal(t, "ToolchainStatus has now been restored to ready status for ", notification.Spec.Subject)
+							require.Equal(t, email, notification.Spec.Recipient)
+
+							t.Run("Toolchain status not ready again for extended period, notification is created", func(t *testing.T) {
+								// given
+								hostOperatorDeployment := newDeploymentWithConditions(defaultHostOperatorDeploymentName,
+									status.DeploymentNotAvailableCondition(), status.DeploymentProgressingCondition())
+
+								// Reload the toolchain status
+								require.NoError(t, fakeClient.Get(context.Background(), test.NamespacedName(test.HostOperatorNs,
+									toolchainStatus.Name), toolchainStatus))
+
+								// Reconcile in order to update the ready status to false
+								reconciler, req, fakeClient := prepareReconcile(t, requestName, newResponseGood(), mockLastGitHubAPICall, defaultGitHubClient, []string{"member-1", "member-2"},
+									hostOperatorDeployment, memberStatus, registrationServiceDeployment, toolchainStatus, toolchainConfig, proxyRouteInvalid())
+
+								// when
+								_, err := reconciler.Reconcile(context.TODO(), req)
+
+								require.NoError(t, err)
+								// Confirm there is no notification
+								assertToolchainStatusNotificationNotCreated(t, fakeClient, unreadyStatusNotification)
+								assertToolchainStatusNotificationNotCreated(t, fakeClient, restoredStatusNotification)
+
+								// Reload the toolchain status
+								require.NoError(t, fakeClient.Get(context.Background(), test.NamespacedName(test.HostOperatorNs,
+									toolchainStatus.Name), toolchainStatus))
+
+								// Now override the last transition time again
+								overrideLastTransitionTime(t, toolchainStatus, metav1.Time{Time: time.Now().Add(-time.Duration(24) * time.Hour)})
+
+								// Reconcile once more
+								reconciler, req, fakeClient = prepareReconcile(t, requestName, newResponseGood(), mockLastGitHubAPICall, defaultGitHubClient, []string{"member-1", "member-2"},
+									hostOperatorDeployment, memberStatus, registrationServiceDeployment, toolchainStatus, toolchainConfig, proxyRouteInvalid())
+
+								// when
+								res, err = reconciler.Reconcile(context.TODO(), req)
+
+								// then
+								require.NoError(t, err)
+								assert.Equal(t, requeueResult, res)
+								// Confirm restored notification is not created
+								assertToolchainStatusNotificationNotCreated(t, fakeClient, restoredStatusNotification)
+								// Confirm the unready notification has been created
+								notification := assertToolchainStatusNotificationCreated(t, fakeClient)
+								require.True(t, strings.HasPrefix(notification.ObjectMeta.Name, "toolchainstatus-unready-"))
+								require.Len(t, notification.ObjectMeta.Name, 38)
+								require.NotNil(t, notification)
+								assert.Equal(t, "ToolchainStatus has been in an unready status for an extended period for ", notification.Spec.Subject)
+								assert.Equal(t, email, notification.Spec.Recipient)
+								assert.True(t, strings.HasPrefix(notification.Spec.Content, "<h3>The following issues"))
+								assert.True(t, strings.HasSuffix(strings.TrimSpace(notification.Spec.Content), "</div>"))
+								assert.NotContains(t, notification.Spec.Content, "managedFields")
+							})
+						})
+					})
+				}
+			})
+		})
+	})
+}
+
 func overrideLastTransitionTime(t *testing.T, toolchainStatus *toolchainv1alpha1.ToolchainStatus, overrideTime metav1.Time) {
 	found := false
 	for i, cond := range toolchainStatus.Status.Conditions {
@@ -1804,6 +2027,15 @@ func proxyRoute() *routev1.Route {
 			TLS: &routev1.TLSConfig{
 				Termination: routev1.TLSTerminationEdge,
 			},
+		},
+	}
+}
+
+func proxyRouteInvalid() *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api",
+			Namespace: test.HostOperatorNs,
 		},
 	}
 }


### PR DESCRIPTION
Updating the notifications about toolchain status content to contain the source as well. 
Reference: https://issues.redhat.com/browse/SANDBOX-202