### PR TITLE
KSPACE-28: Implement the basic version of the SpaceProvisionerConfig controller.

### DIFF
--- a/config/manifests/bases/host-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/host-operator.clusterserviceversion.yaml
@@ -96,7 +96,8 @@ spec:
       kind: SpaceBindingRequest
       name: spacebindingrequests.toolchain.dev.openshift.com
       version: v1alpha1
-    - description: SpaceProvisionerConfig contains configuration for provisioning spaces to clusters
+    - description: SpaceProvisionerConfig contains configuration for provisioning
+        spaces to clusters
       displayName: SpaceProvisionerConfig
       kind: SpaceProvisionerConfig
       name: spaceprovisionerconfigs.toolchain.dev.openshift.com

--- a/controllers/spaceprovisionerconfig/mapper.go
+++ b/controllers/spaceprovisionerconfig/mapper.go
@@ -1,0 +1,42 @@
+package spaceprovisionerconfig
+
+import (
+	"context"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func MapToolChainClusterToSpaceProvisionerConfigs(ctx context.Context, cl runtimeclient.Client) func(runtimeclient.Object) []reconcile.Request {
+	return func(obj runtimeclient.Object) []reconcile.Request {
+		ret, err := findReferencingProvisionerConfigs(ctx, cl, runtimeclient.ObjectKeyFromObject(obj))
+		if err != nil {
+			log.FromContext(ctx).Error(err, "failed to list SpaceProvisionerConfig objects while determining what objects to reconcile",
+				"toolchainClusterCause", runtimeclient.ObjectKeyFromObject(obj))
+			return []reconcile.Request{}
+		}
+		return ret
+	}
+}
+
+func findReferencingProvisionerConfigs(ctx context.Context, cl runtimeclient.Client, toolchainClusterObjectKey runtimeclient.ObjectKey) ([]reconcile.Request, error) {
+	configs := &toolchainv1alpha1.SpaceProvisionerConfigList{}
+	if err := cl.List(ctx, configs, runtimeclient.InNamespace(toolchainClusterObjectKey.Namespace)); err != nil {
+		return nil, err
+	}
+	ret := make([]reconcile.Request, 0, len(configs.Items))
+	for _, cfg := range configs.Items {
+		if cfg.Spec.ToolchainCluster == toolchainClusterObjectKey.Name {
+			ret = append(ret, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: cfg.Namespace,
+					Name:      cfg.Name,
+				},
+			})
+		}
+	}
+	return ret, nil
+}

