### PR TITLE
dynamically load targetCluster from Space

### DIFF
--- a/controllers/masteruserrecord/mapper.go
+++ b/controllers/masteruserrecord/mapper.go
@@ -12,8 +12,8 @@ import (
 
 // MapSpaceToMasterUserRecord maps events on Spaces to MasterUserRecords by labels at SpaceBindings
 func MapSpaceToMasterUserRecord(cl runtimeclient.Client) func(object runtimeclient.Object) []reconcile.Request {
-        var logger = ctrl.Log.WithName("SpaceToMasterUserRecordMapper").WithValues("object-name", object.GetName(), "object-kind", object.GetObjectKind())
 	return func(obj runtimeclient.Object) []reconcile.Request {
+		var logger = ctrl.Log.WithName("SpaceToMasterUserRecordMapper").WithValues("object-name", obj.GetName(), "object-kind", obj.GetObjectKind())
 		spaceBindings := &toolchainv1alpha1.SpaceBindingList{}
 		err := cl.List(context.TODO(), spaceBindings,
 			runtimeclient.InNamespace(obj.GetNamespace()),

--- a/controllers/masteruserrecord/mapper.go
+++ b/controllers/masteruserrecord/mapper.go
@@ -1,0 +1,36 @@
+package masteruserrecord
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// MapSpaceToMasterUserRecord maps events on Spaces to MasterUserRecords by labels at SpaceBindings
+func MapSpaceToMasterUserRecord(cl runtimeclient.Client) func(object runtimeclient.Object) []reconcile.Request {
+	var logger = ctrl.Log.WithName("SpaceToMasterUserRecordMapper")
+	return func(obj runtimeclient.Object) []reconcile.Request {
+		spaceBindings := &toolchainv1alpha1.SpaceBindingList{}
+		err := cl.List(context.TODO(), spaceBindings,
+			runtimeclient.InNamespace(obj.GetNamespace()),
+			runtimeclient.MatchingLabels{toolchainv1alpha1.SpaceBindingSpaceLabelKey: obj.GetName()})
+		if err != nil {
+			logger.Error(err, "Could not list SpaceBindings for the given Space")
+			return nil
+		}
+		var requests []reconcile.Request
+		for _, binding := range spaceBindings.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: obj.GetNamespace(),
+					Name:      binding.Labels[toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey],
+				},
+			})
+		}
+		return requests
+	}
+}

--- a/controllers/masteruserrecord/mapper.go
+++ b/controllers/masteruserrecord/mapper.go
@@ -12,7 +12,7 @@ import (
 
 // MapSpaceToMasterUserRecord maps events on Spaces to MasterUserRecords by labels at SpaceBindings
 func MapSpaceToMasterUserRecord(cl runtimeclient.Client) func(object runtimeclient.Object) []reconcile.Request {
-	var logger = ctrl.Log.WithName("SpaceToMasterUserRecordMapper")
+        var logger = ctrl.Log.WithName("SpaceToMasterUserRecordMapper").WithValues("object-name", object.GetName(), "object-kind", object.GetObjectKind())
 	return func(obj runtimeclient.Object) []reconcile.Request {
 		spaceBindings := &toolchainv1alpha1.SpaceBindingList{}
 		err := cl.List(context.TODO(), spaceBindings,

--- a/controllers/masteruserrecord/mapper_test.go
+++ b/controllers/masteruserrecord/mapper_test.go
@@ -1,0 +1,82 @@
+package masteruserrecord
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	spacebindingtest "github.com/codeready-toolchain/host-operator/test/spacebinding"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	spacetest "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestBannedUserToUserSignupMapper(t *testing.T) {
+	//given
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	spaceBindingJane := spacebindingtest.NewSpaceBinding("jane", "john-space", "admin", "jane-123")
+	noise := spacebindingtest.NewSpaceBinding("mr-noise", "mr-noise-space", "admin", "mr-noise")
+	space := spacetest.NewSpace(test.HostOperatorNs, "john-space")
+
+	t.Run("with one SpaceBinding", func(t *testing.T) {
+		// given
+		client := test.NewFakeClient(t, spaceBinding, noise)
+
+		// when
+		requests := MapSpaceToMasterUserRecord(client)(space)
+
+		// then
+		assert.Len(t, requests, 1)
+		assert.Contains(t, requests, newRequest("john"))
+	})
+
+	t.Run("with two SpaceBindings", func(t *testing.T) {
+		// given
+		client := test.NewFakeClient(t, spaceBinding, spaceBindingJane, noise)
+
+		// when
+		requests := MapSpaceToMasterUserRecord(client)(space)
+
+		// then
+		assert.Len(t, requests, 2)
+		assert.Contains(t, requests, newRequest("john"))
+		assert.Contains(t, requests, newRequest("jane"))
+	})
+
+	t.Run("without any SpaceBinding", func(t *testing.T) {
+		// given
+		client := test.NewFakeClient(t, noise)
+
+		// when
+		requests := MapSpaceToMasterUserRecord(client)(space)
+
+		// then
+		assert.Len(t, requests, 0)
+	})
+
+	t.Run("when list fails", func(t *testing.T) {
+		// given
+		client := test.NewFakeClient(t, noise)
+		client.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
+			return fmt.Errorf("dummy error")
+		}
+
+		// when
+		requests := MapSpaceToMasterUserRecord(client)(space)
+
+		// then
+		assert.Len(t, requests, 0)
+	})
+}
+
+func newRequest(name string) reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      name,
+		},
+	}
+}

--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -118,7 +118,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}
 	}
 
-	return reconcile.Result{}, nil
+	_, err = alignReadiness(logger, r.Scheme, r.Client, mur)
+	return reconcile.Result{}, err
 }
 
 func (r *Reconciler) ensureUserAccountsAreNotPresent(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, targetClusters []string) (time.Duration, error) {

--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -241,7 +241,6 @@ func (r *Reconciler) ensureUserAccount(logger logr.Logger, mur *toolchainv1alpha
 		hostClient:    r.Client,
 		memberCluster: memberCluster,
 		memberUserAcc: userAccount,
-		targetCluster: targetCluster,
 		logger:        logger,
 		scheme:        r.Scheme,
 	}
@@ -326,7 +325,6 @@ func (r *Reconciler) deleteUserAccount(logger logr.Logger, memberCluster cluster
 		hostClient:    r.Client,
 		memberCluster: memberCluster,
 		memberUserAcc: userAcc,
-		targetCluster: memberCluster.Name,
 		logger:        logger,
 		scheme:        r.Scheme,
 	}

--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -159,9 +159,8 @@ func (r *Reconciler) ensureUserAccounts(logger logr.Logger, mur *toolchainv1alph
 			"unable to list SpaceBindings for the MasterUserRecord")
 	}
 	var targetClusters []string
