### PR TITLE
WIP: Base the capacity manager on the SpaceProvisionerConfig

### DIFF
--- a/controllers/deactivation/deactivation_controller_test.go
+++ b/controllers/deactivation/deactivation_controller_test.go
@@ -45,8 +45,7 @@ const (
 )
 
 func TestReconcile(t *testing.T) {
-	config := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.CapacityThresholds().MaxNumberOfSpaces(
-		testconfig.PerMemberCluster("member1", 321)),
+	config := commonconfig.NewToolchainConfigObjWithReset(t,
 		testconfig.Deactivation().DeactivatingNotificationDays(3))
 
 	// given
@@ -65,7 +64,6 @@ func TestReconcile(t *testing.T) {
 	states.SetDeactivating(userSignupFoobar, true)
 
 	t.Run("controller should not deactivate user", func(t *testing.T) {
-
 		// the time since the mur was provisioned is within the deactivation timeout period for the 'deactivate30' tier
 		t.Run("usersignup should not be deactivated - deactivate30 (30 days)", func(t *testing.T) {
 			// given
@@ -137,8 +135,7 @@ func TestReconcile(t *testing.T) {
 		// a user that belongs to the deactivation domain excluded list
 		t.Run("user deactivation excluded", func(t *testing.T) {
 			// given
-			config := commonconfig.NewToolchainConfigObjWithReset(t, testconfig.CapacityThresholds().MaxNumberOfSpaces(
-				testconfig.PerMemberCluster("member1", 321)),
+			config := commonconfig.NewToolchainConfigObjWithReset(t,
 				testconfig.Deactivation().DeactivatingNotificationDays(3),
 			)
 			restore := commontest.SetEnvVarAndRestore(t, "HOST_OPERATOR_DEACTIVATION_DOMAINS_EXCLUDED", "@redhat.com")
@@ -155,11 +152,9 @@ func TestReconcile(t *testing.T) {
 			require.True(t, res.RequeueAfter == 0, "requeueAfter should not be set")
 			assertThatUserSignupDeactivated(t, cl, username, false)
 		})
-
 	})
 	// in these tests, the controller should (eventually) deactivate the user
 	t.Run("controller should deactivate user", func(t *testing.T) {
-
 		userSignupFoobar := userSignupWithEmail(username, "foo@bar.com")
 		t.Run("usersignup should be marked as deactivating - deactivate30 (30 days)", func(t *testing.T) {
 			// given
@@ -288,7 +283,6 @@ func TestReconcile(t *testing.T) {
 			assertThatUserSignupDeactivated(t, cl, username, true)
 			AssertMetricsCounterEquals(t, 1, metrics.UserSignupAutoDeactivatedTotal)
 		})
-
 	})
 
 	t.Run("test usersignup deactivating state reset to false", func(t *testing.T) {
@@ -355,7 +349,6 @@ func TestReconcile(t *testing.T) {
 	})
 
 	t.Run("failures", func(t *testing.T) {
-
 		// cannot find UserTier
 		t.Run("unable to get UserTier", func(t *testing.T) {
 			// given
@@ -433,7 +426,6 @@ func TestReconcile(t *testing.T) {
 			assertThatUserSignupDeactivated(t, cl, username, false)
 		})
 	})
-
 }
 
 func prepareReconcile(t *testing.T, name string, initObjs ...runtime.Object) (reconcile.Reconciler, reconcile.Request, *commontest.FakeClient) {

--- a/controllers/spacecompletion/space_completion_controller.go
+++ b/controllers/spacecompletion/space_completion_controller.go
@@ -96,7 +96,7 @@ func (r *Reconciler) ensureFields(ctx context.Context, space *toolchainv1alpha1.
 	if space.Spec.TargetCluster == "" {
 		targetCluster, err := r.ClusterManager.GetOptimalTargetCluster(ctx, capacity.OptimalTargetClusterFilter{
 			ToolchainStatusNamespace: space.Namespace,
-			ClusterRoles:             space.Spec.TargetClusterRoles,
+			PlacementRoles:           space.Spec.TargetClusterRoles,
 		})
 		if err != nil {
 			return false, errs.Wrapf(err, "unable to get the optimal target cluster")

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +23,8 @@ import (
 
 // Reconciler is the reconciler for the SpaceProvisionerConfig CRs.
 type Reconciler struct {
-	Client runtimeclient.Client
+	Client       runtimeclient.Client
+	ClusterCache cluster.ToolchainClusterService
 }
 
 var _ reconcile.Reconciler = (*Reconciler)(nil)
@@ -106,6 +108,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		}
 		reportedError = fmt.Errorf("failed to update the SpaceProvisionerConfig status: %w", err)
 	}
+
+	// in any case, we need to update the ToolchainClusterCache because there's been a change in the SPC.
+	r.ClusterCache.DeleteToolchainCluster(toolchainClusterKey.Name)
 
 	return ctrl.Result{}, reportedError
 }

--- a/controllers/toolchainconfig/configuration.go
+++ b/controllers/toolchainconfig/configuration.go
@@ -82,7 +82,8 @@ func (c *ToolchainConfig) Environment() string {
 }
 
 func (c *ToolchainConfig) GitHubSecret() GitHubSecret {
-	return GitHubSecret{s: c.cfg.Host.ToolchainStatus.GitHubSecret,
+	return GitHubSecret{
+		s:       c.cfg.Host.ToolchainStatus.GitHubSecret,
 		secrets: c.secrets,
 	}
 }
@@ -150,10 +151,12 @@ func (s SpaceConfig) SpaceBindingRequestIsEnabled() bool {
 	return commonconfig.GetBool(s.spaceConfig.SpaceBindingRequestEnabled, false)
 }
 
+// Deprecated: This is superseded by SpaceProvisionderConfig.Spec.CapacityThresholds
 type CapacityThresholdsConfig struct {
 	capacityThresholds toolchainv1alpha1.CapacityThresholds
 }
 
+// Deprecated: This is superseded by SpaceProvisionderConfig.Spec.CapacityThresholds.MaxNumberOfSpaces
 func (c CapacityThresholdsConfig) MaxNumberOfSpacesSpecificPerMemberCluster() map[string]int {
 	return c.capacityThresholds.MaxNumberOfSpacesPerMemberCluster
 }
@@ -162,6 +165,7 @@ func (c CapacityThresholdsConfig) ResourceCapacityThresholdDefault() int {
 	return commonconfig.GetInt(c.capacityThresholds.ResourceCapacityThreshold.DefaultThreshold, 80)
 }
 
+// Deprecated: This is superseded by SpaceProvisionderConfig.Spec.CapacityThresholds.MaxMemoryUtilization
 func (c CapacityThresholdsConfig) ResourceCapacityThresholdSpecificPerMemberCluster() map[string]int {
 	return c.capacityThresholds.ResourceCapacityThreshold.SpecificPerMemberCluster
 }

--- a/controllers/usersignup/approval.go
+++ b/controllers/usersignup/approval.go
@@ -57,7 +57,7 @@ func getClusterIfApproved(ctx context.Context, cl runtimeclient.Client, userSign
 	clusterName, err := clusterManager.GetOptimalTargetCluster(ctx, capacity.OptimalTargetClusterFilter{
 		PreferredCluster:         preferredCluster,
 		ToolchainStatusNamespace: userSignup.Namespace,
-		ClusterRoles:             clusterRoles,
+		PlacementRoles:           clusterRoles,
 	})
 	if err != nil {
 		return false, unknown, errors.Wrapf(err, "unable to get the optimal target cluster")

--- a/controllers/usersignup/approval_test.go
+++ b/controllers/usersignup/approval_test.go
@@ -45,12 +45,12 @@ func TestGetClusterIfApproved(t *testing.T) {
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.AutomaticApproval().
 				Enabled(true),
-			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+		)
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(70)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(75)))
 
 		// when
 		approved, clusterName, err := getClusterIfApproved(ctx, fakeClient, signup, capacity.NewClusterManager(clusters, fakeClient))
@@ -176,12 +176,12 @@ func TestGetClusterIfApproved(t *testing.T) {
 
 	t.Run("automatic approval not enabled, user manually approved but no cluster has capacity", func(t *testing.T) {
 		// given
-		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
-			testconfig.CapacityThresholds().ResourceCapacityThreshold(50),
-		)
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t)
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxMemoryPercent(50)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxMemoryPercent(50)))
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
 
 		// when
@@ -195,13 +195,12 @@ func TestGetClusterIfApproved(t *testing.T) {
 
 	t.Run("automatic approval not enabled, user manually approved and second cluster has capacity", func(t *testing.T) {
 		// given
-		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
-			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 2000)).
-				ResourceCapacityThreshold(62))
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t)
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(2000), WithMaxMemoryPercent(62)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxMemoryPercent(62)))
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually())
 
 		// when
@@ -215,11 +214,10 @@ func TestGetClusterIfApproved(t *testing.T) {
 
 	t.Run("automatic approval not enabled, user manually approved, no cluster has capacity but targetCluster is specified", func(t *testing.T) {
 		// given
-		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
-			testconfig.CapacityThresholds().MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000)))
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t)
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1)), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
 		signup := commonsignup.NewUserSignup(commonsignup.ApprovedManually(), commonsignup.WithTargetCluster("member1"))
 
 		// when

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
+replace github.com/codeready-toolchain/toolchain-common => ../toolchain-common
+
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240207000013-661b63025269
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240216093005-a7f4a3ea7fb9

--- a/pkg/capacity/manager_test.go
+++ b/pkg/capacity/manager_test.go
@@ -42,12 +42,11 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
 
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(70)))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
@@ -66,11 +65,13 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 10000), testconfig.PerMemberCluster("member2", 300), testconfig.PerMemberCluster("member3", 400)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(10000), WithMaxMemoryPercent(70)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(300), WithMaxMemoryPercent(75)),
+			NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue, WithMaxNumberOfSpaces(400), WithMaxMemoryPercent(80)))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
@@ -89,11 +90,13 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000), testconfig.PerMemberCluster("member3", 2000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(70)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(75)),
+			NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue, WithMaxNumberOfSpaces(2000), WithMaxMemoryPercent(80)))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
@@ -111,11 +114,12 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(70)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(75)))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
@@ -135,11 +139,12 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 60), testconfig.PerMemberCluster("member2", 75)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(60)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(75)))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
@@ -158,11 +163,12 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 700), testconfig.PerMemberCluster("member2", 1000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 90), testconfig.PerMemberCluster("member2", 95)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(700), WithMaxMemoryPercent(90)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(95)))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
@@ -182,11 +188,12 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1), testconfig.PerMemberCluster("member2", 1)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 60), testconfig.PerMemberCluster("member2", 75)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1), WithMaxMemoryPercent(60)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1), WithMaxMemoryPercent(75)))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
@@ -206,7 +213,6 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces().
 				ResourceCapacityThreshold(62))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
