### PR TITLE
KSPACE-43: Adding common GetClusters func

### DIFF
--- a/controllers/spacecompletion/space_completion_controller_test.go
+++ b/controllers/spacecompletion/space_completion_controller_test.go
@@ -213,7 +213,7 @@ func TestCreateSpace(t *testing.T) {
 	})
 }
 
-func prepareReconcile(t *testing.T, space *toolchainv1alpha1.Space, getMemberClusters cluster.GetMemberClustersFunc) (*spacecompletion.Reconciler, reconcile.Request, *test.FakeClient) {
+func prepareReconcile(t *testing.T, space *toolchainv1alpha1.Space, getMemberClusters cluster.GetClustersFunc) (*spacecompletion.Reconciler, reconcile.Request, *test.FakeClient) {
 	require.NoError(t, os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs))
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)

--- a/controllers/toolchainconfig/sync.go
+++ b/controllers/toolchainconfig/sync.go
@@ -14,11 +14,11 @@ import (
 )
 
 type Synchronizer struct {
-	getMembersFunc cluster.GetMemberClustersFunc
+	getMembersFunc cluster.GetClustersFunc
 	logger         logr.Logger
 }
 
-func NewSynchronizer(logger logr.Logger, getMembersFunc cluster.GetMemberClustersFunc) Synchronizer {
+func NewSynchronizer(logger logr.Logger, getMembersFunc cluster.GetClustersFunc) Synchronizer {
 	return Synchronizer{
 		getMembersFunc: getMembersFunc,
 		logger:         logger,

--- a/controllers/toolchainconfig/toolchainconfig_controller.go
+++ b/controllers/toolchainconfig/toolchainconfig_controller.go
@@ -56,7 +56,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 // Reconciler reconciles a ToolchainConfig object
 type Reconciler struct {
 	Client             runtimeclient.Client
-	GetMembersFunc     cluster.GetMemberClustersFunc
+	GetMembersFunc     cluster.GetClustersFunc
 	Scheme             *runtime.Scheme
 	RegServiceTemplate *templatev1.Template
 }

--- a/controllers/toolchainconfig/toolchainconfig_controller_test.go
+++ b/controllers/toolchainconfig/toolchainconfig_controller_test.go
@@ -363,7 +363,7 @@ func matchesDefaultConfig(t *testing.T, actual toolchainconfig.ToolchainConfig) 
 	assert.Equal(t, 3, actual.Deactivation().DeactivatingNotificationDays())
 }
 
-func newController(t *testing.T, hostCl runtimeclient.Client, members cluster.GetMemberClustersFunc) toolchainconfig.Reconciler {
+func newController(t *testing.T, hostCl runtimeclient.Client, members cluster.GetClustersFunc) toolchainconfig.Reconciler {
 	os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs)
 	s := clientgoscheme.Scheme
 	err := apis.AddToScheme(s)

--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -119,7 +119,7 @@ type HTTPClient interface {
 type Reconciler struct {
 	Client              runtimeclient.Client
 	Scheme              *runtime.Scheme
-	GetMembersFunc      cluster.GetMemberClustersFunc
+	GetMembersFunc      cluster.GetClustersFunc
 	HTTPClientImpl      HTTPClient
 	Namespace           string
 	VersionCheckManager status.VersionCheckManager

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -3877,7 +3877,7 @@ func TestApprovedManuallyUserSignupWhenNoMembersAvailable(t *testing.T) {
 
 }
 
-func prepareReconcile(t *testing.T, name string, getMemberClusters cluster.GetMemberClustersFunc, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
+func prepareReconcile(t *testing.T, name string, getMemberClusters cluster.GetClustersFunc, initObjs ...runtime.Object) (*Reconciler, reconcile.Request, *test.FakeClient) {
 	os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs)
 	metrics.Reset()
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/codeready-toolchain/host-operator
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240314071034-3b543ee71d46
+
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240313081501-5cafefaa6598

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,6 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87 h1:eQLsrMqfjAzGfuO9t6pVxO4K6cUDKOMxEvl0ujQq/2I=
 github.com/codeready-toolchain/api v0.0.0-20240227210924-371ddb054d87/go.mod h1:FO7kgXH1x1LqkF327D5a36u0WIrwjVCbeijPkzgwaZc=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240313081501-5cafefaa6598 h1:06nit/nCQFVKp51ZtIOyY49ncmxEK5shJGTaM+Ogicw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240313081501-5cafefaa6598/go.mod h1:c2JxboVI7keMD5fx5bB7LwzowFYYTwbepJhzPWSYXVs=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -193,6 +191,8 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
+github.com/fbm3307/toolchain-common v0.0.0-20240314071034-3b543ee71d46 h1:rxYAYK+h0jGTtsdVXl2mUgQk+6jdFmsh+JwpYab2WsM=
+github.com/fbm3307/toolchain-common v0.0.0-20240314071034-3b543ee71d46/go.mod h1:c2JxboVI7keMD5fx5bB7LwzowFYYTwbepJhzPWSYXVs=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
@@ -208,7 +209,7 @@ func main() { // nolint:gocyclo
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-	memberClusters, err := addMemberClusters(mgr, cl, namespace, true)
+	memberClusters, err := addMemberClusters(ctx, mgr, cl, namespace, true)
 	if err != nil {
 		setupLog.Error(err, "")
 		os.Exit(1)
@@ -255,7 +256,7 @@ func main() { // nolint:gocyclo
 	}
 	if err := (&toolchainconfig.Reconciler{
 		Client:         mgr.GetClient(),
-		GetMembersFunc: commoncluster.GetMemberClusters,
+		GetMembersFunc: commoncluster.GetClusters,
 		Scheme:         mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ToolchainConfig")
@@ -267,7 +268,7 @@ func main() { // nolint:gocyclo
 		Scheme:              mgr.GetScheme(),
 		HTTPClientImpl:      &http.Client{},
 		VersionCheckManager: status.VersionCheckManager{GetGithubClientFunc: commonclient.NewGitHubClient},
-		GetMembersFunc:      commoncluster.GetMemberClusters,
+		GetMembersFunc:      commoncluster.GetClusters,
 		Namespace:           namespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ToolchainStatus")
@@ -280,7 +281,7 @@ func main() { // nolint:gocyclo
 		Namespace:      namespace,
 		Scheme:         mgr.GetScheme(),
 		SegmentClient:  segmentClient,
-		ClusterManager: capacity.NewClusterManager(commoncluster.GetMemberClusters, mgr.GetClient()),
+		ClusterManager: capacity.NewClusterManager(commoncluster.GetClusters, mgr.GetClient()),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UserSignup")
 		os.Exit(1)
@@ -293,7 +294,7 @@ func main() { // nolint:gocyclo
 		os.Exit(1)
 	}
 	// init cluster scoped member cluster clients
-	clusterScopedMemberClusters, err := addMemberClusters(mgr, cl, namespace, false)
+	clusterScopedMemberClusters, err := addMemberClusters(ctx, mgr, cl, namespace, false)
 	if err != nil {
 		setupLog.Error(err, "")
 		os.Exit(1)
@@ -335,7 +336,7 @@ func main() { // nolint:gocyclo
 	if err = (&spacecompletion.Reconciler{
 		Client:         mgr.GetClient(),
 		Namespace:      namespace,
-		ClusterManager: capacity.NewClusterManager(commoncluster.GetMemberClusters, mgr.GetClient()),
+		ClusterManager: capacity.NewClusterManager(commoncluster.GetClusters, mgr.GetClient()),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SpaceCompletion")
 		os.Exit(1)
@@ -427,8 +428,8 @@ func main() { // nolint:gocyclo
 	}
 }
 
-func addMemberClusters(mgr ctrl.Manager, cl runtimeclient.Client, namespace string, namespacedCache bool) (map[string]cluster.Cluster, error) {
-	memberConfigs, err := commoncluster.ListToolchainClusterConfigs(cl, namespace, memberClientTimeout)
+func addMemberClusters(ctx context.Context, mgr ctrl.Manager, cl runtimeclient.Client, namespace string, namespacedCache bool) (map[string]cluster.Cluster, error) {
+	memberConfigs, err := commoncluster.ListToolchainClusterConfigs(ctx, cl, namespace, memberClientTimeout)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to get ToolchainCluster configs for members")
 	}

--- a/pkg/capacity/manager.go
+++ b/pkg/capacity/manager.go
@@ -52,7 +52,7 @@ func hasMemberREnoughResources(memberStatus toolchainv1alpha1.Member, threshold 
 	return false
 }
 
-func NewClusterManager(getMemberClusters cluster.GetMemberClustersFunc, cl runtimeclient.Client) *ClusterManager {
+func NewClusterManager(getMemberClusters cluster.GetClustersFunc, cl runtimeclient.Client) *ClusterManager {
 	return &ClusterManager{
 		getMemberClusters: getMemberClusters,
 		client:            cl,
@@ -60,7 +60,7 @@ func NewClusterManager(getMemberClusters cluster.GetMemberClustersFunc, cl runti
 }
 
 type ClusterManager struct {
-	getMemberClusters cluster.GetMemberClustersFunc
+	getMemberClusters cluster.GetClustersFunc
 	client            runtimeclient.Client
 	lastUsed          string
 }
@@ -142,7 +142,7 @@ func (b *ClusterManager) GetOptimalTargetCluster(ctx context.Context, optimalClu
 // If the preferred target cluster was not provided or not available, but a list of clusterRoles was provided, then it filters only the available clusters matching all those roles.
 // If no cluster roles were provided then it returns all the available clusters.
 // The function returns a slice with an empty string if not optimal target clusters where found.
-func getOptimalTargetClusters(preferredCluster string, getMemberClusters cluster.GetMemberClustersFunc, clusterRoles []string, conditions ...cluster.Condition) []string {
+func getOptimalTargetClusters(preferredCluster string, getMemberClusters cluster.GetClustersFunc, clusterRoles []string, conditions ...cluster.Condition) []string {
 	emptyTargetCluster := []string{""}
 	// Automatic cluster selection based on cluster readiness
 	members := getMemberClusters(append(conditions, cluster.Ready)...)

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -14,7 +14,7 @@ import (
 
 type GetMemberClusterFunc func(clusters ...ClientForCluster) func(name string) (*cluster.CachedToolchainCluster, bool)
 
-func NewGetMemberClusters(memberClusters ...*cluster.CachedToolchainCluster) cluster.GetMemberClustersFunc {
+func NewGetMemberClusters(memberClusters ...*cluster.CachedToolchainCluster) cluster.GetClustersFunc {
 	return func(conditions ...cluster.Condition) []*cluster.CachedToolchainCluster {
 		clusters := map[string]*cluster.CachedToolchainCluster{}
 		for _, memberCluster := range memberClusters {


### PR DESCRIPTION
Adding a new common function GetClusters() to fetch the clusters from cache as we have dropped the cluster type as per changes in toolchain-common

Related PRs
Toolchain-common - https://github.com/codeready-toolchain/toolchain-common/pull/372
Paired -Toolchain-e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/921