### PR TITLE
Increase appstudio pods quota

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/cluster.yaml
@@ -132,7 +132,7 @@ parameters:
 - name: DEPLOYMENT_QUOTA
   value: "30"
 - name: POD_QUOTA
-  value: "300"
+  value: "600"
 - name: ROUTE_QUOTA
   value: "30"
 - name: SERVICE_QUOTA


### PR DESCRIPTION
Even though this quota is named `for-<some-tenant>-deployments` implying that it only affects deployments, this is not the case and it does block the build. This quota cap the number of pods in a namespace, including the completed ones.

Not only the build tasks can no longer start, it looks like this does block some kind of pod cleanup because as soon as I increased the quota, not only builds started but overall number of pods started to go down after slightly increasing over 300.

PipelineRun usually have about 10 tasks or more so 300 pods, not counting deployments, allows maximum 30 PipelineRun which is too low. The pod counts includes the completed ones so since PipelineRun are not deleted right after completion, we need to increase that quota to not end up in this situation all the time.

The final number will need fine tuning but for now increase it to 600 as I experimented on tenant's namespace where the issue was seen and 600 allowed to not get the issue again until now.

[KONFLUX-2454](https://issues.redhat.com//browse/KONFLUX-2454)