### PR TITLE
Add HomeSpace status field

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_usersignups.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_usersignups.yaml
@@ -199,8 +199,9 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               homeSpace:
-                description: HomeSpace represents the default home space for the user.
-                  This is used by the proxy when no workspace context is provided.
+                description: HomeSpace is the name of the Space that is created for
+                  the user immediately after their account is approved. This is used
+                  by the proxy when no workspace context is provided.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/toolchain.dev.openshift.com_usersignups.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_usersignups.yaml
@@ -198,6 +198,10 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              homeSpace:
+                description: HomeSpace represents the default home space for the user.
+                  This is used by the proxy when no workspace context is provided.
+                type: string
             type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
This field is going to be used by the proxy when no workspace context is provided.

API PR: https://github.com/codeready-toolchain/api/pull/384
Ref. https://issues.redhat.com/browse/SANDBOX-425
