### PR TITLE
ci: bump actions to silence node12 warnings

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
         go-version: 1.19.x
     
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: generate
       run: |
@@ -49,7 +49,7 @@ jobs:
         go-version: 1.19.x
         
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: generate
       run: |
@@ -73,10 +73,10 @@ jobs:
         go-version: 1.19.x
         
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: Generate SBOM
-      uses: CycloneDX/gh-gomod-generate-sbom@v1
+      uses: CycloneDX/gh-gomod-generate-sbom@v2
       with:
         version: v1
         args: mod -licenses -json -output -

--- a/.github/workflows/ci-check-gomod.yml
+++ b/.github/workflows/ci-check-gomod.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     
     - name: check
       run: |

--- a/.github/workflows/operator-cd.yml
+++ b/.github/workflows/operator-cd.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/publish-operators-for-e2e-tests.yml
+++ b/.github/workflows/publish-operators-for-e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     # Checkout from PR event - in that case the comment field is empty
     - name: Checkout code from PR event
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       if: ${{ github.event.comment == '' }}
       with:
         ref: ${{github.event.pull_request.head.ref}}
@@ -39,7 +39,7 @@ jobs:
     # Checkout the code based on the data retrieved from the previous step
     # Is executed only for comment events - in that case the pull_request field is empty
     - name: Checkout code from PR
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       if: ${{ github.event.pull_request == '' }}
       with:
         repository: ${{ fromJson(steps.request.outputs.data).head.repo.full_name }}


### PR DESCRIPTION
As of [June 2023][1], GitHub no longer uses node v12 within its actions runner with the intention of removing support for this version in the future.  They have been encouraging action authors to switch to node v16 and [encouraging users][2] to use the new versions of the actions when they become available.

Bump the versions of the affected actions to bring this in line.

[1]: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
[2]: https://github.com/codeready-toolchain/host-operator/actions/runs/6421632076