@@ -229,7 +235,6 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces().
 				ResourceCapacityThreshold(1))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
@@ -252,11 +257,36 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
-		clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionFalse), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue))
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionFalse, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(70)),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(75)))
+
+		// when
+		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
+			ctx,
+			capacity.OptimalTargetClusterFilter{
+				ToolchainStatusNamespace: commontest.HostOperatorNs,
+			},
+		)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "member2", clusterName)
+	})
+
+	t.Run("cluster not considered when provisioning is disabled", func(t *testing.T) {
+		// given
+		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
+			testconfig.CapacityThresholds().
+				ResourceCapacityThreshold(80))
+		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
+		InitializeCounters(t, toolchainStatus)
+		clusters := NewGetMemberClusters(
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(70), WithProvisioningDisabled()),
+			NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(75)))
 
 		// when
 		clusterName, err := capacity.NewClusterManager(clusters, fakeClient).GetOptimalTargetCluster(
@@ -275,13 +305,13 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1000), testconfig.PerMemberCluster("member2", 1000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 70), testconfig.PerMemberCluster("member2", 75)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
+		// member2 has capacity but doesn't have the required cluster role
 		clusters := NewGetMemberClusters(
-			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
-			NewMemberClusterWithoutClusterRoles(t, "member2", corev1.ConditionTrue), // member2 has capacity but doesn't have the required cluster role
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(70)),
+			NewMemberClusterWithoutClusterRoles(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(75)),
 		)
 
 		// when
