### PR TITLE
Use `go list` in the go.mod replacements check to improve reliability

### DIFF
--- a/.github/workflows/ci-check-gomod.yml
+++ b/.github/workflows/ci-check-gomod.yml
@@ -16,7 +16,7 @@ jobs:
     
     - name: check
       run: |
-        if [[ -n "$(grep 'replace github.com/codeready-toolchain/.*' go.mod || true)" ]]; then
-          echo "forbidden replacement in go.mod"
+        if go list -m all | grep --color=never -E 'github.com/(codeready-toolchain|kubesaw)/.+\s*=>'; then
+          echo "the above replacement(s) are not allowed in go.mod"
           exit 1
         fi

--- a/.github/workflows/ci-check-gomod.yml
+++ b/.github/workflows/ci-check-gomod.yml
@@ -13,10 +13,5 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    
     - name: check
-      run: |
-        if go list -m all | grep --color=never -E 'github.com/(codeready-toolchain|kubesaw)/.+\s*=>'; then
-          echo "the above replacement(s) are not allowed in go.mod"
-          exit 1
-        fi
+      uses: codeready-toolchain/toolchain-cicd/gomod-check@master


### PR DESCRIPTION
Use `go list -m all` to get us the full machine-readable list of modules instead of manually parsing go.mod using grep to correctly check forbidden replacements in the go.mod.