-	for i := range spaceBindings.Items {
-		binding := spaceBindings.Items[i]
-		if !coputil.IsBeingDeleted(&binding) {
+	for _, binding := range spaceBindings.Items {
+		if !coputil.IsBeingDeleted(&binding) { // nolint:gosec
 			space := &toolchainv1alpha1.Space{}
 			if err := r.Client.Get(context.TODO(), namespacedName(mur.Namespace, binding.Spec.Space), space); err != nil {
 				return nil, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,

--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/counter"
 	"github.com/codeready-toolchain/host-operator/pkg/mapper"
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
+	"github.com/codeready-toolchain/toolchain-common/controllers"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,7 +40,12 @@ const (
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr manager.Manager, memberClusters map[string]cluster.Cluster) error {
 	b := ctrl.NewControllerManagedBy(mgr).
-		For(&toolchainv1alpha1.MasterUserRecord{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+		For(&toolchainv1alpha1.MasterUserRecord{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&source.Kind{Type: &toolchainv1alpha1.SpaceBinding{}}, handler.EnqueueRequestsFromMapFunc(
+			controllers.MapToOwnerByLabel(r.Namespace, toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey))).
+		Watches(&source.Kind{Type: &toolchainv1alpha1.Space{}}, handler.EnqueueRequestsFromMapFunc(
+			MapSpaceToMasterUserRecord(r.Client)), builder.WithPredicates(predicate.GenerationChangedPredicate{}))
+
 	// watch UserAccounts in all the member clusters
 	for _, memberCluster := range memberClusters {
 		b = b.Watches(source.NewKindWithCache(&toolchainv1alpha1.UserAccount{}, memberCluster.Cache),
@@ -81,37 +87,96 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		logger.Error(err, "unable to get MasterUserRecord")
 		return reconcile.Result{}, err
 	}
 
-	// If the UserAccount is not being deleted, create or synchronize UserAccounts.
+	// If the MUR is not being deleted, create or synchronize UserAccounts.
 	if !coputil.IsBeingDeleted(mur) {
 		// Add the finalizer if it is not present
 		if err := r.addFinalizer(logger, mur, murFinalizerName); err != nil {
-			logger.Error(err, "unable to add finalizer to MasterUserRecord")
 			return reconcile.Result{}, err
 		}
 		logger.Info("ensuring user accounts")
-		for _, account := range mur.Spec.UserAccounts {
-			err := r.ensureUserAccount(logger, account, mur)
-			if err != nil {
-				logger.Error(err, "unable to synchronize with member UserAccount")
-				return reconcile.Result{}, err
-			}
+		var membersWithUserAccounts []string
+		if membersWithUserAccounts, err = r.ensureUserAccounts(logger, mur); err != nil || membersWithUserAccounts == nil {
+			return reconcile.Result{}, err
 		}
-		// If the UserAccount is being deleted, delete the UserAccounts in members.
+		requeueTime, err := r.ensureUserAccountsAreNotPresent(logger, mur, r.membersWithoutUserAccount(membersWithUserAccounts))
+		if err != nil {
+			return reconcile.Result{}, err
+		} else if requeueTime > 0 {
+			return reconcile.Result{RequeueAfter: requeueTime}, err
+		}
+
+		// If the MUR is being deleted, delete the UserAccounts in members.
 	} else if coputil.HasFinalizer(mur, murFinalizerName) {
 		requeueTime, err := r.manageCleanUp(logger, mur)
 		if err != nil {
-			logger.Error(err, "unable to clean up MasterUserRecord as part of deletion")
 			return reconcile.Result{}, err
 		} else if requeueTime > 0 {
-			return reconcile.Result{Requeue: true, RequeueAfter: requeueTime}, err
+			return reconcile.Result{RequeueAfter: requeueTime}, err
 		}
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) ensureUserAccountsAreNotPresent(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, targetClusters []string) (time.Duration, error) {
+	for _, toDelete := range targetClusters {
+		requeueTime, err := r.deleteUserAccount(logger, toDelete, mur)
+		if err != nil {
+			return 0, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToDeleteUserAccountsReason), err,
+				"failed to delete UserAccount in the member cluster '%s'", toDelete)
+		} else if requeueTime > 0 {
+			return requeueTime, nil
+		}
+	}
+	return 0, nil
+}
+
+func (r *Reconciler) membersWithoutUserAccount(membersWithUserAccounts []string) []string {
+	var membersWithout []string
+memberClusters:
+	for memberName := range r.MemberClusters {
+		for _, targetCluster := range membersWithUserAccounts {
+			if memberName == targetCluster {
+				continue memberClusters
+			}
+		}
+		membersWithout = append(membersWithout, memberName)
+	}
+	return membersWithout
+}
+
+func (r *Reconciler) ensureUserAccounts(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord) ([]string, error) {
+	spaceBindings := &toolchainv1alpha1.SpaceBindingList{}
+	if err := r.Client.List(context.TODO(), spaceBindings, runtimeclient.InNamespace(mur.GetNamespace())); err != nil {
+		return nil, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
+			"unable to list SpaceBindings")
+	}
+	var targetClusters []string
+	for i := range spaceBindings.Items {
+		binding := spaceBindings.Items[i]
+		if !coputil.IsBeingDeleted(&binding) {
+			space := &toolchainv1alpha1.Space{}
+			if err := r.Client.Get(context.TODO(), namespacedName(mur.Namespace, binding.Spec.Space), space); err != nil {
+				return nil, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
+					"unable to get Space '%s' for the SpaceBinding '%s'", binding.Spec.Space, binding.Name)
+			}
+			if !coputil.IsBeingDeleted(space) && space.Spec.TargetCluster != "" {
+				// todo - right now we provision only one UserAccount. It's provisioned in the same cluster where the default space is created
+				// todo - as soon as the other components (reg-service & proxy) are updated to support more UserAccounts per MUR, then this should be changed as well
+				if space.Labels[toolchainv1alpha1.SpaceCreatorLabelKey] == mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] {
+					if createdOrUpdated, err := r.ensureUserAccount(logger, mur, space.Spec.TargetCluster); err != nil || createdOrUpdated {
+						return nil, err
+					}
+					targetClusters = append(targetClusters, space.Spec.TargetCluster)
+					break
+				}
+			}
+		}
+	}
+	return targetClusters, nil
 }
 
 func (r *Reconciler) addFinalizer(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, finalizer string) error {
@@ -129,17 +194,17 @@ func (r *Reconciler) addFinalizer(logger logr.Logger, mur *toolchainv1alpha1.Mas
 	return nil
 }
 
-// ensureUserAccount ensures that there's a UserAccount resource on the member cluster for the given `murAccount`.
+// ensureUserAccount ensures that there's a UserAccount resource on the member clusters for the given `murAccount`.
 // If the UserAccount resource already exists, then this latter is synchronized using the given `murAccount` and the associated `mur` status is also updated to reflect
 // the UserAccount specs.
-// Returns non-zero duration as the first argument if there is a need for requeing (eg, if the remote UserAccount is being deleted and the controller should wait until the deletion is complete)
-func (r *Reconciler) ensureUserAccount(logger logr.Logger, murAccount toolchainv1alpha1.UserAccountEmbedded, mur *toolchainv1alpha1.MasterUserRecord) error {
+// Returns bool as the first argument if the UserAccount was either created or updated
+func (r *Reconciler) ensureUserAccount(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, targetCluster string) (bool, error) {
 	// get & check member cluster
-	memberCluster, found := r.MemberClusters[murAccount.TargetCluster]
+	memberCluster, found := r.MemberClusters[targetCluster]
 	if !found {
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordTargetClusterNotReadyReason),
-			fmt.Errorf("unknown target member cluster '%s'", murAccount.TargetCluster),
-			"failed to get the member cluster '%s'", murAccount.TargetCluster)
+		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordTargetClusterNotReadyReason),
+			fmt.Errorf("unknown target member cluster '%s'", targetCluster),
+			"failed to get the member cluster '%s'", targetCluster)
 	}
 
 	// get UserAccount from member
@@ -154,44 +219,45 @@ func (r *Reconciler) ensureUserAccount(logger logr.Logger, murAccount toolchainv
 			userAccount.Spec.OriginalSub = mur.Spec.OriginalSub
 
 			if err := memberCluster.Client.Create(context.TODO(), userAccount); err != nil {
-				return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
-					"failed to create UserAccount in the member cluster '%s'", murAccount.TargetCluster)
+				return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
+					"failed to create UserAccount in the member cluster '%s'", targetCluster)
 			}
-			return updateStatusConditions(logger, r.Client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
+			return true, updateStatusConditions(logger, r.Client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, ""))
 		}
 		// another/unexpected error occurred while trying to fetch the user account on the member cluster
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToGetUserAccountReason), err,
-			"failed to get userAccount '%s' from cluster '%s'", mur.Name, murAccount.TargetCluster)
+		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToGetUserAccountReason), err,
+			"failed to get userAccount '%s' from cluster '%s'", mur.Name, targetCluster)
 	}
 	// if the UserAccount is being deleted (by accident?), then we should wait until is has been totally deleted, and this controller will recreate it again
 	if coputil.IsBeingDeleted(userAccount) {
 		logger.Info("UserAccount is being deleted. Waiting until deletion is complete", "member_cluster", memberCluster.Name)
 
-		return updateStatusConditions(logger, r.Client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "recovering deleted UserAccount"))
+		return true, updateStatusConditions(logger, r.Client, mur, toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "recovering deleted UserAccount"))
 	}
 
 	sync := Synchronizer{
-		record:            mur,
-		hostClient:        r.Client,
-		memberCluster:     memberCluster,
-		memberUserAcc:     userAccount,
-		recordSpecUserAcc: murAccount,
-		logger:            logger,
-		scheme:            r.Scheme,
+		record:        mur,
+		hostClient:    r.Client,
+		memberCluster: memberCluster,
+		memberUserAcc: userAccount,
+		targetCluster: targetCluster,
+		logger:        logger,
+		scheme:        r.Scheme,
 	}
-	if err := sync.synchronizeSpec(); err != nil {
+	updated, err := sync.synchronizeSpec()
+	if err != nil {
 		// note: if we got an error while sync'ing the spec, then we may not be able to update the MUR status it here neither.
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToSynchronizeUserAccountSpecReason), err,
-			"update of the UserAccount.spec in the cluster '%s' failed", murAccount.TargetCluster)
+		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToSynchronizeUserAccountSpecReason), err,
+			"update of the UserAccount.spec in the cluster '%s' failed", targetCluster)
 	}
 	if err := sync.synchronizeStatus(); err != nil {
-		err = errs.Wrapf(err, "update of the MasterUserRecord failed while synchronizing with UserAccount status from the cluster '%s'", murAccount.TargetCluster)
+		err = errs.Wrapf(err, "update of the MasterUserRecord failed while synchronizing with UserAccount status from the cluster '%s'", targetCluster)
 		// note: if we got an error while updating the status, then we probably can't update it here neither.
-		return r.wrapErrorWithStatusUpdate(logger, mur, r.useExistingConditionOfType(toolchainv1alpha1.ConditionReady), err, "")
+		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.useExistingConditionOfType(toolchainv1alpha1.ConditionReady), err, "")
 	}
 	// nothing done and no error occurred
-	logger.Info("user account on member cluster was already in sync", "target_cluster", murAccount.TargetCluster)
-	return nil
+	logger.Info("user account on member cluster was already in sync", "target_cluster", targetCluster)
+	return updated, nil
 }
 
 type statusUpdater func(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord, message string) error
