### PR TITLE
fix: forward context in pkg/pending

### DIFF
--- a/controllers/spacecompletion/space_completion_controller.go
+++ b/controllers/spacecompletion/space_completion_controller.go
@@ -32,14 +32,14 @@ type Reconciler struct {
 
 // SetupWithManager sets up the controller reconciler with the Manager
 // Watches the Space resources and the ToolchainStatus CRD
-func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("spacecompletion").
 		// watch Spaces in the host cluster
 		For(&toolchainv1alpha1.Space{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&source.Kind{Type: &toolchainv1alpha1.ToolchainStatus{}},
-			handler.EnqueueRequestsFromMapFunc(pending.NewSpaceMapper(mgr.GetClient()).MapToOldestPending)).
+			handler.EnqueueRequestsFromMapFunc(pending.NewSpaceMapper(mgr.GetClient()).BuildMapToOldestPending(ctx))).
 		Complete(r)
 }
 

--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -42,7 +42,7 @@ import (
 type StatusUpdaterFunc func(ctx context.Context, userAcc *toolchainv1alpha1.UserSignup, message string) error
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
+func (r *Reconciler) SetupWithManager(ctx context.Context, mgr manager.Manager) error {
 	unapprovedMapper := pending.NewUserSignupMapper(mgr.GetClient())
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&toolchainv1alpha1.UserSignup{}, builder.WithPredicates(UserSignupChangedPredicate{})).
@@ -58,7 +58,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(commoncontrollers.MapToOwnerByLabel(r.Namespace, toolchainv1alpha1.SpaceCreatorLabelKey))).
 		Watches(
 			&source.Kind{Type: &toolchainv1alpha1.ToolchainStatus{}},
-			handler.EnqueueRequestsFromMapFunc(unapprovedMapper.MapToOldestPending),
+			handler.EnqueueRequestsFromMapFunc(unapprovedMapper.BuildMapToOldestPending(ctx)),
 			builder.WithPredicates(&OnlyWhenAutomaticApprovalIsEnabled{
 				client: mgr.GetClient(),
 			})).

