### PR TITLE
Allow user signups to complete when the associated space is updating

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -357,7 +357,9 @@ func (r *Reconciler) checkIfMurAlreadyExists(reqLogger logr.Logger, config toolc
 
 			// if the Space is not Ready, another reconcile will occur when space status is updated since this controller watches space (without a predicate)
 			reqLogger.Info("Checking whether Space is Ready", "Space", space.Name)
-			if !condition.IsTrueWithReason(space.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceProvisionedReason) {
+			if !(condition.IsTrueWithReason(space.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceProvisionedReason) ||
+				// don't mark the user signup as incomplete if the space is updating - wait for the space to finish first.
+				condition.IsFalseWithReason(space.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceUpdatingReason)) {
 				return true, r.updateIncompleteStatus(userSignup, fmt.Sprintf("space %s was not ready", space.Name))
 			}
 		}

--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -357,8 +357,8 @@ func (r *Reconciler) checkIfMurAlreadyExists(reqLogger logr.Logger, config toolc
 
 			// if the Space is not Ready, another reconcile will occur when space status is updated since this controller watches space (without a predicate)
 			reqLogger.Info("Checking whether Space is Ready", "Space", space.Name)
-			if !(condition.IsTrueWithReason(space.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceProvisionedReason) ||
-				condition.IsTrue(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete)) {
+			if !condition.IsTrueWithReason(space.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceProvisionedReason) &&
+				!condition.IsTrue(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete) {
 				return true, r.updateIncompleteStatus(userSignup, fmt.Sprintf("space %s was not ready", space.Name))
 			}
 		}

--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -358,8 +358,7 @@ func (r *Reconciler) checkIfMurAlreadyExists(reqLogger logr.Logger, config toolc
 			// if the Space is not Ready, another reconcile will occur when space status is updated since this controller watches space (without a predicate)
 			reqLogger.Info("Checking whether Space is Ready", "Space", space.Name)
 			if !(condition.IsTrueWithReason(space.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceProvisionedReason) ||
-				// don't mark the user signup as incomplete if the space is updating - wait for the space to finish first.
-				condition.IsFalseWithReason(space.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceUpdatingReason)) {
+				condition.IsTrue(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete)) {
 				return true, r.updateIncompleteStatus(userSignup, fmt.Sprintf("space %s was not ready", space.Name))
 			}
 		}


### PR DESCRIPTION
If we mark user signups as incomplete while a space is updating, then the registration controller will reject the login.  As a workaround, allow user signups to progress while the associated space is updating.

Resolves https://issues.redhat.com/browse/SANDBOX-72.