@@ -235,14 +301,8 @@ func (r *Reconciler) useExistingConditionOfType(condType toolchainv1alpha1.Condi
 }
 
 func (r *Reconciler) manageCleanUp(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord) (time.Duration, error) {
-	for _, ua := range mur.Spec.UserAccounts {
-		requeueTime, err := r.deleteUserAccount(logger, ua.TargetCluster, mur.Name)
-		if err != nil {
-			return 0, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToDeleteUserAccountsReason), err,
-				"failed to delete UserAccount in the member cluster '%s'", ua.TargetCluster)
-		} else if requeueTime > 0 {
-			return requeueTime, nil
-		}
+	if requeue, err := r.ensureUserAccountsAreNotPresent(logger, mur, r.membersWithoutUserAccount(nil)); err != nil || requeue > 0 {
+		return requeue, err
 	}
 	// Remove finalizer from MasterUserRecord
 	coputil.RemoveFinalizer(mur, murFinalizerName)
@@ -256,25 +316,39 @@ func (r *Reconciler) manageCleanUp(logger logr.Logger, mur *toolchainv1alpha1.Ma
 	return 0, nil
 }
 
-func (r *Reconciler) deleteUserAccount(logger logr.Logger, targetCluster, name string) (time.Duration, error) {
+func (r *Reconciler) deleteUserAccount(logger logr.Logger, targetCluster string, mur *toolchainv1alpha1.MasterUserRecord) (time.Duration, error) {
 	requeueTime := 10 * time.Second
 	// get & check member cluster
 	memberCluster, found := r.MemberClusters[targetCluster]
 	if !found {
 		return 0, fmt.Errorf("unknown target member cluster '%s'", targetCluster)
 	}
-	// Get the User associated with the UserAccount
+
 	userAcc := &toolchainv1alpha1.UserAccount{}
-	namespacedName := types.NamespacedName{Namespace: memberCluster.OperatorNamespace, Name: name}
+	sync := Synchronizer{
+		record:        mur,
+		hostClient:    r.Client,
+		memberCluster: memberCluster,
+		memberUserAcc: userAcc,
+		targetCluster: targetCluster,
+		logger:        logger,
+		scheme:        r.Scheme,
+	}
+
+	// Get the User associated with the UserAccount
+	namespacedName := types.NamespacedName{Namespace: memberCluster.OperatorNamespace, Name: mur.Name}
 	if err := memberCluster.Client.Get(context.TODO(), namespacedName, userAcc); err != nil {
 		if errors.IsNotFound(err) {
-			logger.Info("UserAccount deleted")
-			return 0, nil
+			logger.Info(fmt.Sprintf("UserAccount is not present in '%s' - making sure that it's not in the MasterUserRecord.Status", targetCluster))
+			return 0, sync.removeAccountFromStatus()
 		}
 		return 0, err
 	}
 
 	if coputil.IsBeingDeleted(userAcc) {
+		if err := sync.synchronizeStatus(); err != nil {
+			return 0, err
+		}
 		// if the UserAccount is being deleted, allow up to 1 minute of retries before reporting an error
 		deletionTimestamp := userAcc.GetDeletionTimestamp()
 		if time.Since(deletionTimestamp.Time) > 60*time.Second {

--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -260,7 +260,7 @@ func (r *Reconciler) ensureUserAccount(logger logr.Logger, mur *toolchainv1alpha
 		return false, r.wrapErrorWithStatusUpdate(logger, mur, r.useExistingConditionOfType(toolchainv1alpha1.ConditionReady), err, "")
 	}
 	// nothing done and no error occurred
-	logger.Info("user account on member cluster was already in sync", "target_cluster", targetCluster)
+	logger.Info("user account on member cluster was already present", "target_cluster", targetCluster, "updated", updated)
 	return updated, nil
 }
 

--- a/controllers/masteruserrecord/masteruserrecord_controller.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller.go
@@ -150,9 +150,13 @@ memberClusters:
 
 func (r *Reconciler) ensureUserAccounts(logger logr.Logger, mur *toolchainv1alpha1.MasterUserRecord) ([]string, error) {
 	spaceBindings := &toolchainv1alpha1.SpaceBindingList{}
-	if err := r.Client.List(context.TODO(), spaceBindings, runtimeclient.InNamespace(mur.GetNamespace())); err != nil {
+	if err := r.Client.List(context.TODO(), spaceBindings,
+		runtimeclient.InNamespace(mur.GetNamespace()),
+		runtimeclient.MatchingLabels{
+			toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: mur.Name,
+		}); err != nil {
 		return nil, r.wrapErrorWithStatusUpdate(logger, mur, r.setStatusFailed(toolchainv1alpha1.MasterUserRecordUnableToCreateUserAccountReason), err,
-			"unable to list SpaceBindings")
+			"unable to list SpaceBindings for the MasterUserRecord")
 	}
 	var targetClusters []string
 	for i := range spaceBindings.Items {

--- a/controllers/masteruserrecord/masteruserrecord_controller_test.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller_test.go
@@ -919,7 +919,7 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 	t.Run("mur status synced with updated user account statuses", func(t *testing.T) {
 		// given
-		// setup MUR that wil contain UserAccountStatusEmbedded fields for UserAccounts from commontest.Member2ClusterName and "member3-cluster" but will miss from commontest.MemberClusterName
+		// setup MUR that wil contain UserAccountStatusEmbedded fields for UserAccounts from commontest.Member2ClusterName but will miss from commontest.MemberClusterName
 		// then the reconcile should add the misssing UserAccountStatusEmbedded for the missing commontest.MemberClusterName cluster without updating anything else
 		mur := murtest.NewMasterUserRecord(t, "john",
 			murtest.WithOwnerLabel("john-123"),

--- a/controllers/masteruserrecord/masteruserrecord_controller_test.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller_test.go
@@ -13,12 +13,13 @@ import (
 	"github.com/codeready-toolchain/host-operator/pkg/metrics"
 	. "github.com/codeready-toolchain/host-operator/test"
 	tiertest "github.com/codeready-toolchain/host-operator/test/nstemplatetier"
+	spacebindingtest "github.com/codeready-toolchain/host-operator/test/spacebinding"
 	commoncluster "github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
+	spacetest "github.com/codeready-toolchain/toolchain-common/pkg/test/space"
 	uatest "github.com/codeready-toolchain/toolchain-common/pkg/test/useraccount"
 	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
-
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,12 +42,16 @@ func TestAddFinalizer(t *testing.T) {
 	// given
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
+	mur := murtest.NewMasterUserRecord(t, "john", murtest.WithOwnerLabel("john-123"))
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	space := spacetest.NewSpace(mur.Namespace, "john-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "john-123"),
+		spacetest.WithSpecTargetCluster(commontest.MemberClusterName))
 
 	t.Run("ok", func(t *testing.T) {
 		// given
-		mur := murtest.NewMasterUserRecord(t, "john")
 		memberClient := commontest.NewFakeClient(t)
-		hostClient := commontest.NewFakeClient(t, mur)
+		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 		InitializeCounters(t, NewToolchainStatus(
 			WithMember(commontest.MemberClusterName),
 			WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
@@ -79,9 +84,8 @@ func TestAddFinalizer(t *testing.T) {
 	})
 
 	t.Run("fails because it cannot add finalizer", func(t *testing.T) {
-		// given
-		mur := murtest.NewMasterUserRecord(t, "john")
-		hostClient := commontest.NewFakeClient(t, mur)
+		// given\
+		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 		memberClient := commontest.NewFakeClient(t)
 		hostClient.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
 			return fmt.Errorf("unable to add finalizer to MUR %s", mur.Name)
@@ -122,14 +126,20 @@ func TestCreateUserAccountSuccessful(t *testing.T) {
 	// given
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord(t, "john")
+	mur := murtest.NewMasterUserRecord(t, "john",
+		murtest.WithOwnerLabel("john-123"),
+		murtest.WithAnnotation(toolchainv1alpha1.SSOUserIDAnnotationKey, "123456"),
+		murtest.WithAnnotation(toolchainv1alpha1.SSOAccountIDAnnotationKey, "987654"))
 	mur.Spec.OriginalSub = "original-sub:12345"
-	mur.Annotations[toolchainv1alpha1.SSOUserIDAnnotationKey] = "123456"
-	mur.Annotations[toolchainv1alpha1.SSOAccountIDAnnotationKey] = "987654"
+
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	space := spacetest.NewSpace(mur.Namespace, "john-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "john-123"),
+		spacetest.WithSpecTargetCluster(commontest.MemberClusterName))
 
 	require.NoError(t, murtest.Modify(mur, murtest.Finalizer("finalizer.toolchain.dev.openshift.com")))
 	memberClient := commontest.NewFakeClient(t)
-	hostClient := commontest.NewFakeClient(t, mur)
+	hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMember(commontest.MemberClusterName),
 		WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -175,17 +185,17 @@ func TestCreateUserAccountWhenItWasPreviouslyDeleted(t *testing.T) {
 	// given
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord(t, "john")
-	mur.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{
-		{
-			Cluster: toolchainv1alpha1.Cluster{
-				Name: commontest.MemberClusterName,
-			},
-		},
-	}
+	mur := murtest.NewMasterUserRecord(t, "john",
+		murtest.WithOwnerLabel("john-123"),
+		murtest.StatusUserAccount(commontest.MemberClusterName))
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	space := spacetest.NewSpace(mur.Namespace, "john-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "john-123"),
+		spacetest.WithSpecTargetCluster(commontest.MemberClusterName))
+
 	require.NoError(t, murtest.Modify(mur, murtest.Finalizer("finalizer.toolchain.dev.openshift.com")))
 	memberClient := commontest.NewFakeClient(t)
-	hostClient := commontest.NewFakeClient(t, mur)
+	hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 	InitializeCounters(t, NewToolchainStatus(
 		WithMember(commontest.MemberClusterName),
 		WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -219,11 +229,22 @@ func TestCreateUserAccountWhenItWasPreviouslyDeleted(t *testing.T) {
 
 }
 
-func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
+func TestWithMultipleMembersAndSpaces(t *testing.T) {
 	// given
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord(t, "john", murtest.AdditionalAccounts(commontest.Member2ClusterName), murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
+	mur := murtest.NewMasterUserRecord(t, "john",
+		murtest.Finalizer("finalizer.toolchain.dev.openshift.com"), murtest.WithOwnerLabel("john-123"))
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	space := spacetest.NewSpace(mur.Namespace, "john-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "john-123"),
+		spacetest.WithSpecTargetCluster(commontest.MemberClusterName))
+
+	sharedSpaceBinding := spacebindingtest.NewSpaceBinding("john", "jane-space", "admin", "")
+	sharedSpace := spacetest.NewSpace(mur.Namespace, "jane-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "jane-123"),
+		spacetest.WithSpecTargetCluster(commontest.Member2ClusterName))
+
 	toolchainStatus := NewToolchainStatus(
 		WithMember(commontest.MemberClusterName, WithRoutes("https://console.member-cluster/", "", ToBeReady())),
 		WithMember(commontest.Member2ClusterName, WithRoutes("https://console.member-cluster/", "", ToBeReady())),
@@ -234,36 +255,184 @@ func TestCreateMultipleUserAccountsSuccessful(t *testing.T) {
 			string(metrics.Internal): 1,
 		}),
 	)
-	memberClient := commontest.NewFakeClient(t)
-	memberClient2 := commontest.NewFakeClient(t)
-	hostClient := commontest.NewFakeClient(t, mur, toolchainStatus)
-	InitializeCounters(t, toolchainStatus)
 
-	cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient), ClusterClient(commontest.Member2ClusterName, memberClient2))
+	t.Run("creation of UserAccounts for different spaces is disabled", func(t *testing.T) {
+		memberClient := commontest.NewFakeClient(t, newUserAccount(namespacedName(commontest.MemberOperatorNs, mur.Name), mur))
+		memberClient2 := commontest.NewFakeClient(t)
+		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space, sharedSpaceBinding, sharedSpace, toolchainStatus)
+		InitializeCounters(t, toolchainStatus)
 
-	// when reconciling
-	result, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
-	// then
-	require.NoError(t, err)
-	assert.False(t, result.Requeue)
-	uatest.AssertThatUserAccount(t, "john", memberClient).
-		Exists().
-		MatchMasterUserRecord(mur).
-		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
-	uatest.AssertThatUserAccount(t, "john", memberClient2).
-		Exists().
-		MatchMasterUserRecord(mur).
-		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
-	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
-		HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")).
-		HasFinalizer()
-	AssertThatCountersAndMetrics(t).
-		HaveUsersPerActivationsAndDomain(toolchainv1alpha1.Metric{
-			"1,internal": 1, // unchanged
-		}).
-		HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
-			string(metrics.Internal): 1, // unchanged
+		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient), ClusterClient(commontest.Member2ClusterName, memberClient2))
+
+		// when reconciling
+		result, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, result.RequeueAfter)
+		uatest.AssertThatUserAccount(t, "john", memberClient).
+			Exists().
+			MatchMasterUserRecord(mur).
+			HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
+		uatest.AssertThatUserAccount(t, "john", memberClient2).
+			DoesNotExist()
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions().
+			HasStatusUserAccounts(commontest.MemberClusterName).
+			HasFinalizer()
+		AssertThatCountersAndMetrics(t).
+			HaveUsersPerActivationsAndDomain(toolchainv1alpha1.Metric{
+				"1,internal": 1, // unchanged
+			}).
+			HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
+				string(metrics.Internal): 1, // unchanged
+			})
+	})
+
+	t.Run("mur is being moved - new account should be created", func(t *testing.T) {
+		murCopy := mur.DeepCopy()
+		murCopy.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{
+			{
+				Cluster: toolchainv1alpha1.Cluster{
+					Name: commontest.Member2ClusterName,
+				},
+			},
+		}
+		memberClient := commontest.NewFakeClient(t)
+		memberClient2 := commontest.NewFakeClient(t, newUserAccount(namespacedName(commontest.MemberOperatorNs, mur.Name), mur))
+		hostClient := commontest.NewFakeClient(t, murCopy, spaceBinding, space, sharedSpaceBinding, sharedSpace, toolchainStatus)
+		InitializeCounters(t, toolchainStatus)
+
+		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient), ClusterClient(commontest.Member2ClusterName, memberClient2))
+
+		// when
+		result, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, result.RequeueAfter)
+		uatest.AssertThatUserAccount(t, "john", memberClient).
+			Exists().
+			MatchMasterUserRecord(mur).
+			HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
+		uatest.AssertThatUserAccount(t, "john", memberClient2).
+			Exists().
+			MatchMasterUserRecord(mur).
+			HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")).
+			HasStatusUserAccounts(commontest.Member2ClusterName).
+			HasFinalizer()
+		AssertThatCountersAndMetrics(t).
+			HaveUsersPerActivationsAndDomain(toolchainv1alpha1.Metric{
+				"1,internal": 1, // unchanged
+			}).
+			HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
+				string(metrics.Internal): 1, // unchanged
+			})
+
+		t.Run("the previous account should be deleted", func(t *testing.T) {
+			// when
+			result, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, 10*time.Second, result.RequeueAfter)
+			uatest.AssertThatUserAccount(t, "john", memberClient).
+				Exists().
+				MatchMasterUserRecord(mur).
+				HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
+			uatest.AssertThatUserAccount(t, "john", memberClient2).
+				DoesNotExist()
+			murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+				HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")).
+				HasStatusUserAccounts(commontest.Member2ClusterName, commontest.MemberClusterName).
+				HasFinalizer()
+
+			t.Run("update the status when the UserAccount is gone", func(t *testing.T) {
+				// when
+				result, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
+				// then
+				require.NoError(t, err)
+				assert.Empty(t, result.RequeueAfter)
+				uatest.AssertThatUserAccount(t, "john", memberClient).
+					Exists().
+					MatchMasterUserRecord(mur).
+					HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
+				uatest.AssertThatUserAccount(t, "john", memberClient2).
+					DoesNotExist()
+				murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+					HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")).
+					HasStatusUserAccounts(commontest.MemberClusterName).
+					HasFinalizer()
+			})
 		})
+	})
+
+	t.Run("space that is being deleted should be ignored", func(t *testing.T) {
+		memberClient := commontest.NewFakeClient(t)
+		memberClient2 := commontest.NewFakeClient(t)
+		terminatingSpace := space.DeepCopy()
+		spacetest.WithDeletionTimestamp()(terminatingSpace)
+		spacetest.WithFinalizer()(terminatingSpace)
+
+		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, terminatingSpace, sharedSpaceBinding, sharedSpace, toolchainStatus)
+		InitializeCounters(t, toolchainStatus)
+
+		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient), ClusterClient(commontest.Member2ClusterName, memberClient2))
+
+		// when reconciling
+		result, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, result.RequeueAfter)
+		uatest.AssertThatUserAccount(t, "john", memberClient).
+			DoesNotExist()
+		uatest.AssertThatUserAccount(t, "john", memberClient2).
+			DoesNotExist()
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions().
+			HasStatusUserAccounts().
+			HasFinalizer()
+		AssertThatCountersAndMetrics(t).
+			HaveUsersPerActivationsAndDomain(toolchainv1alpha1.Metric{
+				"1,internal": 1, // unchanged
+			}).
+			HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
+				string(metrics.Internal): 1, // unchanged
+			})
+	})
+
+	t.Run("spaceBinding that is being deleted should be ignored", func(t *testing.T) {
+		memberClient := commontest.NewFakeClient(t)
+		memberClient2 := commontest.NewFakeClient(t)
+		terminatingSpaceBinding := spaceBinding.DeepCopy()
+		spacebindingtest.WithDeletionTimestamp()(terminatingSpaceBinding)
+		spacebindingtest.WithFinalizer()(terminatingSpaceBinding)
+
+		hostClient := commontest.NewFakeClient(t, mur, terminatingSpaceBinding, space, sharedSpaceBinding, sharedSpace, toolchainStatus)
+		InitializeCounters(t, toolchainStatus)
+
+		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient), ClusterClient(commontest.Member2ClusterName, memberClient2))
+
+		// when reconciling
+		result, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, result.RequeueAfter)
+		uatest.AssertThatUserAccount(t, "john", memberClient).
+			DoesNotExist()
+		uatest.AssertThatUserAccount(t, "john", memberClient2).
+			DoesNotExist()
+		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
+			HasConditions().
+			HasStatusUserAccounts().
+			HasFinalizer()
+		AssertThatCountersAndMetrics(t).
+			HaveUsersPerActivationsAndDomain(toolchainv1alpha1.Metric{
+				"1,internal": 1, // unchanged
+			}).
+			HaveMasterUserRecordsPerDomain(toolchainv1alpha1.Metric{
+				string(metrics.Internal): 1, // unchanged
+			})
+	})
 }
 
 func TestRequeueWhenUserAccountDeleted(t *testing.T) {
@@ -290,7 +459,9 @@ func TestRequeueWhenUserAccountDeleted(t *testing.T) {
 	t.Run("when userAccount is accidentally being deleted then don't change the counter", func(t *testing.T) {
 		// given
 		InitializeCounters(t, toolchainStatus)
-		userAccount2 := uatest.NewUserAccountFromMur(mur, uatest.DeletedUa())
+		userAccount2 := uatest.NewUserAccountFromMur(mur,
+			uatest.DeletedUa(),
+			uatest.WithFinalizer())
 		memberClient2 := commontest.NewFakeClient(t, userAccount2)
 		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient1),
 			ClusterClient(commontest.Member2ClusterName, memberClient2),
@@ -315,11 +486,17 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	// given
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
-	mur := murtest.NewMasterUserRecord(t, "john", murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
-	hostClient := commontest.NewFakeClient(t, mur)
+	mur := murtest.NewMasterUserRecord(t, "john",
+		murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
+		murtest.WithOwnerLabel("john-123"))
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	space := spacetest.NewSpace(mur.Namespace, "john-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "john-123"),
+		spacetest.WithSpecTargetCluster(commontest.MemberClusterName))
 
 	t.Run("when member cluster does not exist and UA hasn't been created yet", func(t *testing.T) {
 		// given
+		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 		InitializeCounters(t, NewToolchainStatus(
 			WithMember(commontest.MemberClusterName),
 			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -356,6 +533,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 
 	t.Run("when member cluster does not exist and UA was already created", func(t *testing.T) {
 		// given
+		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 		InitializeCounters(t, NewToolchainStatus(
 			WithMember(commontest.MemberClusterName),
 			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -389,6 +567,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 
 	t.Run("status update of the MasterUserRecord failed", func(t *testing.T) {
 		// given
+		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 		InitializeCounters(t, NewToolchainStatus(
 			WithMember(commontest.MemberClusterName),
 			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -422,6 +601,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 
 	t.Run("creation of the UserAccount failed", func(t *testing.T) {
 		// given
+		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 		InitializeCounters(t, NewToolchainStatus(
 			WithMember(commontest.MemberClusterName),
 			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
@@ -477,10 +657,11 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 		}
 		otherTier := tiertest.OtherTier()
 		modifiedMur := murtest.NewMasterUserRecord(t, "john",
+			murtest.WithOwnerLabel("john-123"),
 			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 			murtest.TierName(otherTier.Name),
 			murtest.UserID("abc123")) // UserID is different and needs to be synced
-		hostClient := commontest.NewFakeClient(t, modifiedMur)
+		hostClient := commontest.NewFakeClient(t, modifiedMur, spaceBinding, space)
 
 		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient))
 
@@ -518,11 +699,12 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 			}))
 		updatingCond := toBeNotReady("updating", "")
 		provisionedMur := murtest.NewMasterUserRecord(t, "john",
+			murtest.WithOwnerLabel("john-123"),
 			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 			murtest.StatusCondition(updatingCond))
 		memberClient := commontest.NewFakeClient(t, uatest.NewUserAccountFromMur(provisionedMur,
 			uatest.StatusCondition(toBeNotReady("somethingFailed", ""))))
-		hostClient := commontest.NewFakeClient(t, provisionedMur, toolchainStatus)
+		hostClient := commontest.NewFakeClient(t, provisionedMur, toolchainStatus, spaceBinding, space)
 		InitializeCounters(t, toolchainStatus)
 
 		hostClient.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
@@ -565,6 +747,7 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 				string(metrics.Internal): 1,
 			})))
 		mur := murtest.NewMasterUserRecord(t, "john",
+			murtest.WithOwnerLabel("john-123"),
 			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 			murtest.ToBeDeleted())
 		hostClient := commontest.NewFakeClient(t, mur)
@@ -598,18 +781,22 @@ func TestCreateSynchronizeOrDeleteUserAccountFailed(t *testing.T) {
 	})
 }
 
-func TestModifyUserAccounts(t *testing.T) {
+// todo change test to support updates of multiple UserAccounts
+func TestModifyUserAccount(t *testing.T) {
 	// given
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
 	mur := murtest.NewMasterUserRecord(t, "john",
+		murtest.WithOwnerLabel("john-123"),
 		murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 		murtest.StatusCondition(toBeProvisioned()),
 		murtest.AdditionalAccounts(commontest.Member2ClusterName, "member3-cluster"))
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	space := spacetest.NewSpace(mur.Namespace, "john-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "john-123"),
+		spacetest.WithSpecTargetCluster(commontest.MemberClusterName))
 
 	userAccount := uatest.NewUserAccountFromMur(mur)
-	userAccount2 := uatest.NewUserAccountFromMur(mur)
-	userAccount3 := uatest.NewUserAccountFromMur(mur)
 
 	err := murtest.Modify(mur, murtest.UserID("abc123"))
 	require.NoError(t, err)
@@ -626,9 +813,9 @@ func TestModifyUserAccounts(t *testing.T) {
 		}))
 
 	memberClient := commontest.NewFakeClient(t, userAccount)
-	memberClient2 := commontest.NewFakeClient(t, userAccount2)
-	memberClient3 := commontest.NewFakeClient(t, userAccount3)
-	hostClient := commontest.NewFakeClient(t, mur, toolchainStatus)
+	memberClient2 := commontest.NewFakeClient(t)
+	memberClient3 := commontest.NewFakeClient(t)
+	hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space, toolchainStatus)
 
 	InitializeCounters(t, toolchainStatus)
 
@@ -644,23 +831,6 @@ func TestModifyUserAccounts(t *testing.T) {
 		MatchMasterUserRecord(mur).
 		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
 
-	// when ensuring 2nd account
-	_, err = cntrl.Reconcile(context.TODO(), newMurRequest(mur))
-	// then
-	require.NoError(t, err)
-	uatest.AssertThatUserAccount(t, "john", memberClient2).
-		Exists().
-		MatchMasterUserRecord(mur).
-		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
-
-	// when ensuring 3rd account
-	_, err = cntrl.Reconcile(context.TODO(), newMurRequest(mur))
-	// then
-	require.NoError(t, err)
-	uatest.AssertThatUserAccount(t, "john", memberClient3).
-		Exists().
-		MatchMasterUserRecord(mur).
-		HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30")
 	murtest.AssertThatMasterUserRecord(t, "john", hostClient).
 		HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordUpdatingReason, ""))
 	AssertThatCountersAndMetrics(t).
@@ -675,57 +845,44 @@ func TestModifyUserAccounts(t *testing.T) {
 func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	space := spacetest.NewSpace(commontest.HostOperatorNs, "john-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "john-123"),
+		spacetest.WithSpecTargetCluster(commontest.MemberClusterName))
 
 	t.Run("mur status synced with updated user account statuses", func(t *testing.T) {
 		// given
 		// setup MUR that wil contain UserAccountStatusEmbedded fields for UserAccounts from commontest.Member2ClusterName and "member3-cluster" but will miss from commontest.MemberClusterName
 		// then the reconcile should add the misssing UserAccountStatusEmbedded for the missing commontest.MemberClusterName cluster without updating anything else
 		mur := murtest.NewMasterUserRecord(t, "john",
+			murtest.WithOwnerLabel("john-123"),
 			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 			murtest.StatusCondition(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")),
-			murtest.AdditionalAccounts(commontest.Member2ClusterName, "member3-cluster"))
+			murtest.StatusUserAccount(commontest.Member2ClusterName, toBeProvisioned()))
 
 		userAccount := uatest.NewUserAccountFromMur(mur,
 			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
 		userAccount2 := uatest.NewUserAccountFromMur(mur,
-			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
-		userAccount3 := uatest.NewUserAccountFromMur(mur,
-			uatest.StatusCondition(toBeNotReady("Provisioning", "")), uatest.ResourceVersion("123abc"))
-
-		mur.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{
-			{
-				Cluster: toolchainv1alpha1.Cluster{
-					Name: commontest.Member2ClusterName,
-				},
-				UserAccountStatus: userAccount2.Status,
-			},
-			{
-				Cluster: toolchainv1alpha1.Cluster{
-					Name: "member3-cluster",
-				},
-				UserAccountStatus: userAccount3.Status,
-			},
-		}
+			uatest.DeletedUa(),
+			uatest.WithFinalizer(),
+			uatest.StatusCondition(toBeNotReady("Terminating", "")), uatest.ResourceVersion("123abc"))
 
 		memberClient := commontest.NewFakeClient(t, userAccount)
 		memberClient2 := commontest.NewFakeClient(t, userAccount2)
-		memberClient3 := commontest.NewFakeClient(t, userAccount3)
 
 		toolchainStatus := NewToolchainStatus(
 			WithMember(commontest.MemberClusterName, WithRoutes("https://console.member-cluster/", "", ToBeReady())),
 			WithMember(commontest.Member2ClusterName, WithRoutes("https://console.member2-cluster/", "", ToBeReady())),
-			WithMember("member3-cluster", WithRoutes("https://console.member3-cluster/", "", ToBeReady())),
 			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
 				"1,internal": 1,
 			}),
 			WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
 				string(metrics.Internal): 1,
 			}))
-		hostClient := commontest.NewFakeClient(t, mur, toolchainStatus)
+		hostClient := commontest.NewFakeClient(t, mur, toolchainStatus, spaceBinding, space)
 		InitializeCounters(t, toolchainStatus)
 
-		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient), ClusterClient(commontest.Member2ClusterName, memberClient2),
-			ClusterClient("member3-cluster", memberClient3))
+		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient), ClusterClient(commontest.Member2ClusterName, memberClient2))
 
 		// when
 		_, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
@@ -743,16 +900,12 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 			MatchMasterUserRecord(mur).
 			HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30").
 			HasConditions(userAccount2.Status.Conditions...)
-		uatest.AssertThatUserAccount(t, "john", memberClient3).
-			Exists().
-			MatchMasterUserRecord(mur).
-			HasLabelWithValue(toolchainv1alpha1.TierLabelKey, "deactivate30").
-			HasConditions(userAccount3.Status.Conditions...)
 
 		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
 			HasConditions(toBeNotReady(toolchainv1alpha1.MasterUserRecordProvisioningReason, "")).
-			HasStatusUserAccounts(commontest.MemberClusterName, commontest.Member2ClusterName, "member3-cluster").
-			AllUserAccountsHaveCondition(userAccount.Status.Conditions[0])
+			HasStatusUserAccounts(commontest.MemberClusterName, commontest.Member2ClusterName).
+			HasStatusUserAccountsWithCondition(commontest.MemberClusterName, userAccount.Status.Conditions[0]).
+			HasStatusUserAccountsWithCondition(commontest.Member2ClusterName, userAccount2.Status.Conditions[0])
 		AssertThatCountersAndMetrics(t).
 			HaveUsersPerActivationsAndDomain(toolchainv1alpha1.Metric{
 				"1,internal": 1, // unchanged
@@ -762,10 +915,10 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 			})
 	})
 