--- a/main.go
+++ b/main.go
@@ -149,6 +149,7 @@ func main() { // nolint:gocyclo
 	// END : hack to redirect klogv1 calls to klog v2
 
 	printVersion()
+	ctx := ctrl.SetupSignalHandler()
 
 	namespace, err := commonconfig.GetWatchNamespace()
 	if err != nil {
@@ -279,7 +280,7 @@ func main() { // nolint:gocyclo
 		Scheme:         mgr.GetScheme(),
 		SegmentClient:  segmentClient,
 		ClusterManager: capacity.NewClusterManager(commoncluster.GetMemberClusters, mgr.GetClient()),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UserSignup")
 		os.Exit(1)
 	}
@@ -334,7 +335,7 @@ func main() { // nolint:gocyclo
 		Client:         mgr.GetClient(),
 		Namespace:      namespace,
 		ClusterManager: capacity.NewClusterManager(commoncluster.GetMemberClusters, mgr.GetClient()),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SpaceCompletion")
 		os.Exit(1)
 	}
@@ -366,17 +367,15 @@ func main() { // nolint:gocyclo
 	}
 	//+kubebuilder:scaffold:builder
 
-	stopChannel := ctrl.SetupSignalHandler()
-
 	go func() {
 		setupLog.Info("Starting cluster health checker & creating/updating the NSTemplateTier resources once cache is sync'd")
-		if !mgr.GetCache().WaitForCacheSync(stopChannel) {
+		if !mgr.GetCache().WaitForCacheSync(ctx) {
 			setupLog.Error(errors.New("timed out waiting for caches to sync"), "")
 			os.Exit(1)
 		}
 
 		setupLog.Info("Starting ToolchainCluster health checks.")
-		toolchaincluster.StartHealthChecks(stopChannel, mgr, namespace, 10*time.Second)
+		toolchaincluster.StartHealthChecks(ctx, mgr, namespace, 10*time.Second)
 
 		// create or update Toolchain status during the operator deployment
 		setupLog.Info("Creating/updating the ToolchainStatus resource")
@@ -415,7 +414,7 @@ func main() { // nolint:gocyclo
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(stopChannel); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -388,7 +388,7 @@ func main() { // nolint:gocyclo
 		// create or update all NSTemplateTiers on the cluster at startup
 		setupLog.Info("Creating/updating the NSTemplateTier resources")
 		nstemplatetierAssets := assets.NewAssets(nstemplatetiers.AssetNames, nstemplatetiers.Asset)
-		if err := nstemplatetiers.CreateOrUpdateResources(stopChannel, mgr.GetScheme(), mgr.GetClient(), namespace, nstemplatetierAssets); err != nil {
+		if err := nstemplatetiers.CreateOrUpdateResources(ctx, mgr.GetScheme(), mgr.GetClient(), namespace, nstemplatetierAssets); err != nil {
 			setupLog.Error(err, "")
 			os.Exit(1)
 		}

--- a/pkg/pending/cache_test.go
+++ b/pkg/pending/cache_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestGetOldestSignupPendingApproval(t *testing.T) {
 	// given
+	ctx := context.TODO()
 	withoutStateLabel := commonsignup.NewUserSignup()
 	notReady := commonsignup.NewUserSignup(commonsignup.WithStateLabel("not-ready"))
 	pending := commonsignup.NewUserSignup(commonsignup.WithStateLabel("pending"))
@@ -31,7 +32,7 @@ func TestGetOldestSignupPendingApproval(t *testing.T) {
 	cache, cl := newCache(t, &toolchainv1alpha1.UserSignup{}, listPendingUserSignups, withoutStateLabel, notReady, pending, approved, deactivated, banned)
 
 	// when
-	foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+	foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 	// then
 	assert.Len(t, cache.sortedObjectNames, 1)
@@ -40,7 +41,7 @@ func TestGetOldestSignupPendingApproval(t *testing.T) {
 
 	t.Run("won't return any since all are approved", func(t *testing.T) {
 		// when
-		foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+		foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 		// then
 		assert.Empty(t, cache.sortedObjectNames)
@@ -54,7 +55,7 @@ func TestGetOldestSignupPendingApproval(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+		foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 		// then
 		assert.Len(t, cache.sortedObjectNames, 1)
@@ -62,7 +63,7 @@ func TestGetOldestSignupPendingApproval(t *testing.T) {
 
 		t.Run("should keep unapproved resource", func(t *testing.T) {
 			// when
-			foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+			foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 			// then
 			assert.Len(t, cache.sortedObjectNames, 1)
@@ -73,6 +74,7 @@ func TestGetOldestSignupPendingApproval(t *testing.T) {
 
 func TestGetOldestSpacePendingTargetCluster(t *testing.T) {
 	// given
+	ctx := context.TODO()
 	withoutStateLabel := spacetest.NewSpace(test.HostOperatorNs, "without-state")
 	pending := spacetest.NewSpace(test.HostOperatorNs, "pending", spacetest.WithStateLabel("pending"))
 	clusterAssigned := spacetest.NewSpace(test.HostOperatorNs, "cluster-assigned", spacetest.WithStateLabel("cluster-assigned"))
@@ -80,7 +82,7 @@ func TestGetOldestSpacePendingTargetCluster(t *testing.T) {
 	cache, cl := newCache(t, &toolchainv1alpha1.Space{}, listPendingSpaces, withoutStateLabel, pending, clusterAssigned)
 
 	// when
-	foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+	foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 	// then
 	require.Len(t, cache.sortedObjectNames, 1)
@@ -89,7 +91,7 @@ func TestGetOldestSpacePendingTargetCluster(t *testing.T) {
 
 	t.Run("won't return any since all have cluster assigned", func(t *testing.T) {
 		// when
-		foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+		foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 		// then
 		assert.Empty(t, cache.sortedObjectNames)
@@ -103,7 +105,7 @@ func TestGetOldestSpacePendingTargetCluster(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+		foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 		// then
 		assert.Len(t, cache.sortedObjectNames, 1)
@@ -111,7 +113,7 @@ func TestGetOldestSpacePendingTargetCluster(t *testing.T) {
 
 		t.Run("should keep pending resource", func(t *testing.T) {
 			// when
-			foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+			foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 			// then
 			assert.Len(t, cache.sortedObjectNames, 1)
@@ -134,6 +136,7 @@ func assignCluster(t *testing.T, cl *test.FakeClient, sp *toolchainv1alpha1.Spac
 
 func TestGetOldestPendingApprovalWithMultipleUserSignups(t *testing.T) {
 	// given
+	ctx := context.TODO()
 	withoutStateLabel := commonsignup.NewUserSignup()
 	// we need to create the UserSignups with different timestamp in the range of seconds because
 	// the k8s resource keeps the time in RFC3339 format where the smallest unit are seconds.
@@ -143,7 +146,7 @@ func TestGetOldestPendingApprovalWithMultipleUserSignups(t *testing.T) {
 	cache, cl := newCache(t, &toolchainv1alpha1.UserSignup{}, listPendingUserSignups, withoutStateLabel, pending2, pending3, pending1)
 
 	// when
-	foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+	foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 	// then
 	assert.Len(t, cache.sortedObjectNames, 3)
@@ -157,7 +160,7 @@ func TestGetOldestPendingApprovalWithMultipleUserSignups(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+		foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 		// then
 		assert.Len(t, cache.sortedObjectNames, 2)
@@ -166,7 +169,7 @@ func TestGetOldestPendingApprovalWithMultipleUserSignups(t *testing.T) {
 
 		t.Run("should keep one UserSignup since the pending4 hasn't been loaded yet and previous ones were removed", func(t *testing.T) {
 			// when
-			foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+			foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 			// then
 			assert.Len(t, cache.sortedObjectNames, 1)
@@ -175,7 +178,7 @@ func TestGetOldestPendingApprovalWithMultipleUserSignups(t *testing.T) {
 
 			t.Run("should load the pending4 resource", func(t *testing.T) {
 				// when
-				foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+				foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 				// then
 				assert.Len(t, cache.sortedObjectNames, 1)
@@ -187,6 +190,7 @@ func TestGetOldestPendingApprovalWithMultipleUserSignups(t *testing.T) {
 
 func TestGetOldestPendingApprovalWithMultipleSpaces(t *testing.T) {
 	// given
+	ctx := context.TODO()
 	withoutStateLabel := spacetest.NewSpace(test.HostOperatorNs, "without-state")
 	// we need to create the Spaces with different timestamp in the range of seconds because
 	// the k8s resource keeps the time in RFC3339 format where the smallest unit are seconds.
@@ -196,7 +200,7 @@ func TestGetOldestPendingApprovalWithMultipleSpaces(t *testing.T) {
 	cache, cl := newCache(t, &toolchainv1alpha1.Space{}, listPendingSpaces, withoutStateLabel, pending2, pending3, pending1)
 
 	// when
-	foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+	foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 	// then
 	assert.Len(t, cache.sortedObjectNames, 3)
@@ -210,7 +214,7 @@ func TestGetOldestPendingApprovalWithMultipleSpaces(t *testing.T) {
 		require.NoError(t, err)
 
 		// when
-		foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+		foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 		// then
 		assert.Len(t, cache.sortedObjectNames, 2)
@@ -219,7 +223,7 @@ func TestGetOldestPendingApprovalWithMultipleSpaces(t *testing.T) {
 
 		t.Run("should keep one Space since the pending4 hasn't been loaded yet and previous ones were removed", func(t *testing.T) {
 			// when
-			foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+			foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 			// then
 			assert.Len(t, cache.sortedObjectNames, 1)
@@ -228,7 +232,7 @@ func TestGetOldestPendingApprovalWithMultipleSpaces(t *testing.T) {
 
 			t.Run("should load the pending4 resource", func(t *testing.T) {
 				// when
-				foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+				foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 				// then
 				assert.Len(t, cache.sortedObjectNames, 1)
@@ -240,6 +244,7 @@ func TestGetOldestPendingApprovalWithMultipleSpaces(t *testing.T) {
 
 func TestGetOldestPendingApprovalWithMultipleUserSignupsInParallel(t *testing.T) {
 	// given
+	ctx := context.TODO()
 	cache, cl := newCache(t, &toolchainv1alpha1.UserSignup{}, listPendingUserSignups)
 
 	var latch sync.WaitGroup
@@ -261,14 +266,14 @@ func TestGetOldestPendingApprovalWithMultipleUserSignupsInParallel(t *testing.T)
 				pending2,
 			}
 			for _, signup := range allSingups {
-				err := cl.Create(context.TODO(), signup)
+				err := cl.Create(ctx, signup)
 				require.NoError(t, err)
 			}
 
 			for _, pending := range []*toolchainv1alpha1.UserSignup{pending1, pending2} {
 				go func(toApprove *toolchainv1alpha1.UserSignup) {
 					defer waitForFinished.Done()
-					oldestPendingApproval := cache.getOldestPendingObject(test.HostOperatorNs)
+					oldestPendingApproval := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 					require.NotNil(t, oldestPendingApproval)
 					approve(t, cl, toApprove)
 				}(pending)
@@ -281,7 +286,7 @@ func TestGetOldestPendingApprovalWithMultipleUserSignupsInParallel(t *testing.T)
 	waitForFinished.Wait()
 
 	// when
-	foundPending := cache.getOldestPendingObject(test.HostOperatorNs)
+	foundPending := cache.getOldestPendingObject(ctx, test.HostOperatorNs)
 
 	// then
 	assert.Nil(t, foundPending)

--- a/pkg/pending/mapper.go
+++ b/pkg/pending/mapper.go
@@ -1,10 +1,13 @@
 package pending
 
 import (
+	"context"
+
 	"github.com/codeready-toolchain/api/api/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/types"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -34,8 +37,14 @@ func NewPendingObjectsMapper(client runtimeclient.Client, objectType runtimeclie
 	}
 }
 
-func (b ObjectsMapper) MapToOldestPending(obj runtimeclient.Object) []reconcile.Request {
-	pendingObject := b.unapprovedCache.getOldestPendingObject(obj.GetNamespace())
+func (b ObjectsMapper) BuildMapToOldestPending(ctx context.Context) handler.MapFunc {
+	return func(obj runtimeclient.Object) []reconcile.Request {
+		return b.MapToOldestPending(ctx, obj)
+	}
+}
+
+func (b ObjectsMapper) MapToOldestPending(ctx context.Context, obj runtimeclient.Object) []reconcile.Request {
+	pendingObject := b.unapprovedCache.getOldestPendingObject(ctx, obj.GetNamespace())
 	if pendingObject == nil {
 		return []reconcile.Request{}
 	}

--- a/pkg/pending/mapper_test.go
+++ b/pkg/pending/mapper_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestMapperReturnsOldest(t *testing.T) {
 	// given
+	ctx := context.TODO()
 	pendingSignup := commonsignup.NewUserSignup(commonsignup.WithStateLabel("pending"))
 	approvedSignup := commonsignup.NewUserSignup(commonsignup.WithStateLabel("approved"))
 	deactivatedSignup := commonsignup.NewUserSignup(commonsignup.WithStateLabel("deactivated"))
@@ -31,7 +32,7 @@ func TestMapperReturnsOldest(t *testing.T) {
 		mapper := NewUserSignupMapper(cl)
 
 		// when
-		requests := mapper.MapToOldestPending(NewToolchainStatus())
+		requests := mapper.MapToOldestPending(ctx, NewToolchainStatus())
 
 		// then
 		require.Len(t, requests, 1)
@@ -44,7 +45,7 @@ func TestMapperReturnsOldest(t *testing.T) {
 		mapper := NewSpaceMapper(cl)
 
 		// when
-		requests := mapper.MapToOldestPending(NewToolchainStatus())
+		requests := mapper.MapToOldestPending(ctx, NewToolchainStatus())
 
 		// then
 		require.Len(t, requests, 1)
@@ -55,6 +56,7 @@ func TestMapperReturnsOldest(t *testing.T) {
 
 func TestMapperReturnsEmptyRequestsWhenNoPendingIsFound(t *testing.T) {
 	// given
+	ctx := context.TODO()
 	banned := commonsignup.NewUserSignup(commonsignup.WithStateLabel("banned"))
 	approved := commonsignup.NewUserSignup(commonsignup.WithStateLabel("approved"))
 	deactivated := commonsignup.NewUserSignup(commonsignup.WithStateLabel("deactivated"))
@@ -62,7 +64,7 @@ func TestMapperReturnsEmptyRequestsWhenNoPendingIsFound(t *testing.T) {
 	mapper := NewUserSignupMapper(cl)
 
 	// when
-	requests := mapper.MapToOldestPending(NewToolchainStatus())
+	requests := mapper.MapToOldestPending(ctx, NewToolchainStatus())
 
 	// then
 	assert.Empty(t, requests)
@@ -70,6 +72,7 @@ func TestMapperReturnsEmptyRequestsWhenNoPendingIsFound(t *testing.T) {
 
 func TestMapperReturnsEmptyRequestsWhenClientReturnsError(t *testing.T) {
 	// given
+	ctx := context.TODO()
 	cl := test.NewFakeClient(t)
 	cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
 		return fmt.Errorf("some error")
@@ -77,7 +80,7 @@ func TestMapperReturnsEmptyRequestsWhenClientReturnsError(t *testing.T) {
 	mapper := NewUserSignupMapper(cl)
 
 	// when
-	requests := mapper.MapToOldestPending(NewToolchainStatus())
+	requests := mapper.MapToOldestPending(ctx, NewToolchainStatus())
 
 	// then
 	assert.Empty(t, requests)


### PR DESCRIPTION
Changes in `main.go` conflicts with changes applied by #916.

Some changes introduced here can be reverted after upgrading [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) to [v0.15.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.15.0) or higher. More precisely it will be possible to apply the following actions: 
* `pkg/pending/mapper.go#BuildMapToOldestPending` can be removed
* context can be removed from `controllers/spacecompletion/space_completion_controller.go#SetupWithManager` 
* context can be removed from `controllers/usersignup/usersignup_controller.go#SetupWithManager` 
