### PR TITLE
rename metrics label

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
@@ -66,6 +66,15 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              spaceRequestConfig:
+                description: SpaceRequestConfig stores all the configuration related
+                  to the Space Request feature
+                properties:
+                  serviceAccountName:
+                    description: Provides the name of the Service Account whose token
+                      is to be copied
+                    type: string
+                type: object
               spaceRoles:
                 additionalProperties:
                   description: NSTemplateTierSpaceRole the space roles definition

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -226,7 +226,7 @@ objects:
         run: proxy-metrics
     spec:
       ports:
-        - name: "8082"
+        - name: proxy-metrics
           protocol: TCP
           port: 80
           targetPort: metrics

--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -99,6 +99,7 @@ objects:
                 - containerPort: 8080
                 - containerPort: 8081
                 - containerPort: 8082
+                  name: metrics
               command:
                 - registration-service
               imagePullPolicy: IfNotPresent
@@ -222,13 +223,13 @@ objects:
       namespace: ${NAMESPACE}
       labels:
         provider: codeready-toolchain
-        run: registration-service
+        run: proxy-metrics
     spec:
       ports:
         - name: "8082"
           protocol: TCP
           port: 80
-          targetPort: 8082
+          targetPort: metrics
       selector:
         run: registration-service
       type: ClusterIP


### PR DESCRIPTION
having same labels for the 2 services may confuse Prometheus, thus renaming the label for metrics Service.
Also naming the port 8082 for metrics.

related PR: https://github.com/codeready-toolchain/registration-service/pull/363