-	t.Run("outdated mur status error cleaned", func(t *testing.T) {
+	t.Run("outdated mur status error cleaned and align readiness", func(t *testing.T) {
 		// given
 		// A basic userSignup to set as the mur owner
-		userSignup := commonsignup.NewUserSignup()
+		userSignup := commonsignup.NewUserSignup(commonsignup.WithName("john-123"))
 		userSignup.Status = toolchainv1alpha1.UserSignupStatus{
 			CompliantUsername: "john",
 		}
@@ -773,22 +926,13 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 		// MUR with ready condition set to false with an error
 		// all MUR.Status.UserAccount[] conditions are already in sync with the corresponding UserAccounts and set to Ready
 		mur := murtest.NewMasterUserRecord(t, "john",
+			murtest.WithOwnerLabel(userSignup.Name),
 			murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 			murtest.StatusCondition(toBeNotReady(toolchainv1alpha1.MasterUserRecordTargetClusterNotReadyReason, "something went wrong")),
-			murtest.AdditionalAccounts(commontest.Member2ClusterName))
+			murtest.AdditionalAccounts(commontest.MemberClusterName, commontest.Member2ClusterName),
+			murtest.StatusUserAccount(commontest.MemberClusterName, toBeProvisioned()),
+			murtest.StatusUserAccount(commontest.Member2ClusterName, toBeProvisioned()))
 		userAccount := uatest.NewUserAccountFromMur(mur, uatest.StatusCondition(toBeProvisioned()), uatest.ResourceVersion("123abc"))
-		userAccount2 := uatest.NewUserAccountFromMur(mur, uatest.StatusCondition(toBeProvisioned()), uatest.ResourceVersion("123abc"))
-		mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] = userSignup.Name
-		mur.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{
-			{
-				Cluster:           toolchainv1alpha1.Cluster{Name: commontest.MemberClusterName},
-				UserAccountStatus: userAccount.Status,
-			},
-			{
-				Cluster:           toolchainv1alpha1.Cluster{Name: commontest.Member2ClusterName},
-				UserAccountStatus: userAccount2.Status,
-			},
-		}
 
 		toolchainStatus := NewToolchainStatus(
 			WithMember(commontest.MemberClusterName, WithRoutes("https://console.member-cluster/", "", ToBeReady())),
@@ -800,11 +944,11 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 			WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
 				string(metrics.Internal): 1,
 			}))
