### PR TITLE
Added migration code to populate unmigrated identity claims

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -106,6 +106,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 	logger = logger.WithValues("username", userSignup.Spec.Username)
 
+	if util.IsBeingDeleted(userSignup) {
+		logger.Info("The UserSignup is being deleted")
+		return reconcile.Result{}, nil
+	}
+
 	// TODO remove this section (and the referenced function) after migration has completed
 	// FROM HERE ---------
 	migrated, err := r.migrateUserSignupClaimsIfNecessary(ctx, userSignup)
@@ -119,11 +124,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{Requeue: true}, nil
 	}
 	// TO HERE ^^^^^^^^^^^^
-
-	if util.IsBeingDeleted(userSignup) {
-		logger.Info("The UserSignup is being deleted")
-		return reconcile.Result{}, nil
-	}
 
 	if userSignup.GetLabels() == nil {
 		userSignup.Labels = make(map[string]string)

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -2437,6 +2437,10 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 		// when
 		_, err := r.Reconcile(context.TODO(), req)
 
+		// Reconcile again, as the first reconcile performs a temporary migration.
+		// FIXME remove after migration complete
+		_, err = r.Reconcile(context.TODO(), req)
+
 		// then
 		require.Error(t, err)
 		require.Equal(t, "Failed to create user deactivation notification: unable to create deactivation notification", err.Error())
@@ -2534,6 +2538,10 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 
 		// when
 		_, err := r.Reconcile(context.TODO(), req)
+
+		// Reconcile again, as the first reconcile performs a temporary migration.
+		// FIXME remove after migration complete
+		_, err = r.Reconcile(context.TODO(), req)
 
 		// then
 		require.NoError(t, err)
@@ -2723,6 +2731,10 @@ func TestUserSignupDeactivatedWhenMURAndSpaceAndSpaceBindingExists(t *testing.T)
 		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, mur, space, spacebinding, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 		err := r.setSpaceToReady(mur.Name) // given space is ready
 		require.NoError(t, err)
+		_, err = r.Reconcile(context.TODO(), req)
+
+		// Reconcile again, as the first reconcile performs a temporary migration.
+		// FIXME remove after migration complete
 		_, err = r.Reconcile(context.TODO(), req)
 
 		// then
@@ -2921,6 +2933,10 @@ func TestUserSignupDeactivatingNotificationCreated(t *testing.T) {
 
 	// when
 	_, err := r.Reconcile(context.TODO(), req)
+
+	// Reconcile again, as the first reconcile performs a temporary migration.
+	// FIXME remove after migration complete
+	_, err = r.Reconcile(context.TODO(), req)
 
 	// then
 	require.NoError(t, err)
@@ -3378,8 +3394,13 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 		}
 
 		t.Run("first reconcile", func(t *testing.T) {
-			// when
+
+			// Reconcile again, as the first reconcile performs a temporary migration.
+			// FIXME remove after migration complete
 			_, err := r.Reconcile(context.TODO(), req)
+
+			// when
+			_, err = r.Reconcile(context.TODO(), req)
 			require.Error(t, err)
 
 			// then
@@ -3486,8 +3507,12 @@ func TestUserSignupDeactivatedButStatusUpdateFails(t *testing.T) {
 		}
 	}
 
-	// when
+	// Reconcile as the first reconcile performs a temporary migration.
+	// FIXME remove after migration complete
 	_, err := r.Reconcile(context.TODO(), req)
+
+	// when
+	_, err = r.Reconcile(context.TODO(), req)
 	require.Error(t, err)
 
 	// then

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -2434,11 +2434,12 @@ func TestUserSignupFailedToCreateDeactivationNotification(t *testing.T) {
 			}
 		}
 
-		// when
-		_, err := r.Reconcile(context.TODO(), req)
-
-		// Reconcile again, as the first reconcile performs a temporary migration.
+		// Reconcile as the first reconcile performs a temporary migration.
 		// FIXME remove after migration complete
+		_, err := r.Reconcile(context.TODO(), req)
+		require.NoError(t, err)
+
+		// when
 		_, err = r.Reconcile(context.TODO(), req)
 
 		// then
@@ -2536,11 +2537,12 @@ func TestUserSignupReactivateAfterDeactivated(t *testing.T) {
 			}),
 		))
 
-		// when
-		_, err := r.Reconcile(context.TODO(), req)
-
-		// Reconcile again, as the first reconcile performs a temporary migration.
+		// Reconcile as the first reconcile performs a temporary migration.
 		// FIXME remove after migration complete
+		_, err := r.Reconcile(context.TODO(), req)
+		require.NoError(t, err)
+
+		// when
 		_, err = r.Reconcile(context.TODO(), req)
 
 		// then
@@ -2731,10 +2733,12 @@ func TestUserSignupDeactivatedWhenMURAndSpaceAndSpaceBindingExists(t *testing.T)
 		r, req, _ := prepareReconcile(t, userSignup.Name, NewGetMemberClusters(), userSignup, mur, space, spacebinding, commonconfig.NewToolchainConfigObjWithReset(t, testconfig.AutomaticApproval().Enabled(true)), baseNSTemplateTier, deactivate30Tier)
 		err := r.setSpaceToReady(mur.Name) // given space is ready
 		require.NoError(t, err)
-		_, err = r.Reconcile(context.TODO(), req)
 
-		// Reconcile again, as the first reconcile performs a temporary migration.
+		// Reconcile as the first reconcile performs a temporary migration.
 		// FIXME remove after migration complete
+		_, err = r.Reconcile(context.TODO(), req)
+		require.NoError(t, err)
+
 		_, err = r.Reconcile(context.TODO(), req)
 
 		// then
@@ -2931,11 +2935,12 @@ func TestUserSignupDeactivatingNotificationCreated(t *testing.T) {
 		}),
 	))
 
-	// when
-	_, err := r.Reconcile(context.TODO(), req)
-
-	// Reconcile again, as the first reconcile performs a temporary migration.
+	// Reconcile as the first reconcile performs a temporary migration.
 	// FIXME remove after migration complete
+	_, err := r.Reconcile(context.TODO(), req)
+	require.NoError(t, err)
+
+	// when
 	_, err = r.Reconcile(context.TODO(), req)
 
 	// then
@@ -3398,6 +3403,7 @@ func TestUserSignupDeactivatedButMURDeleteFails(t *testing.T) {
 			// Reconcile again, as the first reconcile performs a temporary migration.
 			// FIXME remove after migration complete
 			_, err := r.Reconcile(context.TODO(), req)
+			require.NoError(t, err)
 
 			// when
 			_, err = r.Reconcile(context.TODO(), req)
@@ -3510,6 +3516,7 @@ func TestUserSignupDeactivatedButStatusUpdateFails(t *testing.T) {
 	// Reconcile as the first reconcile performs a temporary migration.
 	// FIXME remove after migration complete
 	_, err := r.Reconcile(context.TODO(), req)
+	require.NoError(t, err)
 
 	// when
 	_, err = r.Reconcile(context.TODO(), req)


### PR DESCRIPTION
Migrates remaining users using their existing property values to populate `UserSignup.Spec.IdentityClaims`.

Fixes https://issues.redhat.com/browse/SANDBOX-463

e2e test: https://github.com/codeready-toolchain/toolchain-e2e/pull/838