### PR TITLE
Add threshold in codecov settings

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,3 +1,4 @@
+# Config can be validated before merging: curl -X POST --data-binary @.codecov.yaml https://codecov.io/validate
 codecov:
   max_report_age: "off"  # see https://docs.codecov.io/docs/codecov-yaml#section-expired-reports
 
@@ -11,10 +12,14 @@ coverage:
   # solid green color.
   range: "20...60"
 
+  # See https://docs.codecov.com/docs/commit-status
   status:
     # project will give us the diff in the total code coverage between a commit
     # and its parent
-    project: yes
+    project:
+      default:
+        # Allow the coverage to drop by 1%, and posting a success status.
+        threshold: 1%
     # Patch gives just the coverage of the patch
     patch: yes
     # changes tells us if there are unexpected code coverage changes in other files


### PR DESCRIPTION
Setting threshold to 1% for codecov.

Config can be validated before merging: curl -X POST --data-binary @.codecov.yaml https://codecov.io/validate