### PR TITLE
Increase appstudio tier pvc quota

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -66,7 +66,7 @@ objects:
       limits.ephemeral-storage: 50Gi
       requests.storage: 200Gi
       requests.ephemeral-storage: 50Gi
-      count/persistentvolumeclaims: "30"
+      count/persistentvolumeclaims: "90"
 - apiVersion: v1
   kind: ResourceQuota
   metadata:


### PR DESCRIPTION
Most of on boarded teams did hit this quota which I change manually to 90 in all the cases and it has been working so far. Do the change in the default tier otherwise we would need to promote every team to appstudiolarge tier.