--- a/controllers/spaceprovisionerconfig/mapper.go
+++ b/controllers/spaceprovisionerconfig/mapper.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func MapToolChainClusterToSpaceProvisionerConfigs(ctx context.Context, cl runtimeclient.Client) func(runtimeclient.Object) []reconcile.Request {
+func MapToolchainClusterToSpaceProvisionerConfigs(ctx context.Context, cl runtimeclient.Client) func(runtimeclient.Object) []reconcile.Request {
 	return func(obj runtimeclient.Object) []reconcile.Request {
 		ret, err := findReferencingProvisionerConfigs(ctx, cl, runtimeclient.ObjectKeyFromObject(obj))
 		if err != nil {

--- a/controllers/spaceprovisionerconfig/mapper_test.go
+++ b/controllers/spaceprovisionerconfig/mapper_test.go
@@ -26,9 +26,9 @@ func TestFindingReferencingSpaceProvisionerConfigs(t *testing.T) {
 		ExpectedRequests     []reconcile.Request
 	}
 
-	spc0 := testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, "cluster1")
-	spc1 := testSpc.NewSpaceProvisionerConfig("spc1", test.HostOperatorNs, "cluster2")
-	spc2 := testSpc.NewSpaceProvisionerConfig("spc2", test.HostOperatorNs, "cluster1")
+	spc0 := testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
+	spc1 := testSpc.NewSpaceProvisionerConfig("spc1", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster2"))
+	spc2 := testSpc.NewSpaceProvisionerConfig("spc2", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
 
 	tests := map[string]testCase{
 		"find 1 referencing SpaceProvisionerConfig in many": {
@@ -66,7 +66,7 @@ func TestFindingReferencingSpaceProvisionerConfigs(t *testing.T) {
 
 	t.Run("empty references when listing space provisioner configs fails", func(t *testing.T) {
 		// given
-		cl := test.NewFakeClient(t, testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, "cluster1"))
+		cl := test.NewFakeClient(t, testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1")))
 		expectedErr := errors.New("expected list error")
 		cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 			if _, ok := list.(*toolchainv1alpha1.SpaceProvisionerConfigList); ok {
@@ -86,14 +86,14 @@ func TestFindingReferencingSpaceProvisionerConfigs(t *testing.T) {
 
 func TestMapToolchainClusterToSpaceProvisionerConfigs(t *testing.T) {
 	t.Run("maps existing spcs", func(t *testing.T) {
-		// this pretty much duplicates the test of finding the referencing space provisioner configs above but does it from
-		// the POV of the higher level function. Therefore, we don't need to replicate all the positive cases here, just
-		// one should be enough.
+		// this pretty much duplicates the test of finding the referencing space provisioner configs but does it from the POV
+		// of the higher level function. Therefore, we don't need to replicate all the positive cases here, just one should
+		//
 
 		// given
-		spc0 := testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, "cluster1")
-		spc1 := testSpc.NewSpaceProvisionerConfig("spc1", test.HostOperatorNs, "cluster2")
-		spc2 := testSpc.NewSpaceProvisionerConfig("spc2", test.HostOperatorNs, "cluster1")
+		spc0 := testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
+		spc1 := testSpc.NewSpaceProvisionerConfig("spc1", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster2"))
+		spc2 := testSpc.NewSpaceProvisionerConfig("spc2", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
 		cl := test.NewFakeClient(t, spc0, spc1, spc2)
 
 		// when
@@ -113,7 +113,7 @@ func TestMapToolchainClusterToSpaceProvisionerConfigs(t *testing.T) {
 
 	t.Run("interprets errors as empty result", func(t *testing.T) {
 		// given
-		cl := test.NewFakeClient(t, testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, "cluster1"))
+		cl := test.NewFakeClient(t, testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1")))
 		expectedErr := errors.New("expected list error")
 		cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 			if _, ok := list.(*toolchainv1alpha1.SpaceProvisionerConfigList); ok {

--- a/controllers/spaceprovisionerconfig/mapper_test.go
+++ b/controllers/spaceprovisionerconfig/mapper_test.go
@@ -6,8 +6,8 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/spaceprovisionerconfig/mapper_test.go
+++ b/controllers/spaceprovisionerconfig/mapper_test.go
@@ -2,6 +2,7 @@ package spaceprovisionerconfig
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -14,50 +15,162 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestToolchainClusterToSpaceProvisionerConfigMapper(t *testing.T) {
-	// given
-	cl := test.NewFakeClient(t, &toolchainv1alpha1.SpaceProvisionerConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "spc0",
-			Namespace: test.HostOperatorNs,
-		},
-		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
-			ToolchainCluster: "cluster1",
-		},
-	}, &toolchainv1alpha1.SpaceProvisionerConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "spc1",
-			Namespace: test.HostOperatorNs,
-		},
-		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
-			ToolchainCluster: "cluster2",
-		},
-	}, &toolchainv1alpha1.SpaceProvisionerConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "spc2",
-			Namespace: test.HostOperatorNs,
-		},
-		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
-			ToolchainCluster: "cluster1",
-		},
+func TestFindingReferencedSpaceProvisionerConfigs(t *testing.T) {
+	t.Run("find referenced provisioner configs", func(t *testing.T) {
+		// given
+		cl := test.NewFakeClient(t, &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc0",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster1",
+			},
+		}, &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc1",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster2",
+			},
+		}, &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc2",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster1",
+			},
+		})
+
+		// when
+		reqs, err := findReferencingProvisionerConfigs(context.TODO(), cl, runtimeclient.ObjectKey{Name: "cluster1", Namespace: test.HostOperatorNs})
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, reqs, 2)
+		assert.Equal(t, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: test.HostOperatorNs,
+				Name:      "spc0",
+			},
+		}, reqs[0])
+		assert.Equal(t, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: test.HostOperatorNs,
+				Name:      "spc2",
+			},
+		}, reqs[1])
 	})
+	t.Run("empty references when listing space provisioner configs fails", func(t *testing.T) {
+		// given
+		cl := test.NewFakeClient(t, &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc0",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster1",
+			},
+		})
+		expectedErr := errors.New("expected list error")
+		cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
+			if _, ok := list.(*toolchainv1alpha1.SpaceProvisionerConfigList); ok {
+				return expectedErr
+			}
+			return cl.Client.List(ctx, list, opts...)
+		}
 
-	// when
-	reqs, err := findReferencingProvisionerConfigs(context.TODO(), cl, runtimeclient.ObjectKey{Name: "cluster1", Namespace: test.HostOperatorNs})
+		// when
+		reqs, err := findReferencingProvisionerConfigs(context.TODO(), cl, runtimeclient.ObjectKey{Name: "cluster1", Namespace: test.HostOperatorNs})
 
-	// then
-	require.NoError(t, err)
-	require.Len(t, reqs, 2)
-	assert.Equal(t, reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: test.HostOperatorNs,
-			Name:      "spc0",
-		},
-	}, reqs[0])
-	assert.Equal(t, reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: test.HostOperatorNs,
-			Name:      "spc2",
-		},
-	}, reqs[1])
+		// then
+		require.ErrorIs(t, err, expectedErr)
+		require.Nil(t, reqs)
+	})
+}
+
+func TestMapToolchainClusterToSpaceProvisionerConfigs(t *testing.T) {
+	t.Run("maps existing spcs", func(t *testing.T) {
+		// given
+		cl := test.NewFakeClient(t, &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc0",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster1",
+			},
+		}, &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc1",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster2",
+			},
+		}, &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc2",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster1",
+			},
+		})
+
+		// when
+		reqs := MapToolchainClusterToSpaceProvisionerConfigs(context.TODO(), cl)(&toolchainv1alpha1.ToolchainCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster1",
+				Namespace: test.HostOperatorNs,
+			},
+		})
+
+		// then
+		require.Len(t, reqs, 2)
+		assert.Equal(t, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: test.HostOperatorNs,
+				Name:      "spc0",
+			},
+		}, reqs[0])
+		assert.Equal(t, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: test.HostOperatorNs,
+				Name:      "spc2",
+			},
+		}, reqs[1])
+	})
+	t.Run("interprets errors as empty result", func(t *testing.T) {
+		// given
+		cl := test.NewFakeClient(t, &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc0",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster1",
+			},
+		})
+		expectedErr := errors.New("expected list error")
+		cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
+			if _, ok := list.(*toolchainv1alpha1.SpaceProvisionerConfigList); ok {
+				return expectedErr
+			}
+			return cl.Client.List(ctx, list, opts...)
+		}
+
+		// when
+		reqs := MapToolchainClusterToSpaceProvisionerConfigs(context.TODO(), cl)(&toolchainv1alpha1.ToolchainCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster1",
+				Namespace: test.HostOperatorNs,
+			},
+		})
+
+		// then
+		require.Empty(t, reqs)
+	})
 }

