### PR TITLE
ASC-402: Modify NSTemplateTierSpec to support SA token copy

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
@@ -50,6 +50,9 @@ spec:
                 required:
                 - templateRef
                 type: object
+              copySaToken:
+                description: flag to signigy whether to copy SA token or not
+                type: boolean
               namespaces:
                 description: The namespace templates
                 items:

--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
@@ -51,7 +51,7 @@ spec:
                 - templateRef
                 type: object
               copySaToken:
-                description: flag to signigy whether to copy SA token or not
+                description: flag to signify whether to copy SA token or not
                 type: boolean
               namespaces:
                 description: The namespace templates

--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
@@ -67,10 +67,12 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               spaceRequestConfig:
-                description: Provides the name of the Service Account whose token
-                  is to be copied
+                description: SpaceRequestConfigName stores all the configuration related
+                  to the Space Request feature
                 properties:
-                  saTokenToCopy:
+                  serviceAccountName:
+                    description: Provides the name of the Service Account whose token
+                      is to be copied
                     type: string
                 type: object
               spaceRoles:

--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
@@ -50,9 +50,6 @@ spec:
                 required:
                 - templateRef
                 type: object
-              copySaToken:
-                description: flag to signify whether to copy SA token or not
-                type: boolean
               namespaces:
                 description: The namespace templates
                 items:
@@ -69,6 +66,13 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              spaceRequestConfig:
+                description: Provides the name of the Service Account whose token
+                  is to be copied
+                properties:
+                  saTokenToCopy:
+                    type: string
+                type: object
               spaceRoles:
                 additionalProperties:
                   description: NSTemplateTierSpaceRole the space roles definition

--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
@@ -67,7 +67,7 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               spaceRequestConfig:
-                description: SpaceRequestConfigName stores all the configuration related
+                description: SpaceRequestConfig stores all the configuration related
                   to the Space Request feature
                 properties:
                   serviceAccountName:

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -38,6 +38,7 @@ objects:
           - toolchainconfigs
           - toolchainstatuses
           - proxyplugins
+          - nstemplatetiers
         verbs:
           - get
           - list

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -38,7 +38,6 @@ objects:
           - toolchainconfigs
           - toolchainstatuses
           - proxyplugins
-          - nstemplatetiers
         verbs:
           - get
           - list


### PR DESCRIPTION
This PR aims at modifying the NSTemplateTier CRD so as to support functionality of copy SA token or not.

See https://github.com/codeready-toolchain/api/pull/380