-		hostClient := commontest.NewFakeClient(t, userSignup, mur, toolchainStatus)
+		hostClient := commontest.NewFakeClient(t, userSignup, mur, spaceBinding, space, toolchainStatus)
 		InitializeCounters(t, toolchainStatus)
 
 		memberClient := commontest.NewFakeClient(t, userAccount)
-		memberClient2 := commontest.NewFakeClient(t, uatest.NewUserAccountFromMur(mur))
+		memberClient2 := commontest.NewFakeClient(t)
 
 		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient),
 			ClusterClient(commontest.Member2ClusterName, memberClient2))
@@ -818,7 +962,7 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 
 		murtest.AssertThatMasterUserRecord(t, "john", hostClient).
 			HasConditions(toBeProvisioned(), toBeProvisionedNotificationCreated()).
-			HasStatusUserAccounts(commontest.MemberClusterName, commontest.Member2ClusterName).
+			HasStatusUserAccounts(commontest.MemberClusterName).
 			HasFinalizer()
 
 		// Get the notification resource and verify it
@@ -846,6 +990,17 @@ func TestSyncMurStatusWithUserAccountStatuses(t *testing.T) {
 }
 
 func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
+	toolchainStatus := NewToolchainStatus(
+		WithMember(commontest.MemberClusterName, WithRoutes("https://console.member-cluster/", "", ToBeReady())),
+		WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
+			"1,internal": 1,
+			"1,external": 1,
+		}),
+		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
+			string(metrics.Internal): 1,
+			string(metrics.External): 1,
+		}))
+
 	t.Run("success", func(t *testing.T) {
 		// given
 		logf.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -856,24 +1011,14 @@ func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
 
 		memberClient := commontest.NewFakeClient(t, userAcc)
 		hostClient := commontest.NewFakeClient(t, mur)
-		InitializeCounters(t, NewToolchainStatus(
-			WithMember(commontest.MemberClusterName),
-			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
-				"1,internal": 1,
-				"1,external": 1,
-			}),
-			WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
-				string(metrics.Internal): 1,
-				string(metrics.External): 1,
-			})))
+		InitializeCounters(t, toolchainStatus)
 
 		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient))
 
 		// when
 		result1, err1 := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
 		require.NoError(t, err1)