--- a/controllers/spaceprovisionerconfig/mapper_test.go
+++ b/controllers/spaceprovisionerconfig/mapper_test.go
@@ -7,7 +7,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	testSpc "github.com/codeready-toolchain/toolchain-common/pkg/test/spaceprovisionerconfig"
+	. "github.com/codeready-toolchain/toolchain-common/pkg/test/spaceprovisionerconfig"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,9 +26,9 @@ func TestFindingReferencingSpaceProvisionerConfigs(t *testing.T) {
 		ExpectedRequests     []reconcile.Request
 	}
 
-	spc0 := testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
-	spc1 := testSpc.NewSpaceProvisionerConfig("spc1", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster2"))
-	spc2 := testSpc.NewSpaceProvisionerConfig("spc2", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
+	spc0 := NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, ReferencingToolchainCluster("cluster1"))
+	spc1 := NewSpaceProvisionerConfig("spc1", test.HostOperatorNs, ReferencingToolchainCluster("cluster2"))
+	spc2 := NewSpaceProvisionerConfig("spc2", test.HostOperatorNs, ReferencingToolchainCluster("cluster1"))
 
 	tests := map[string]testCase{
 		"find 1 referencing SpaceProvisionerConfig in many": {
@@ -66,7 +66,7 @@ func TestFindingReferencingSpaceProvisionerConfigs(t *testing.T) {
 
 	t.Run("empty references when listing space provisioner configs fails", func(t *testing.T) {
 		// given
-		cl := test.NewFakeClient(t, testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1")))
+		cl := test.NewFakeClient(t, NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, ReferencingToolchainCluster("cluster1")))
 		expectedErr := errors.New("expected list error")
 		cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 			if _, ok := list.(*toolchainv1alpha1.SpaceProvisionerConfigList); ok {
@@ -91,9 +91,9 @@ func TestMapToolchainClusterToSpaceProvisionerConfigs(t *testing.T) {
 		//
 
 		// given
-		spc0 := testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
-		spc1 := testSpc.NewSpaceProvisionerConfig("spc1", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster2"))
-		spc2 := testSpc.NewSpaceProvisionerConfig("spc2", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
+		spc0 := NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, ReferencingToolchainCluster("cluster1"))
+		spc1 := NewSpaceProvisionerConfig("spc1", test.HostOperatorNs, ReferencingToolchainCluster("cluster2"))
+		spc2 := NewSpaceProvisionerConfig("spc2", test.HostOperatorNs, ReferencingToolchainCluster("cluster1"))
 		cl := test.NewFakeClient(t, spc0, spc1, spc2)
 
 		// when
@@ -113,7 +113,7 @@ func TestMapToolchainClusterToSpaceProvisionerConfigs(t *testing.T) {
 
 	t.Run("interprets errors as empty result", func(t *testing.T) {
 		// given
-		cl := test.NewFakeClient(t, testSpc.NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1")))
+		cl := test.NewFakeClient(t, NewSpaceProvisionerConfig("spc0", test.HostOperatorNs, ReferencingToolchainCluster("cluster1")))
 		expectedErr := errors.New("expected list error")
 		cl.MockList = func(ctx context.Context, list runtimeclient.ObjectList, opts ...runtimeclient.ListOption) error {
 			if _, ok := list.(*toolchainv1alpha1.SpaceProvisionerConfigList); ok {

--- a/controllers/spaceprovisionerconfig/mapper_test.go
+++ b/controllers/spaceprovisionerconfig/mapper_test.go
@@ -1,0 +1,63 @@
+package spaceprovisionerconfig
+
+import (
+	"context"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestToolchainClusterToSpaceProvisionerConfigMapper(t *testing.T) {
+	// given
+	cl := test.NewFakeClient(t, &toolchainv1alpha1.SpaceProvisionerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spc0",
+			Namespace: test.HostOperatorNs,
+		},
+		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+			ToolchainCluster: "cluster1",
+		},
+	}, &toolchainv1alpha1.SpaceProvisionerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spc1",
+			Namespace: test.HostOperatorNs,
+		},
+		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+			ToolchainCluster: "cluster2",
+		},
+	}, &toolchainv1alpha1.SpaceProvisionerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spc2",
+			Namespace: test.HostOperatorNs,
+		},
+		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+			ToolchainCluster: "cluster1",
+		},
+	})
+
+	// when
+	reqs, err := findReferencingProvisionerConfigs(context.TODO(), cl, runtimeclient.ObjectKey{Name: "cluster1", Namespace: test.HostOperatorNs})
+
+	// then
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      "spc0",
+		},
+	}, reqs[0])
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      "spc2",
+		},
+	}, reqs[1])
+}

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -35,7 +35,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 			// the ToolChainClusters are created or deleted. We don't have to care about updates, the mere existence of the
 			// ToolchainCluster is enough for us.
 			&source.Kind{Type: &toolchainv1alpha1.ToolchainCluster{}},
-			handler.EnqueueRequestsFromMapFunc(MapToolChainClusterToSpaceProvisionerConfigs(ctx, r.Client)),
+			handler.EnqueueRequestsFromMapFunc(MapToolchainClusterToSpaceProvisionerConfigs(ctx, r.Client)),
 			builder.WithPredicates(predicate.Funcs{
 				CreateFunc: func(event.CreateEvent) bool {
 					return true

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -70,7 +70,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	// check that there exists a ToolchainCluster CR in the same namespace
+	// check that there is a ToolchainCluster CR in the same namespace
 	toolchainCluster := &toolchainv1alpha1.ToolchainCluster{}
 	toolchainClusterKey := runtimeclient.ObjectKey{Name: spaceProvisionerConfig.Spec.ToolchainCluster, Namespace: spaceProvisionerConfig.Namespace}
 	toolchainPresent := corev1.ConditionTrue

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -1,0 +1,126 @@
+package spaceprovisionerconfig
+
+import (
+	"context"
+	"fmt"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/redhat-cop/operator-utils/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Reconciler is the reconciler for the SpaceProvisionerConfig CRs.
+type Reconciler struct {
+	Client runtimeclient.Client
+}
+
+var _ reconcile.Reconciler = (*Reconciler)(nil)
+
+func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&toolchainv1alpha1.SpaceProvisionerConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			// We want to trigger the reconciliation of SpaceProvisionerConfigs that reference some ToolChainCluster whenever
+			// the ToolChainClusters are created or deleted. We don't have to care about updates, the mere existence of the
+			// ToolchainCluster is enough for us.
+			&source.Kind{Type: &toolchainv1alpha1.ToolchainCluster{}},
+			handler.EnqueueRequestsFromMapFunc(func(o runtimeclient.Object) []reconcile.Request {
+				reqs, err := findReferencingProvisionerConfigs(ctx, r.Client, runtimeclient.ObjectKeyFromObject(o))
+				if err != nil {
+					log.FromContext(ctx).Error(err, "failed to list SpaceProvisionerConfig objects while determining what objects to reconcile",
+						"toolchainClusterCause", runtimeclient.ObjectKeyFromObject(o))
+					return nil
+				}
+				return reqs
+			}),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(event.CreateEvent) bool {
+					return true
+				},
+				DeleteFunc: func(event.DeleteEvent) bool {
+					return true
+				},
+			},
+			)).
+		Complete(r)
+}
+
+func findReferencingProvisionerConfigs(ctx context.Context, cl runtimeclient.Client, toolchainClusterObjectKey runtimeclient.ObjectKey) ([]reconcile.Request, error) {
+	configs := &toolchainv1alpha1.SpaceProvisionerConfigList{}
+	if err := cl.List(ctx, configs, runtimeclient.InNamespace(toolchainClusterObjectKey.Namespace)); err != nil {
+		return nil, err
+	}
+	ret := make([]reconcile.Request, 0, len(configs.Items))
+	for _, cfg := range configs.Items {
+		if cfg.Spec.ToolchainCluster == toolchainClusterObjectKey.Name {
+			ret = append(ret, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: cfg.Namespace,
+					Name:      cfg.Name,
+				},
+			})
+		}
+	}
+	return ret, nil
+}
+
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaceprovisionerconfigs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=spaceprovisionerconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=toolchain.dev.openshift.com,resources=toolchainclusters,verbs=get;list;watch
+
+// Reconcile ensures that SpaceProvisionerConfig is valid and points to an existing ToolchainCluster.
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	spaceProvisionerConfig := &toolchainv1alpha1.SpaceProvisionerConfig{}
+	if err := r.Client.Get(ctx, request.NamespacedName, spaceProvisionerConfig); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("SpaceProvisionerConfig not found anymore")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to get SpaceProvisionerConfig: %w", err)
+	}
+
+	if util.IsBeingDeleted(spaceProvisionerConfig) {
+		logger.Info("SpaceProvisionerConfig is being deleted - skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
+	// check that there exists a ToolchainCluster CR in the same namespace
+	toolchainCluster := &toolchainv1alpha1.ToolchainCluster{}
+	toolchainClusterKey := runtimeclient.ObjectKey{Name: spaceProvisionerConfig.Spec.ToolchainCluster, Namespace: spaceProvisionerConfig.Namespace}
+	toolchainPresent := corev1.ConditionTrue
+	toolchainPresenceReason := toolchainv1alpha1.SpaceProvisionerConfigValidReason
+	if err := r.Client.Get(ctx, toolchainClusterKey, toolchainCluster); err != nil {
+		if !errors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to get ToolchainCluster: %w", err)
+		}
+		toolchainPresenceReason = toolchainv1alpha1.SpaceProvisionerConfigToolchainClusterNotFoundReason
+		toolchainPresent = corev1.ConditionFalse
+	}
+
+	spaceProvisionerConfig.Status.Conditions, _ = condition.AddOrUpdateStatusConditions(spaceProvisionerConfig.Status.Conditions,
+		toolchainv1alpha1.Condition{
+			Type:   toolchainv1alpha1.ConditionReady,
+			Status: toolchainPresent,
+			Reason: toolchainPresenceReason,
+		})
+
+	if err := r.Client.Status().Update(ctx, spaceProvisionerConfig); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update the SpaceProvisionerConfig status: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
@@ -146,7 +146,7 @@ func TestSpaceProvisionerConfigReEnqueing(t *testing.T) {
 
 func prepareReconcile(t *testing.T, spc *toolchainv1alpha1.SpaceProvisionerConfig, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
 	require.NoError(t, os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs))
-	s := runtime.Scheme
+	s := runtime.NewScheme()
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
 

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
@@ -24,7 +24,7 @@ import (
 func TestSpaceProvisionerConfigValidation(t *testing.T) {
 	t.Run("is not valid when non-existing ToolchainCluster is referenced", func(t *testing.T) {
 		// given
-		spc := testSpc.NewSpaceProvisionerConfig("spc", test.HostOperatorNs, "non-existent")
+		spc := testSpc.NewSpaceProvisionerConfig("spc", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("non-existent"))
 		r, req, cl := prepareReconcile(t, spc)
 
 		// when
@@ -42,7 +42,7 @@ func TestSpaceProvisionerConfigValidation(t *testing.T) {
 
 	t.Run("is valid when existing ToolchainCluster is referenced", func(t *testing.T) {
 		// given
-		spc := testSpc.NewSpaceProvisionerConfig("spc", test.HostOperatorNs, "cluster1")
+		spc := testSpc.NewSpaceProvisionerConfig("spc", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
 		r, req, cl := prepareReconcile(t, spc, &toolchainv1alpha1.ToolchainCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster1",
@@ -65,7 +65,7 @@ func TestSpaceProvisionerConfigValidation(t *testing.T) {
 }
 
 func TestSpaceProvisionerConfigReEnqueing(t *testing.T) {
-	spc := testSpc.NewSpaceProvisionerConfig("spc", test.HostOperatorNs, "cluster1")
+	spc := testSpc.NewSpaceProvisionerConfig("spc", test.HostOperatorNs, testSpc.ReferencingToolchainCluster("cluster1"))
 
 	t.Run("re-enqueues on failure to GET", func(t *testing.T) {
 		// given

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/apis"
-	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	testSpc "github.com/codeready-toolchain/toolchain-common/pkg/test/spaceprovisionerconfig"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +33,11 @@ func TestSpaceProvisionerConfigValidation(t *testing.T) {
 
 		// then
 		assert.NoError(t, reconcileErr)
-		assert.True(t, condition.IsFalse(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
+		assert.Len(t, spc.Status.Conditions, 1)
+		assert.Equal(t, toolchainv1alpha1.ConditionReady, spc.Status.Conditions[0].Type)
+		assert.Equal(t, corev1.ConditionFalse, spc.Status.Conditions[0].Status)
+		assert.Equal(t, toolchainv1alpha1.SpaceProvisionerConfigToolchainClusterNotFoundReason, spc.Status.Conditions[0].Reason)
+		assert.Empty(t, spc.Status.Conditions[0].Message)
 	})
 
 	t.Run("is valid when existing ToolchainCluster is referenced", func(t *testing.T) {
@@ -53,7 +56,11 @@ func TestSpaceProvisionerConfigValidation(t *testing.T) {
 
 		// then
 		assert.NoError(t, reconcileErr)
-		assert.True(t, condition.IsTrue(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
+		assert.Len(t, spc.Status.Conditions, 1)
+		assert.Equal(t, toolchainv1alpha1.ConditionReady, spc.Status.Conditions[0].Type)
+		assert.Equal(t, corev1.ConditionTrue, spc.Status.Conditions[0].Status)
+		assert.Equal(t, toolchainv1alpha1.SpaceProvisionerConfigValidReason, spc.Status.Conditions[0].Reason)
+		assert.Empty(t, spc.Status.Conditions[0].Message)
 	})
 }
 

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
@@ -1,0 +1,141 @@
+package spaceprovisionerconfig
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/apis"
+	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubectl/pkg/scheme"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestSpaceProvisionerConfig(t *testing.T) {
+	t.Run("is not valid when non-existing ToolchainCluster is referenced", func(t *testing.T) {
+		// given
+		spc := &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "non-existent",
+			},
+		}
+		r, req, cl := prepareReconcile(t, spc)
+
+		// when
+		_, reconcileErr := r.Reconcile(context.TODO(), req)
+		getErr := cl.Get(context.TODO(), runtimeclient.ObjectKey{Name: "spc", Namespace: test.HostOperatorNs}, spc)
+
+		// then
+		require.NoError(t, reconcileErr)
+		require.NoError(t, getErr)
+		assert.True(t, condition.IsFalse(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
+	})
+
+	t.Run("is valid when existing ToolchainCluster is referenced", func(t *testing.T) {
+		// given
+		spc := &toolchainv1alpha1.SpaceProvisionerConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spc",
+				Namespace: test.HostOperatorNs,
+			},
+			Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+				ToolchainCluster: "cluster1",
+			},
+		}
+		r, req, cl := prepareReconcile(t, spc, &toolchainv1alpha1.ToolchainCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster1",
+				Namespace: test.HostOperatorNs,
+			},
+		})
+
+		// when
+		_, reconcileErr := r.Reconcile(context.TODO(), req)
+		getErr := cl.Get(context.TODO(), runtimeclient.ObjectKey{Name: "spc", Namespace: test.HostOperatorNs}, spc)
+
+		// then
+		require.NoError(t, reconcileErr)
+		require.NoError(t, getErr)
+		assert.True(t, condition.IsTrue(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
+	})
+}
+
+func TestEnqueingFilter(t *testing.T) {
+	// given
+	cl := test.NewFakeClient(t, &toolchainv1alpha1.SpaceProvisionerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spc0",
+			Namespace: test.HostOperatorNs,
+		},
+		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+			ToolchainCluster: "cluster1",
+		},
+	}, &toolchainv1alpha1.SpaceProvisionerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spc1",
+			Namespace: test.HostOperatorNs,
+		},
+		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+			ToolchainCluster: "cluster2",
+		},
+	}, &toolchainv1alpha1.SpaceProvisionerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spc2",
+			Namespace: test.HostOperatorNs,
+		},
+		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
+			ToolchainCluster: "cluster1",
+		},
+	})
+
+	// when
+	reqs, err := findReferencingProvisionerConfigs(context.TODO(), cl, runtimeclient.ObjectKey{Name: "cluster1", Namespace: test.HostOperatorNs})
+
+	// then
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      "spc0",
+		},
+	}, reqs[0])
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      "spc2",
+		},
+	}, reqs[1])
+}
+
+func prepareReconcile(t *testing.T, spc *toolchainv1alpha1.SpaceProvisionerConfig, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
+	require.NoError(t, os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs))
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+
+	fakeClient := test.NewFakeClient(t, append(initObjs, spc)...)
+
+	r := &Reconciler{
+		Client: fakeClient,
+	}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: test.HostOperatorNs,
+			Name:      spc.Name,
+		},
+	}
+	return r, req, fakeClient
+}

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kubectl/pkg/scheme"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -147,7 +146,7 @@ func TestSpaceProvisionerConfigReEnqueing(t *testing.T) {
 
 func prepareReconcile(t *testing.T, spc *toolchainv1alpha1.SpaceProvisionerConfig, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
 	require.NoError(t, os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs))
