### PR TITLE
Do not try to delete UserSignups multiple times

### DIFF
--- a/controllers/usersignupcleanup/usersignup_cleanup_controller.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller.go
@@ -2,6 +2,7 @@ package usersignupcleanup
 
 import (
 	"context"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -64,6 +65,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 	reqLogger = reqLogger.WithValues("username", instance.Spec.Username)
 	ctx = log.IntoContext(ctx, reqLogger)
+
+	if util.IsBeingDeleted(instance) {
+		reqLogger.Info("UserSignup is already being deleted")
+		return reconcile.Result{}, nil
+	}
 
 	config, err := toolchainconfig.GetToolchainConfig(r.Client)
 	if err != nil {

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -275,12 +275,12 @@ func alreadyDeletedSignupIgnored(t *testing.T, userSignup *toolchainv1alpha1.Use
 	require.NoError(t, err)
 	require.Empty(t, res)
 
-	// The UserSignup should still be present because signups with a non-empty deletion timestamp are ignored
+	// The UserSignup should still be present because signups with a non-empty deletion timestamp are ignored.
 	key := test.NamespacedName(test.HostOperatorNs, userSignup.Name)
 	err = r.Client.Get(context.Background(), key, userSignup)
 	require.NoError(t, err)
 
-	// and verify that the metrics are unchanged
+	// And verify that the metrics stay unchanged after they were reset to "0" when we prepared the reconcile above.
 	assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithInitiatingVerificationTotal))
 	assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithoutInitiatingVerificationTotal))
 }

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -279,6 +279,10 @@ func alreadyDeletedSignupIgnored(t *testing.T, userSignup *toolchainv1alpha1.Use
 	key := test.NamespacedName(test.HostOperatorNs, userSignup.Name)
 	err = r.Client.Get(context.Background(), key, userSignup)
 	require.NoError(t, err)
+
+	// and verify that the metrics are unchanged
+	assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithInitiatingVerificationTotal))
+	assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithoutInitiatingVerificationTotal))
 }
 
 func expectRequeue(t *testing.T, res reconcile.Result, margin int) {


### PR DESCRIPTION
It turned out that our UserSignup cleanup controller tries to delete the same UserSignup twice. As the result we increment our abandoned signup count twice per each deleted signup. I guess it's because we do not check if the resource is already being deleted and try to delete it again. 