-		assert.True(t, result1.Requeue)
-		assert.Equal(t, int64(result1.RequeueAfter), int64(10*time.Second))
+		assert.Equal(t, 10*time.Second, result1.RequeueAfter)
 
 		result2, err2 := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
 
@@ -902,30 +1047,21 @@ func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
 		s := apiScheme(t)
 		mur := murtest.NewMasterUserRecord(t, "john-wait-for-ua",
 			murtest.ToBeDeleted())
-		userAcc := uatest.NewUserAccountFromMur(mur)
-		// set deletion timestamp to indicate UserAccount deletion is in progress
-		userAcc.DeletionTimestamp = &metav1.Time{Time: time.Now().Add(-5 * time.Second)}
+		userAcc := uatest.NewUserAccountFromMur(mur,
+			uatest.DeletedUa())
 
-		hostClient := commontest.NewFakeClient(t, mur)
+		hostClient := commontest.NewFakeClient(t, mur, toolchainStatus)
 		memberClient := commontest.NewFakeClient(t, userAcc)
-		InitializeCounters(t, NewToolchainStatus(
-			WithMember(commontest.MemberClusterName),
-			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
-				"1,internal": 1,
-				"1,external": 1,
-			}),
-			WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
-				string(metrics.Internal): 1,
-				string(metrics.External): 1,
-			})))
+		InitializeCounters(t, toolchainStatus)
 
 		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient))
 
 		// when
 		result1, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
 		require.NoError(t, err)
-		assert.True(t, result1.Requeue)
-		assert.Equal(t, int64(result1.RequeueAfter), int64(10*time.Second))
+		assert.Equal(t, 10*time.Second, result1.RequeueAfter)
+		murtest.AssertThatMasterUserRecord(t, "john-wait-for-ua", hostClient).
+			HasFinalizer()
 
 		err = memberClient.Delete(context.TODO(), userAcc)
 		require.NoError(t, err)