-	s := scheme.Scheme
+	s := runtime.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
 

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
@@ -30,11 +30,10 @@ func TestSpaceProvisionerConfigValidation(t *testing.T) {
 
 		// when
 		_, reconcileErr := r.Reconcile(context.TODO(), req)
-		getErr := cl.Get(context.TODO(), runtimeclient.ObjectKey{Name: "spc", Namespace: test.HostOperatorNs}, spc)
+		require.NoError(t, cl.Get(context.TODO(), runtimeclient.ObjectKeyFromObject(spc), spc))
 
 		// then
-		require.NoError(t, reconcileErr)
-		require.NoError(t, getErr)
+		assert.NoError(t, reconcileErr)
 		assert.True(t, condition.IsFalse(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
 	})
 
@@ -50,11 +49,10 @@ func TestSpaceProvisionerConfigValidation(t *testing.T) {
 
 		// when
 		_, reconcileErr := r.Reconcile(context.TODO(), req)
-		getErr := cl.Get(context.TODO(), runtimeclient.ObjectKey{Name: "spc", Namespace: test.HostOperatorNs}, spc)
+		require.NoError(t, cl.Get(context.TODO(), runtimeclient.ObjectKeyFromObject(spc), spc))
 
 		// then
-		require.NoError(t, reconcileErr)
-		require.NoError(t, getErr)
+		assert.NoError(t, reconcileErr)
 		assert.True(t, condition.IsTrue(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
 	})
 }
@@ -157,10 +155,10 @@ func TestSpaceProvisionerConfigReEnqueing(t *testing.T) {
 
 		// when
 		res, reconcileErr := r.Reconcile(context.TODO(), req)
-		assert.NoError(t, cl.Get(context.TODO(), runtimeclient.ObjectKeyFromObject(spc), spc))
+		require.NoError(t, cl.Get(context.TODO(), runtimeclient.ObjectKeyFromObject(spc), spc))
 
 		// then
-		assert.Nil(t, reconcileErr)
+		assert.NoError(t, reconcileErr)
 		assert.False(t, res.Requeue)
 		assert.NotEmpty(t, spc.Status.Conditions)
 	})

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
@@ -134,13 +134,12 @@ func TestSpaceProvisionerConfigReEnqueing(t *testing.T) {
 		}
 
 		// when
