### PR TITLE
Increase appstudiolarge tier quotas

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/cluster.yaml
@@ -140,4 +140,4 @@ parameters:
 - name: CONFIGMAP_QUOTA
   value: "100"
 - name: SECRET_QUOTA
-  value: "100"
+  value: "300"

--- a/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -52,9 +52,9 @@ objects:
     scopes:
     - Terminating
     hard:
-      limits.cpu: "120"
+      limits.cpu: ${CPU_BUILD_LIMIT}
       limits.memory: ${MEMORY_BUILD_LIMIT}
-      requests.cpu: "12"
+      requests.cpu: ${CPU_BUILD_REQUEST}
       requests.memory: ${MEMORY_BUILD_REQUEST}
 - apiVersion: v1
   kind: ResourceQuota
@@ -277,6 +277,10 @@ parameters:
   value: "32Gi"
 - name: MEMORY_REQUEST
   value: "32Gi"
+- name: CPU_BUILD_LIMIT
+  value: "120"
+- name: CPU_BUILD_REQUEST
+  value: "12"
 - name: MEMORY_BUILD_LIMIT
   value: "128Gi"
 - name: MEMORY_BUILD_REQUEST

--- a/deploy/templates/nstemplatetiers/appstudiolarge/based_on_tier.yaml
+++ b/deploy/templates/nstemplatetiers/appstudiolarge/based_on_tier.yaml
@@ -11,4 +11,12 @@ parameters:
 - name: CONFIGMAP_QUOTA
   value: "300"
 - name: SECRET_QUOTA
-  value: "300"
+  value: "900"
+- name: CPU_BUILD_LIMIT
+  value: "480"
+- name: CPU_BUILD_REQUEST
+  value: "48"
+- name: MEMORY_BUILD_LIMIT
+  value: "512Gi"
+- name: MEMORY_BUILD_REQUEST
+  value: "128Gi"


### PR DESCRIPTION
Change the default appstudio tier to parametrize all the compute-build values(cpu request/limit) and increase the large tier compute-build quotas. The numbers are quite high but one typical build-container task/pod have a limits of 20GiB and 18 cpus.

Also increase the secret quota for both tiers

[KFLUXINFRA-508](https://issues.redhat.com//browse/KFLUXINFRA-508)