### PR TITLE
KUBESAW-43: Replace the special ToolchainClusterCondition with the standard toolchain Condition

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
@@ -81,16 +81,14 @@ spec:
               conditions:
                 description: Conditions is an array of current cluster conditions.
                 items:
-                  description: ToolchainClusterCondition describes current state of
-                    a cluster.
                   properties:
-                    lastProbeTime:
-                      description: Last time the condition was checked.
-                      format: date-time
-                      type: string
                     lastTransitionTime:
                       description: Last time the condition transit from one status
                         to another.
+                      format: date-time
+                      type: string
+                    lastUpdatedTime:
+                      description: Last time the condition was updated
                       format: date-time
                       type: string
                     message:
@@ -104,10 +102,9 @@ spec:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cluster condition, Ready or Offline.
+                      description: Type of condition
                       type: string
                   required:
-                  - lastProbeTime
                   - status
                   - type
                   type: object

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
@@ -372,16 +372,14 @@ spec:
                               description: Conditions is an array of current cluster
                                 conditions.
                               items:
-                                description: ToolchainClusterCondition describes current
-                                  state of a cluster.
                                 properties:
-                                  lastProbeTime:
-                                    description: Last time the condition was checked.
-                                    format: date-time
-                                    type: string
                                   lastTransitionTime:
                                     description: Last time the condition transit from
                                       one status to another.
+                                    format: date-time
+                                    type: string
+                                  lastUpdatedTime:
+                                    description: Last time the condition was updated
                                     format: date-time
                                     type: string
                                   message:
@@ -397,11 +395,9 @@ spec:
                                       False, Unknown.
                                     type: string
                                   type:
-                                    description: Type of cluster condition, Ready
-                                      or Offline.
+                                    description: Type of condition
                                     type: string
                                 required:
-                                - lastProbeTime
                                 - status
                                 - type
                                 type: object

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1836,7 +1836,7 @@ func cachedToolchainCluster(cl runtimeclient.Client, name string, status corev1.
 		Client: cl,
 		ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
 			Conditions: []toolchainv1alpha1.Condition{{
-				Type:            toolchainv1alpha1.ToolchainClusterReady,
+				Type:            toolchainv1alpha1.ConditionReady,
 				Status:          status,
 				LastUpdatedTime: &lastProbeTime,
 			}},

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1835,10 +1835,9 @@ func cachedToolchainCluster(cl runtimeclient.Client, name string, status corev1.
 		},
 		Client: cl,
 		ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
-			Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
+			Conditions: []toolchainv1alpha1.Condition{{
 				Type:            toolchainv1alpha1.ToolchainClusterReady,
 				Status:          status,
-				LastProbeTime:   lastProbeTime,
 				LastUpdatedTime: &lastProbeTime,
 			}},
 		},

--- a/controllers/toolchainstatus/toolchainstatus_controller_test.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller_test.go
@@ -1835,10 +1835,10 @@ func cachedToolchainCluster(cl runtimeclient.Client, name string, status corev1.
 		},
 		Client: cl,
 		ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
-			Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
-				Type:          toolchainv1alpha1.ToolchainClusterReady,
-				Status:        status,
-				LastProbeTime: lastProbeTime,
+			Conditions: []toolchainv1alpha1.Condition{{
+				Type:               toolchainv1alpha1.ToolchainClusterReady,
+				Status:             status,
+				LastTransitionTime: lastProbeTime,
 			}},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240514101749-1ceadb6ea36b
@@ -116,5 +116,4 @@ require (
 )
 
 go 1.20
-
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881
-
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240507023248-73662d6db2c5
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240513103602-0cabe6c279c8
@@ -117,3 +116,4 @@ require (
 )
 
 go 1.20
+

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240514101749-1ceadb6ea36b

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e
-
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240514101749-1ceadb6ea36b
@@ -117,3 +116,5 @@ require (
 )
 
 go 1.20