-		res, reconcileErr := r.Reconcile(context.TODO(), req)
+		_, reconcileErr := r.Reconcile(context.TODO(), req)
 		spcInCluster := &toolchainv1alpha1.SpaceProvisionerConfig{}
 		require.NoError(t, cl.Get(context.TODO(), runtimeclient.ObjectKeyFromObject(spc), spcInCluster))
 
 		// then
-		assert.NoError(t, reconcileErr)
-		assert.True(t, res.Requeue)
+		assert.Error(t, reconcileErr)
 		AssertThat(t, spcInCluster, Is(NotReadyWithReason(toolchainv1alpha1.SpaceProvisionerConfigToolchainClusterNotFoundReason)))
 		assert.Len(t, spcInCluster.Status.Conditions, 1)
 		assert.Equal(t, "failed to get the referenced ToolchainCluster: "+getErr.Error(), spcInCluster.Status.Conditions[0].Message)

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller_test.go
@@ -2,8 +2,10 @@ package spaceprovisionerconfig
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
+	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/apis"
@@ -11,6 +13,7 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -19,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestSpaceProvisionerConfig(t *testing.T) {
+func TestSpaceProvisionerConfigValidation(t *testing.T) {
 	t.Run("is not valid when non-existing ToolchainCluster is referenced", func(t *testing.T) {
 		// given
 		spc := &toolchainv1alpha1.SpaceProvisionerConfig{
@@ -72,52 +75,74 @@ func TestSpaceProvisionerConfig(t *testing.T) {
 	})
 }
 
-func TestEnqueingFilter(t *testing.T) {
-	// given
-	cl := test.NewFakeClient(t, &toolchainv1alpha1.SpaceProvisionerConfig{
+func TestSpaceProvisionerConfigReEnqueing(t *testing.T) {
+	spc := &toolchainv1alpha1.SpaceProvisionerConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "spc0",
+			Name:      "spc",
 			Namespace: test.HostOperatorNs,
 		},
 		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
 			ToolchainCluster: "cluster1",
 		},
-	}, &toolchainv1alpha1.SpaceProvisionerConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "spc1",
-			Namespace: test.HostOperatorNs,
-		},
-		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
-			ToolchainCluster: "cluster2",
-		},
-	}, &toolchainv1alpha1.SpaceProvisionerConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "spc2",
-			Namespace: test.HostOperatorNs,
-		},
-		Spec: toolchainv1alpha1.SpaceProvisionerConfigSpec{
-			ToolchainCluster: "cluster1",
-		},
+	}
+
+	t.Run("re-enqueues on failure to GET", func(t *testing.T) {
+		// given
+		r, req, cl := prepareReconcile(t, spc.DeepCopy())
+
+		expectedErr := errors.New("purposefully failing the get request")
+		cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
+			return expectedErr
+		}
+
+		// when
+		_, reconcileErr := r.Reconcile(context.TODO(), req)
+
+		// then
+		assert.ErrorIs(t, reconcileErr, expectedErr)
 	})
