### PR TITLE
disable HTTP/2 on kube-rbac-proxy container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,7 @@ spec:
       containers:
         - name: kube-rbac-proxy
           image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13.0
+          imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -38,6 +39,7 @@ spec:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"
             - "--logtostderr=true"
+            - "--http2-disable=true"
             - "--v=3"
           ports:
             - name: https


### PR DESCRIPTION
Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
