### PR TITLE
Make the idler template generic

### DIFF
--- a/deploy/templates/notificationtemplates/sandbox/idlertriggered/notification.html
+++ b/deploy/templates/notificationtemplates/sandbox/idlertriggered/notification.html
@@ -46,7 +46,7 @@
     </p>
 
     <p>
-        In accordance with the usage terms of Developer Sandbox, we have scaled down your workload {{.AppType}} {{.AppName}}. You can restart your workload(s) or scale up the number of instances from the
+        In accordance with the usage terms of Developer Sandbox, your workload {{.AppType}} {{.AppName}} has been scaled down. You can restart your workload(s) or scale up the number of instances from the
         Developer Sandbox User Interface.
     </p>
 

--- a/deploy/templates/notificationtemplates/sandbox/idlertriggered/notification.html
+++ b/deploy/templates/notificationtemplates/sandbox/idlertriggered/notification.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>
-        Notice: Your running application in namespace has been idled
+        Notice: Your running workload has been idled
     </title>
     <style>
         a:hover {
@@ -41,13 +41,12 @@
 >
 
     <p>
-        You are receiving this email because one or more of your applications in the Developer Sandbox for
+        You are receiving this email because one or more of your workloads in the Developer Sandbox for
         Red Hat OpenShift has been running for 12 hours.
     </p>
 
     <p>
-        In accordance with the usage terms of Developer Sandbox, we have reduced the number of instances of your
-        application {{.AppType}} {{.AppName}} to zero (0). You can restart your application(s) by increasing the number of instances from the
+        In accordance with the usage terms of Developer Sandbox, we have scaled down your workload {{.AppType}} {{.AppName}}. You can restart your workload(s) or scale up the number of instances from the
         Developer Sandbox User Interface.
     </p>
 

--- a/deploy/templates/notificationtemplates/sandbox/idlertriggered/subject.txt
+++ b/deploy/templates/notificationtemplates/sandbox/idlertriggered/subject.txt
@@ -1,1 +1,1 @@
-Notice: Your running application in namespace {{.Namespace}} has been idled
+Notice: Your running workload in namespace {{.Namespace}} has been idled

--- a/pkg/templates/notificationtemplates/notification_generator_test.go
+++ b/pkg/templates/notificationtemplates/notification_generator_test.go
@@ -65,8 +65,8 @@ func TestGetNotificationTemplate(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			require.NotNil(t, template)
-			assert.Equal(t, "Notice: Your running application in namespace {{.Namespace}} has been idled", template.Subject)
-			assert.Contains(t, template.Content, "In accordance with the usage terms of Developer Sandbox, we have reduced the number of instances of your\n        application {{.AppType}} {{.AppName}} to zero (0).")
+			assert.Equal(t, "Notice: Your running workload in namespace {{.Namespace}} has been idled", template.Subject)
+			assert.Contains(t, template.Content, "In accordance with the usage terms of Developer Sandbox, your workload {{.AppType}} {{.AppName}} has been scaled down.")
 
 		})
 	})


### PR DESCRIPTION
This way the template can be reused when VMs are idled too.

https://issues.redhat.com/browse/SANDBOX-513