@@ -289,7 +319,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			ctx,
 			capacity.OptimalTargetClusterFilter{
 				ToolchainStatusNamespace: commontest.HostOperatorNs,
-				ClusterRoles:             []string{cluster.RoleLabel(cluster.Tenant)},
+				PlacementRoles:           []string{cluster.RoleLabel(cluster.Tenant)},
 			},
 		)
 
@@ -302,13 +332,13 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 		// given
 		toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
 			testconfig.CapacityThresholds().
-				MaxNumberOfSpaces(testconfig.PerMemberCluster("member1", 1), testconfig.PerMemberCluster("member2", 1000)).
-				ResourceCapacityThreshold(80, testconfig.PerMemberCluster("member1", 1), testconfig.PerMemberCluster("member2", 75)))
+				ResourceCapacityThreshold(80))
 		fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 		InitializeCounters(t, toolchainStatus)
+		// member2 has capacity but doesn't have the required cluster role
 		clusters := NewGetMemberClusters(
-			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
-			NewMemberClusterWithoutClusterRoles(t, "member2", corev1.ConditionTrue), // member2 has capacity but doesn't have the required cluster role
+			NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue, WithMaxNumberOfSpaces(1), WithMaxMemoryPercent(1)),
+			NewMemberClusterWithoutClusterRoles(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(1000), WithMaxMemoryPercent(75)),
 		)
 
 		// when