@@ -966,18 +1102,9 @@ func TestDeleteUserAccountViaMasterUserRecordBeingDeleted(t *testing.T) {
 		// set deletion timestamp to indicate UserAccount deletion is in progress
 		userAcc.DeletionTimestamp = &metav1.Time{Time: time.Now().Add(-60 * time.Second)}
 
-		hostClient := commontest.NewFakeClient(t, mur)
+		hostClient := commontest.NewFakeClient(t, mur, toolchainStatus)
 		memberClient := commontest.NewFakeClient(t, userAcc)
-		InitializeCounters(t, NewToolchainStatus(
-			WithMember(commontest.MemberClusterName),
-			WithMetric(toolchainv1alpha1.UserSignupsPerActivationAndDomainMetricKey, toolchainv1alpha1.Metric{
-				"1,internal": 1,
-				"1,external": 1,
-			}),
-			WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
-				string(metrics.Internal): 1,
-				string(metrics.External): 1,
-			})))
+		InitializeCounters(t, toolchainStatus)
 
 		cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient))
 
@@ -1056,13 +1183,11 @@ func TestDeleteMultipleUserAccountsViaMasterUserRecordBeingDeleted(t *testing.T)
 	// when
 	result1, err1 := cntrl.Reconcile(context.TODO(), newMurRequest(mur)) // first reconcile will wait for first useraccount to be deleted
 	require.NoError(t, err1)
-	assert.True(t, result1.Requeue)
-	assert.Equal(t, int64(result1.RequeueAfter), int64(10*time.Second))
+	assert.Equal(t, 10*time.Second, result1.RequeueAfter)
 
 	result2, err2 := cntrl.Reconcile(context.TODO(), newMurRequest(mur)) // second reconcile will wait for second useraccount to be deleted
 	require.NoError(t, err2)
-	assert.True(t, result2.Requeue)
-	assert.Equal(t, int64(result2.RequeueAfter), int64(10*time.Second))
+	assert.Equal(t, 10*time.Second, result2.RequeueAfter)
 
 	result3, err3 := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
 
@@ -1088,8 +1213,14 @@ func TestDisablingMasterUserRecord(t *testing.T) {
 	logf.SetLogger(zap.New(zap.UseDevMode(true)))
 	s := apiScheme(t)
 	mur := murtest.NewMasterUserRecord(t, "john",
+		murtest.WithOwnerLabel("john-123"),
 		murtest.Finalizer("finalizer.toolchain.dev.openshift.com"),
 		murtest.DisabledMur(true))
+	spaceBinding := spacebindingtest.NewSpaceBinding("john", "john-space", "admin", "john-123")
+	space := spacetest.NewSpace(mur.Namespace, "john-space",
+		spacetest.WithLabel(toolchainv1alpha1.SpaceCreatorLabelKey, "john-123"),
+		spacetest.WithSpecTargetCluster(commontest.MemberClusterName))
+
 	userAccount := uatest.NewUserAccountFromMur(mur, uatest.DisabledUa(false))
 	memberClient := commontest.NewFakeClient(t, userAccount)
 	toolchainStatus := NewToolchainStatus(
@@ -1100,7 +1231,7 @@ func TestDisablingMasterUserRecord(t *testing.T) {
 		WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
 			string(metrics.Internal): 1,
 		}))
-	hostClient := commontest.NewFakeClient(t, mur, toolchainStatus)
+	hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space, toolchainStatus)
 	InitializeCounters(t, toolchainStatus)
 
 	cntrl := newController(hostClient, s, ClusterClient(commontest.MemberClusterName, memberClient))

--- a/controllers/masteruserrecord/masteruserrecord_controller_test.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller_test.go
@@ -1340,6 +1340,7 @@ func newController(hostCl runtimeclient.Client, s *runtime.Scheme, memberCl ...C
 		NewMemberClusterWithClient(cl, name, corev1.ConditionTrue)
 		r.MemberClusters[name] = cluster.Cluster{
 			Config: &commoncluster.Config{
+				Name:              name,
 				Type:              commoncluster.Member,
 				OperatorNamespace: commontest.MemberOperatorNs,
 				OwnerClusterName:  commontest.MemberClusterName,

--- a/controllers/masteruserrecord/masteruserrecord_controller_test.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller_test.go
@@ -323,7 +323,7 @@ func TestWithMultipleMembersAndSpaces(t *testing.T) {
 			})
 	})
 