+	t.Run("re-enqueues on failure to update the status", func(t *testing.T) {
+		// given
+		r, req, cl := prepareReconcile(t, spc.DeepCopy())
 
-	// when
-	reqs, err := findReferencingProvisionerConfigs(context.TODO(), cl, runtimeclient.ObjectKey{Name: "cluster1", Namespace: test.HostOperatorNs})
+		expectedErr := errors.New("purposefully failing the get request")
+		cl.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
+			return expectedErr
+		}
 
-	// then
-	require.NoError(t, err)
-	require.Len(t, reqs, 2)
-	assert.Equal(t, reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: test.HostOperatorNs,
-			Name:      "spc0",
-		},
-	}, reqs[0])
-	assert.Equal(t, reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: test.HostOperatorNs,
-			Name:      "spc2",
-		},
-	}, reqs[1])
+		// when
+		_, reconcileErr := r.Reconcile(context.TODO(), req)
+
+		// then
+		assert.ErrorIs(t, reconcileErr, expectedErr)
+	})
+	t.Run("doesn't re-enqueue when object not found", func(t *testing.T) {
+		// given
+		r, req, cl := prepareReconcile(t, spc.DeepCopy())
+
+		cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
+			return &kerrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+		}
+
+		// when
+		_, reconcileErr := r.Reconcile(context.TODO(), req)
+
+		// then
+		assert.NoError(t, reconcileErr)
+	})
+	t.Run("doesn't re-enqueue when object being deleted", func(t *testing.T) {
+		// given
+		spc := spc.DeepCopy()
+		spc.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+		r, req, _ := prepareReconcile(t, spc)
+
+		// when
+		_, reconcileErr := r.Reconcile(context.TODO(), req)
+
+		// then
+		assert.NoError(t, reconcileErr)
+		assert.Empty(t, spc.Status.Conditions)
+	})
 }
 
 func prepareReconcile(t *testing.T, spc *toolchainv1alpha1.SpaceProvisionerConfig, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20240125165010-df87a40fe9c9
+replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20240125174611-654ac7c7e9a7
 
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20240130164654-654fbb30d282
-
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20240130154956-fb41345f8aae
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20240130202956-94befa4c786c
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20240125174611-654ac7c7e9a7
-
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20240125161658-0594a843cd4e
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20240130154956-fb41345f8aae
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20240130164654-654fbb30d282
+
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240130154956-fb41345f8aae

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20231217224957-34f7cb3fcbf7
+	github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20231218221155-9d1179b6a349
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
@@ -28,6 +28,7 @@ require (
 	k8s.io/client-go v0.25.0
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.70.1
+	k8s.io/kubectl v0.24.0
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
@@ -106,7 +107,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/kubectl v0.24.0 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20240125091627-98a8e74d0fcb
+
 require github.com/google/uuid v1.3.0 // indirect
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20240125165010-df87a40fe9c9
+
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20231218221155-9d1179b6a349
@@ -30,8 +32,6 @@ require (
 	k8s.io/klog/v2 v2.70.1
 	sigs.k8s.io/controller-runtime v0.13.0
 )
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/metlos/toolchain-common v0.0.0-20240125091627-98a8e74d0fcb
 
 require github.com/google/uuid v1.3.0 // indirect
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	k8s.io/client-go v0.25.0
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.70.1
-	k8s.io/kubectl v0.24.0
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
@@ -107,6 +106,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
+	k8s.io/kubectl v0.24.0 // indirect
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420 h1:rxbURSqAgiMCsyKDRwsHMjw7bIktK0IUU/OXpxwu0Zk=
 github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20231218221155-9d1179b6a349 h1:0xOPCrdPMWZwyyAO/O8U/FAWrp8NR6lvjtkLAXNavG4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20231218221155-9d1179b6a349/go.mod h1:cEkJH2jz88KIZt5W8wSnK3Gz6OfszzXv74OIndbTlRE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -438,6 +436,8 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/metlos/toolchain-common v0.0.0-20240125091627-98a8e74d0fcb h1:fA+FVOx7Y0fFVQYG7F1m1wfaIrg6iHRxztSLCoc2Nl0=
+github.com/metlos/toolchain-common v0.0.0-20240125091627-98a8e74d0fcb/go.mod h1:f+h8e03UjCldtgI1NsZm/yXq2b/uZv2jsz5p8OK9Z+c=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20231217224957-34f7cb3fcbf7 h1:8Rbzo3EQoQrJakXRKIxcluK0NwHeIWzzG2nDsiKIxsI=
-github.com/codeready-toolchain/api v0.0.0-20231217224957-34f7cb3fcbf7/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
+github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420 h1:rxbURSqAgiMCsyKDRwsHMjw7bIktK0IUU/OXpxwu0Zk=
+github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20231218221155-9d1179b6a349 h1:0xOPCrdPMWZwyyAO/O8U/FAWrp8NR6lvjtkLAXNavG4=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20231218221155-9d1179b6a349/go.mod h1:cEkJH2jz88KIZt5W8wSnK3Gz6OfszzXv74OIndbTlRE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420 h1:rxbURSqAgiMCsyKDRwsHMjw7bIktK0IUU/OXpxwu0Zk=
 github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20240130154956-fb41345f8aae h1:l9EfxDVv8nDLiMFDMKVNqRraAKAhj8R6UORA607wYeo=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20240130154956-fb41345f8aae/go.mod h1:f+h8e03UjCldtgI1NsZm/yXq2b/uZv2jsz5p8OK9Z+c=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -436,8 +438,6 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metlos/toolchain-common v0.0.0-20240125174611-654ac7c7e9a7 h1:TiscyQrhetYNkwjOkysujCg4W0TAIhM4ujXWZt8+J9w=
-github.com/metlos/toolchain-common v0.0.0-20240125174611-654ac7c7e9a7/go.mod h1:f+h8e03UjCldtgI1NsZm/yXq2b/uZv2jsz5p8OK9Z+c=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=
 github.com/migueleliasweb/go-github-mock v0.0.18/go.mod h1:CcgXcbMoRnf3rRVHqGssuBquZDIcaplxL2W6G+xs7kM=

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420 h1:rxbURSqAgiMCsyKDRwsHMjw7bIktK0IUU/OXpxwu0Zk=
 github.com/codeready-toolchain/api v0.0.0-20240116164228-8d18c9262420/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240130154956-fb41345f8aae h1:l9EfxDVv8nDLiMFDMKVNqRraAKAhj8R6UORA607wYeo=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240130154956-fb41345f8aae/go.mod h1:f+h8e03UjCldtgI1NsZm/yXq2b/uZv2jsz5p8OK9Z+c=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20240130202956-94befa4c786c h1:83NTlxL6LkpKyu39QxyheGV1tWRXSPOmFyu9fC0qUAA=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20240130202956-94befa4c786c/go.mod h1:f+h8e03UjCldtgI1NsZm/yXq2b/uZv2jsz5p8OK9Z+c=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/codeready-toolchain/host-operator/controllers/spacebindingrequest"
 	"github.com/codeready-toolchain/host-operator/controllers/spacecleanup"
 	"github.com/codeready-toolchain/host-operator/controllers/spacecompletion"
+	"github.com/codeready-toolchain/host-operator/controllers/spaceprovisionerconfig"
 	"github.com/codeready-toolchain/host-operator/controllers/spacerequest"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainstatus"
@@ -363,6 +364,12 @@ func main() { // nolint:gocyclo
 		},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SocialEvent")
+		os.Exit(1)
+	}
+	if err = (&spaceprovisionerconfig.Reconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SpaceProvisionerConfig")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
This only checks validity of the CR but doesn't integrate it into the space provisioning flow in any way.

Issue link: https://issues.redhat.com/browse/KSPACE-28
Associated toolchain-e2e PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/883
Associated toolchain-common PR: https://github.com/codeready-toolchain/toolchain-common/pull/357