@@ -316,7 +346,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			ctx,
 			capacity.OptimalTargetClusterFilter{
 				ToolchainStatusNamespace: commontest.HostOperatorNs,
-				ClusterRoles:             []string{cluster.RoleLabel(cluster.Tenant)},
+				PlacementRoles:           []string{cluster.RoleLabel(cluster.Tenant)},
 			},
 		)
 
@@ -339,7 +369,7 @@ func TestGetOptimalTargetCluster(t *testing.T) {
 			ctx,
 			capacity.OptimalTargetClusterFilter{
 				PreferredCluster:         "member2",                                   // request specifically this member eve if it doesn't match the cluster-roles from below
-				ClusterRoles:             []string{cluster.RoleLabel(cluster.Tenant)}, // set
+				PlacementRoles:           []string{cluster.RoleLabel(cluster.Tenant)}, // set
 				ToolchainStatusNamespace: commontest.HostOperatorNs,
 			},
 		)
@@ -405,10 +435,8 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 	ctx := context.TODO()
 	for _, limit := range []int{800, 1000, 1234, 2500, 10000} {
 		t.Run(fmt.Sprintf("for the given limit of max number of spaces per cluster: %d", limit), func(t *testing.T) {
-
 			for _, numberOfSpaces := range []int{0, 8, 50, 88, 100, 123, 555} {
 				t.Run(fmt.Sprintf("when there is a number of spaces at the very beginning %d", numberOfSpaces), func(t *testing.T) {
-
 					toolchainStatus := NewToolchainStatus(
 						WithMetric(toolchainv1alpha1.MasterUserRecordsPerDomainMetricKey, toolchainv1alpha1.Metric{
 							string(metrics.Internal): 1000,
@@ -421,13 +449,14 @@ func TestGetOptimalTargetClusterInBatchesBy50WhenTwoClusterHaveTheSameUsage(t *t
 						WithMember("member3", WithSpaceCount(numberOfSpaces), WithNodeRoleUsage("worker", 55), WithNodeRoleUsage("master", 50)))
 
 					// member2 and member3 have the same capacity left and the member1 is full, so no one can be provisioned there
-					toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t,
-						testconfig.CapacityThresholds().
-							MaxNumberOfSpaces(testconfig.PerMemberCluster("member2", limit), testconfig.PerMemberCluster("member3", limit)))
+					toolchainConfig := commonconfig.NewToolchainConfigObjWithReset(t)
 
 					fakeClient := commontest.NewFakeClient(t, toolchainStatus, toolchainConfig)
 					InitializeCounters(t, toolchainStatus)
-					clusters := NewGetMemberClusters(NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue), NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue))
+					clusters := NewGetMemberClusters(
+						NewMemberClusterWithTenantRole(t, "member1", corev1.ConditionTrue),
+						NewMemberClusterWithTenantRole(t, "member2", corev1.ConditionTrue, WithMaxNumberOfSpaces(uint(limit))),
+						NewMemberClusterWithTenantRole(t, "member3", corev1.ConditionTrue, WithMaxNumberOfSpaces(uint(limit))))
 					clusterBalancer := capacity.NewClusterManager(clusters, fakeClient)
 
 					// now run in 4 cycles and expect that the users will be provisioned in batches of 50


### PR DESCRIPTION
This changes the capacity manager to base its decisions on the configuration from the `SpaceProvisionerConfig` objects instead of the `ToolchainConfig`. There is a lot of "collateral damage" in the tests because of this change because we need to configure the provisioning differently than before.

Notice the debug logs in capacity/manager.go. These need to be removed before merging to master once the e2e failures are fixed.

JIRA issue: https://issues.redhat.com/browse/KSPACE-46

Related PRs:
toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/364
toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/905