-	t.Run("mur is being moved - new account should be created", func(t *testing.T) {
+	t.Run("mur is being moved from member2-cluster to member-cluster - new account should be created in member-cluster", func(t *testing.T) {
 		murCopy := mur.DeepCopy()
 		murCopy.Status.UserAccounts = []toolchainv1alpha1.UserAccountStatusEmbedded{
 			{
@@ -364,7 +364,7 @@ func TestWithMultipleMembersAndSpaces(t *testing.T) {
 				string(metrics.Internal): 1, // unchanged
 			})
 
-		t.Run("the previous account should be deleted", func(t *testing.T) {
+		t.Run("the previous account should be deleted in member2-cluster", func(t *testing.T) {
 			// when
 			result, err := cntrl.Reconcile(context.TODO(), newMurRequest(mur))
 			// then

--- a/controllers/masteruserrecord/masteruserrecord_controller_test.go
+++ b/controllers/masteruserrecord/masteruserrecord_controller_test.go
@@ -119,7 +119,7 @@ func TestAddFinalizer(t *testing.T) {
 	})
 
 	t.Run("fails because it cannot add finalizer", func(t *testing.T) {
-		// given\
+		// given
 		hostClient := commontest.NewFakeClient(t, mur, spaceBinding, space)
 		memberClient := commontest.NewFakeClient(t)
 		hostClient.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {

--- a/controllers/masteruserrecord/sync.go
+++ b/controllers/masteruserrecord/sync.go
@@ -188,9 +188,6 @@ func (s *Synchronizer) alignDisabled() {
 
 // alignReadiness updates the status to Provisioned and returns true if all the embedded UserAccounts are ready
 func (s *Synchronizer) alignReadiness() (bool, error) {
-	if len(s.record.Status.UserAccounts) == 0 {
-		return false, nil
-	}
 	for _, uaStatus := range s.record.Status.UserAccounts {
 		if !condition.IsTrue(uaStatus.Conditions, toolchainv1alpha1.ConditionReady) {
 			return false, nil

--- a/controllers/masteruserrecord/sync_test.go
+++ b/controllers/masteruserrecord/sync_test.go
@@ -666,7 +666,7 @@ func TestRemoveAccountFromStatus(t *testing.T) {
 		require.NoError(t, err)
 		murtest.AssertThatMasterUserRecord(t, mur.Name, hostClient).
 			HasStatusUserAccounts().
-			HasConditions(toBeNotReady("Provisioning", ""))
+			HasConditions(toBeProvisioned(), toBeProvisionedNotificationCreated())
 	})
 
 	t.Run("remove UserAccount from the status when there are two items and align readiness", func(t *testing.T) {

--- a/controllers/masteruserrecord/sync_test.go
+++ b/controllers/masteruserrecord/sync_test.go
@@ -37,7 +37,6 @@ func TestIsSynchronized(t *testing.T) {
 		s := Synchronizer{
 			memberUserAcc: &memberUserAcc,
 			record:        &record,
-			targetCluster: "member-1",
 		}
 		// when/then
 		assert.True(t, s.isSynchronized())
@@ -52,7 +51,6 @@ func TestIsSynchronized(t *testing.T) {
 			s := Synchronizer{
 				memberUserAcc: &memberUserAcc,
 				record:        &record,
-				targetCluster: "member-1",
 			}
 			// when/then
 			assert.False(t, s.isSynchronized())
@@ -65,7 +63,6 @@ func TestIsSynchronized(t *testing.T) {
 			s := Synchronizer{
 				memberUserAcc: &memberUserAcc,
 				record:        &record,
-				targetCluster: "member-1",
 			}
 			// when/then
 			assert.False(t, s.isSynchronized())
@@ -78,7 +75,6 @@ func TestIsSynchronized(t *testing.T) {
 			s := Synchronizer{
 				memberUserAcc: &memberUserAcc,
 				record:        &record,
-				targetCluster: "member-1",
 			}
 			// when/then
 			assert.False(t, s.isSynchronized())
@@ -91,7 +87,6 @@ func TestIsSynchronized(t *testing.T) {
 			s := Synchronizer{
 				memberUserAcc: &memberUserAcc,
 				record:        &record,
-				targetCluster: "member-1",
 			}
 			// when/then
 			assert.False(t, s.isSynchronized())
@@ -104,7 +99,6 @@ func TestIsSynchronized(t *testing.T) {
 			s := Synchronizer{
 				memberUserAcc: &memberUserAcc,
 				record:        &record,
-				targetCluster: "member-1",
 			}
 			// when/then
 			assert.False(t, s.isSynchronized())
@@ -117,7 +111,6 @@ func TestIsSynchronized(t *testing.T) {
 			s := Synchronizer{
 				memberUserAcc: &memberUserAcc,
 				record:        &record,
-				targetCluster: "member-1",
 			}
 			// when/then
 			assert.False(t, s.isSynchronized())
@@ -678,7 +671,6 @@ func TestSynchronizeUserAccountFailed(t *testing.T) {
 			hostClient:    hostClient,
 			memberCluster: newMemberCluster(memberClient),
 			memberUserAcc: userAcc,
-			targetCluster: "member-1",
 			logger:        l,
 			scheme:        scheme,
 		}
@@ -708,7 +700,6 @@ func TestSynchronizeUserAccountFailed(t *testing.T) {
 			hostClient:    hostClient,
 			memberCluster: newMemberCluster(memberClient),
 			memberUserAcc: userAcc,
-			targetCluster: test.MemberClusterName,
 			logger:        l,
 			scheme:        scheme,
 		}
@@ -790,7 +781,6 @@ func TestSynchronizeUserAccountFailed(t *testing.T) {
 						hostClient:    hostClient,
 						memberCluster: newMemberCluster(memberClient),
 						memberUserAcc: userAccount,
-						targetCluster: "member-1",
 						logger:        l,
 						scheme:        scheme,
 					}
@@ -898,7 +888,6 @@ func TestRoutes(t *testing.T) {
 			hostClient:    hostClient,
 			memberCluster: newMemberCluster(memberClient),
 			memberUserAcc: userAccount,
-			targetCluster: test.MemberClusterName,
 			logger:        l,
 		}
 
@@ -933,7 +922,6 @@ func TestRoutes(t *testing.T) {
 			hostClient:    hostClient,
 			memberCluster: newMemberCluster(memberClient),
 			memberUserAcc: userAccount,
-			targetCluster: test.MemberClusterName,
 			logger:        l,
 		}
 
@@ -968,7 +956,6 @@ func TestRoutes(t *testing.T) {
 			hostClient:    hostClient,
 			memberCluster: newMemberCluster(memberClient),
 			memberUserAcc: userAccount,
-			targetCluster: "member-1",
 			logger:        l,
 		}
 
@@ -1005,7 +992,6 @@ func prepareSynchronizer(t *testing.T, userAccount *toolchainv1alpha1.UserAccoun
 		hostClient:    hostClient,
 		memberCluster: newMemberCluster(memberClient),
 		memberUserAcc: userAccount,
-		targetCluster: test.MemberClusterName,
 		logger:        zap.New(zap.UseDevMode(true)),
 		scheme:        apiScheme(t),
 	}, memberClient

--- a/controllers/usersignup/masteruserrecord.go
+++ b/controllers/usersignup/masteruserrecord.go
@@ -36,6 +36,9 @@ func newMasterUserRecord(userSignup *toolchainv1alpha1.UserSignup, targetCluster
 	annotations := map[string]string{
 		toolchainv1alpha1.MasterUserRecordEmailAnnotationKey: userSignup.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey],
 	}
+	if skipValue, present := userSignup.Annotations[toolchainv1alpha1.SkipAutoCreateSpaceAnnotationKey]; present {
+		annotations[toolchainv1alpha1.SkipAutoCreateSpaceAnnotationKey] = skipValue
+	}
 
 	mur := &toolchainv1alpha1.MasterUserRecord{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/usersignup/masteruserrecord_test.go
+++ b/controllers/usersignup/masteruserrecord_test.go
@@ -31,6 +31,26 @@ func TestNewMasterUserRecord(t *testing.T) {
 	assert.Equal(t, expectedMUR, mur)
 }
 
+func TestNewMasterUserRecordWhenSpaceCreationIsSkipped(t *testing.T) {
+	// given
+	userSignup := commonsignup.NewUserSignup(commonsignup.WithAnnotation("toolchain.dev.openshift.com/skip-auto-create-space", "true"))
+
+	// when
+	mur := newMasterUserRecord(userSignup, test.MemberClusterName, "deactivate90", "johny")
+
+	// then
+	expectedMUR := commonmur.NewMasterUserRecord(t, "johny",
+		commonmur.WithOwnerLabel(userSignup.Name),
+		commonmur.TierName("deactivate90"),
+		commonmur.UserID("UserID123"),
+		commonmur.WithAnnotation("toolchain.dev.openshift.com/user-email", "foo@redhat.com"),
+		commonmur.WithAnnotation("toolchain.dev.openshift.com/skip-auto-create-space", "true"))
+
+	expectedMUR.Spec.PropagatedClaims = userSignup.Spec.IdentityClaims.PropagatedClaims
+
+	assert.Equal(t, expectedMUR, mur)
+}
+
 func TestMigrateMurIfNecessary(t *testing.T) {
 
 	t.Run("no update needed", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20230912073725-4ae0201b4630
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20230920120310-0f59f17bca92
+	github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20231010071648-0735f55e8eb2
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
@@ -32,8 +32,6 @@ require (
 )
 
 require github.com/google/uuid v1.3.0 // indirect
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20230928121547-4d52ef0f4be2
 
 require (
 	cloud.google.com/go v0.97.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 
 require github.com/google/uuid v1.3.0 // indirect
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20230928121547-4d52ef0f4be2
+
 require (
 	cloud.google.com/go v0.97.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20230912073725-4ae0201b4630 h1:Z281nLD0OLfdzbUq2tUK5/B6d2OX1hPg5oFGZSJM4RQ=
 github.com/codeready-toolchain/api v0.0.0-20230912073725-4ae0201b4630/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20230920120310-0f59f17bca92 h1:9gcDMkjSAjxM3RLUYCHv9prCDwdi7IgAWpTwTsDpGL8=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20230920120310-0f59f17bca92/go.mod h1:+rs3V8do2s0DzGPyCy2sgnvUs9GfSi5RVWx+AZC+cTM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -432,6 +430,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/matousjobanek/toolchain-common v0.0.0-20230928121547-4d52ef0f4be2 h1:/E8Nq12Du1+u7v5YfG+FAeusmo28rjb49PSfpYKx1b0=
+github.com/matousjobanek/toolchain-common v0.0.0-20230928121547-4d52ef0f4be2/go.mod h1:+rs3V8do2s0DzGPyCy2sgnvUs9GfSi5RVWx+AZC+cTM=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,10 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20230912073725-4ae0201b4630 h1:Z281nLD0OLfdzbUq2tUK5/B6d2OX1hPg5oFGZSJM4RQ=
-github.com/codeready-toolchain/api v0.0.0-20230912073725-4ae0201b4630/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
+github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33 h1:hxXfcFq2JgFISVxrkISg8m9DZMzpcPWRjPspx3M3Sxo=
+github.com/codeready-toolchain/api v0.0.0-20230918195153-739e8fb09a33/go.mod h1:nn3W6eKb9PFIVwSwZW7wDeLACMBOwAV+4kddGuN+ARM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20231010071648-0735f55e8eb2 h1:uMrAMTACCipKMV5pOBauaRRsGahQOdNTQ/uo/pGTQvA=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20231010071648-0735f55e8eb2/go.mod h1:o/JGPWZ/9rVh/np0tcaPRXnreZ+X743o0Gxp1eP62/w=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -430,8 +432,6 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/matousjobanek/toolchain-common v0.0.0-20230928121547-4d52ef0f4be2 h1:/E8Nq12Du1+u7v5YfG+FAeusmo28rjb49PSfpYKx1b0=
-github.com/matousjobanek/toolchain-common v0.0.0-20230928121547-4d52ef0f4be2/go.mod h1:+rs3V8do2s0DzGPyCy2sgnvUs9GfSi5RVWx+AZC+cTM=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=

--- a/test/spacebinding/spacebinding.go
+++ b/test/spacebinding/spacebinding.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codeready-toolchain/api/api/v1alpha1"
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,5 +48,11 @@ func WithDeletionTimestamp() Option {
 	return func(spaceBinding *toolchainv1alpha1.SpaceBinding) {
 		now := metav1.NewTime(time.Now())
 		spaceBinding.DeletionTimestamp = &now
+	}
+}
+
+func WithFinalizer() Option {
+	return func(spaceBinding *toolchainv1alpha1.SpaceBinding) {
+		util.AddFinalizer(spaceBinding, toolchainv1alpha1.FinalizerName)
 	}
 }


### PR DESCRIPTION
The PR changes the way how MasterUserRecord decides where it should create UserAccount(s). It doesn't use the UserAccounts embedded in MasterUserRecord.Spec anymore (and thus the targetCluster neither).
 
Instead of it, it loads all Spaces it has access to (via SpaceBindings) and picks the first one that was created on the behalf of the MUR's UserSignup CR (that is given by the "creator" label). Such a Space corresponds to the default "home" Space that is provisioned automatically by the UserSignup controller when it's approved and being provisioned.

Although the code is ready to provision UserAccounts in multiple members, it still does that only for one single member cluster (account). The reason is that we need to make sure that all other components like registration-service and proxy are ready for such a change. As soon as the other components are updated, we would be able to drop the limitation of provisioning UserAccounts only for the default space, and enable creation of multiple of them. This is a bit bigger effort - I'll create an epic for it.

This PR is the first step to fix [SANDBOX-412](https://issues.redhat.com/browse/SANDBOX-412) The next step would be to change the cli command to only patch the targetCluster in Space CR, and stop deactivating UserSignup resource.

TODO
- [x] update e2e tests

paired PR https://github.com/codeready-toolchain/toolchain-e2e/pull/807

TODO in the next PR
- slightly refactor the unit tests to make then easier to read

depends on https://github.com/codeready-toolchain/toolchain-common/pull/328