+
+

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,9 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8
-
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881
 require (
-	github.com/codeready-toolchain/api v0.0.0-20240424103940-03edc96d88fb
+	github.com/codeready-toolchain/api v0.0.0-20240425165440-d0a6da0060a5
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240424171146-581ea6502cad
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
@@ -117,3 +115,5 @@ require (
 )
 
 go 1.20
+
+

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/codeready-toolchain/host-operator
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69
-
 require (
-	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20240514101749-1ceadb6ea36b
+	github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20240530121312-98aad712838f
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v1.2.3
@@ -115,5 +113,3 @@ require (
 )
 
 go 1.20
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240530072112-7bc983ca29b0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/codeready-toolchain/host-operator
 
 replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240514101749-1ceadb6ea36b
@@ -117,3 +116,4 @@ require (
 
 go 1.20
 
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240530072112-7bc983ca29b0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/codeready-toolchain/host-operator
 
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8
+
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240424103940-03edc96d88fb
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20240424171146-581ea6502cad

--- a/go.sum
+++ b/go.sum
@@ -189,10 +189,10 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8 h1:PVui6JJ8qnZJwO4tZMmNbS6j8iOIRyhNMt6XJfP2Oos=
-github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8/go.mod h1:XM/GvevqWYzwWrIqEkRyoImGnRY+R6uIyVJ5mkVqO7k=
-github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967 h1:6NHrU9WNkeCnAniKFUb6YhUxKkccYidj5fD/yY912y0=
-github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881 h1:nIXhnL4y4YUIvUlYUcVWBUeItv+xoNZHOh/81czSlww=
+github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881/go.mod h1:iPQiIf6G5qBnt6gMIR1GhThqPmvMST/QmotIrm15E2A=
+github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf h1:s2k7giZJOHA3EYRya8EqqbkUl4vHJYG2s5g2XL4Eezo=
+github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -136,10 +136,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20240424103940-03edc96d88fb h1:YvEVAetaNYLAyuwO8AmKTtWD9M7SZPhbBzTVMXhrGas=
-github.com/codeready-toolchain/api v0.0.0-20240424103940-03edc96d88fb/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240424171146-581ea6502cad h1:ka0mIrFO8+0H4uIgfhgCGh1lmRjGndRUYNEEV8O7fkQ=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20240424171146-581ea6502cad/go.mod h1:4BqdcAO16K/+YmPbn5XmTKOU4UUyuQPlge7ms9F1NsU=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -193,6 +189,10 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
+github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8 h1:PVui6JJ8qnZJwO4tZMmNbS6j8iOIRyhNMt6XJfP2Oos=
+github.com/fbm3307/toolchain-common v0.0.0-20240425102648-bac35a1b02f8/go.mod h1:XM/GvevqWYzwWrIqEkRyoImGnRY+R6uIyVJ5mkVqO7k=
+github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967 h1:6NHrU9WNkeCnAniKFUb6YhUxKkccYidj5fD/yY912y0=
+github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac h1:WbOV613ZMtm/wzx1OOoDz7SiNgzlgN4KGusVL8vnMig=
-github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac/go.mod h1:D/yFnVW7yM+OhIMDY5H/7jGZGlKIgaeTkiA4F5DIc4g=
+github.com/fbm3307/toolchain-common v0.0.0-20240530072112-7bc983ca29b0 h1:bw/xnuqXBl9nmaL+5I+p5WxnBsMocSuRBDeu+K9oCUs=
+github.com/fbm3307/toolchain-common v0.0.0-20240530072112-7bc983ca29b0/go.mod h1:D/yFnVW7yM+OhIMDY5H/7jGZGlKIgaeTkiA4F5DIc4g=
 github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69 h1:WiMpRk3NnsEeCVzQzD2gzc2EFx15eWCrkdfmGeG2ltU=
 github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=

--- a/go.sum
+++ b/go.sum
@@ -189,10 +189,10 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881 h1:nIXhnL4y4YUIvUlYUcVWBUeItv+xoNZHOh/81czSlww=
-github.com/fbm3307/toolchain-common v0.0.0-20240502101719-12e05e25f881/go.mod h1:iPQiIf6G5qBnt6gMIR1GhThqPmvMST/QmotIrm15E2A=
-github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf h1:s2k7giZJOHA3EYRya8EqqbkUl4vHJYG2s5g2XL4Eezo=
-github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e h1:0ebS34Y5ft2u7ixBqjWWxSewjnKUnaPUE5aNW88njho=
+github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e/go.mod h1:ykixqKPvSfpASeqwV2U5UASl1J566MfsQz3eCUmgwZc=
+github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f h1:SU/YIxkyXbvXfZMLsxdHb71X0Bs3WHe6vfev9N25VUI=
+github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -189,10 +189,10 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e h1:Qkw0QZ3//P6pLL+9JpFSXJe62Inz4kH2PF+ssXzhIlg=
-github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e/go.mod h1:edqvWcRWzUJzCR7C5jDgK9/E4uitru0DhrFSxSunAjI=
-github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7 h1:iH+MPU2iq6KN6v161Y0VrlEfp1gyz6zEBDjFkGDwHRU=
-github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70 h1:bXkUar0zqhEjnWkrmcWAuRVh4Kzl5Og//XJ2APnFjOI=
+github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70/go.mod h1:CEYP+kvf4ckNVUocGJHTQNKAOwg21Dy2JtEUlYqSGic=
+github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b h1:fF3V9dFDmZCzbV2rWkII7b/LJ9hj5yL2zR0vdaXzeK4=
+github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -189,10 +189,10 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e h1:0ebS34Y5ft2u7ixBqjWWxSewjnKUnaPUE5aNW88njho=
-github.com/fbm3307/toolchain-common v0.0.0-20240514062344-9c5a21b4313e/go.mod h1:ykixqKPvSfpASeqwV2U5UASl1J566MfsQz3eCUmgwZc=
-github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f h1:SU/YIxkyXbvXfZMLsxdHb71X0Bs3WHe6vfev9N25VUI=
-github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e h1:Qkw0QZ3//P6pLL+9JpFSXJe62Inz4kH2PF+ssXzhIlg=
+github.com/fbm3307/toolchain-common v0.0.0-20240515064413-27853532075e/go.mod h1:edqvWcRWzUJzCR7C5jDgK9/E4uitru0DhrFSxSunAjI=
+github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7 h1:iH+MPU2iq6KN6v161Y0VrlEfp1gyz6zEBDjFkGDwHRU=
+github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -189,10 +189,10 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70 h1:bXkUar0zqhEjnWkrmcWAuRVh4Kzl5Og//XJ2APnFjOI=
-github.com/fbm3307/toolchain-common v0.0.0-20240527085525-a1bc979c9c70/go.mod h1:CEYP+kvf4ckNVUocGJHTQNKAOwg21Dy2JtEUlYqSGic=
-github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b h1:fF3V9dFDmZCzbV2rWkII7b/LJ9hj5yL2zR0vdaXzeK4=
-github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac h1:WbOV613ZMtm/wzx1OOoDz7SiNgzlgN4KGusVL8vnMig=
+github.com/fbm3307/toolchain-common v0.0.0-20240529065824-3c5d4e2aceac/go.mod h1:D/yFnVW7yM+OhIMDY5H/7jGZGlKIgaeTkiA4F5DIc4g=
+github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69 h1:WiMpRk3NnsEeCVzQzD2gzc2EFx15eWCrkdfmGeG2ltU=
+github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,10 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7 h1:o5JLcHCVS1BlZevw2mh1mH+iKwn9fLUrT1Ek8NFjvPY=
+github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20240530121312-98aad712838f h1:2qfRfyh7wfEnnfxrUtQeQrvhzWlkBCN0B/UXv1YUMiA=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20240530121312-98aad712838f/go.mod h1:cyHrUfvBYEtsf+FbqQYmR9y0AQi9QAVtM3SUWLA5bd4=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -189,10 +193,6 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchain-common v0.0.0-20240530072112-7bc983ca29b0 h1:bw/xnuqXBl9nmaL+5I+p5WxnBsMocSuRBDeu+K9oCUs=
-github.com/fbm3307/toolchain-common v0.0.0-20240530072112-7bc983ca29b0/go.mod h1:D/yFnVW7yM+OhIMDY5H/7jGZGlKIgaeTkiA4F5DIc4g=
-github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69 h1:WiMpRk3NnsEeCVzQzD2gzc2EFx15eWCrkdfmGeG2ltU=
-github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -88,7 +88,7 @@ func NewGetMemberCluster(ok bool, status corev1.ConditionStatus, modifiers ...Mo
 				Client: cl,
 				ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
 					Conditions: []toolchainv1alpha1.Condition{{
-						Type:   toolchainv1alpha1.ToolchainClusterReady,
+						Type:   toolchainv1alpha1.ConditionReady,
 						Status: status,
 					}},
 				},

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -87,7 +87,7 @@ func NewGetMemberCluster(ok bool, status corev1.ConditionStatus, modifiers ...Mo
 				},
 				Client: cl,
 				ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
-					Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
+					Conditions: []toolchainv1alpha1.Condition{{
 						Type:   toolchainv1alpha1.ToolchainClusterReady,
 						Status: status,
 					}},


### PR DESCRIPTION
This is to replace the special ToolchainClusterCondition with the standard toolchain Condition

This is Related to Change in

- API - https://github.com/codeready-toolchain/api/pull/416
- Toolchain-Common - https://github.com/codeready-toolchain/toolchain-common/pull/391
- Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/560
- Toolchain-E2E - https://github.com/codeready-toolchain/toolchain-e2e/pull/955
- KSCTL - https://github.com/kubesaw/ksctl/pull/38

Only change is updating the dependency of API and toolchain-common

- Registration-Service - https://github.com/codeready-toolchain/registration-service/pull/424
- Sandbox-SRE - https://github.com/codeready-toolchain/sandbox-sre/pull/1706