### PR TITLE
RHTAPSRE-439: Deploy CA bundle configmap

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -262,6 +262,14 @@ objects:
   - kind: ServiceAccount
     namespace: ${SPACE_NAME}-tenant
     name: appstudio-pipeline
+- apiVersion: v1
+  data: {}
+  kind: ConfigMap
+  metadata:
+    labels:
+      config.openshift.io/inject-trusted-cabundle: "true"
+    name: trusted-ca
+    namespace: ${SPACE_NAME}-tenant
 parameters:
 - name: SPACE_NAME
   required: true


### PR DESCRIPTION
Openshift will inject the CA bundle to the configmap. The configmap will be available in every tenant namespace, so tenant's pipelines would able to reach services that use private pki.

 https://docs.openshift.com/container-platform/4.14/networking/configuring-a-custom-pki.html#nw-proxy-configure-object_configuring-a-custom-pki