### PR TITLE
add test for 'kubesaw' prefix

### DIFF
--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -3929,7 +3929,8 @@ func TestUsernameWithForbiddenPrefix(t *testing.T) {
 	require.Len(t, config.Users().ForbiddenUsernamePrefixes(), 5)
 	names := []string{"-Bob", "-Dave", "Linda", ""}
 
-	for _, prefix := range config.Users().ForbiddenUsernamePrefixes() {
+	testingPrefixes := append(config.Users().ForbiddenUsernamePrefixes(), "kubesaw")
+	for _, prefix := range testingPrefixes {
 		userSignup := commonsignup.NewUserSignup(
 			commonsignup.ApprovedManually(),
 			commonsignup.WithTargetCluster("east"))

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -3929,7 +3929,11 @@ func TestUsernameWithForbiddenPrefix(t *testing.T) {
 	require.Len(t, config.Users().ForbiddenUsernamePrefixes(), 5)
 	names := []string{"-Bob", "-Dave", "Linda", ""}
 
-	testingPrefixes := append(config.Users().ForbiddenUsernamePrefixes(), "kubesaw")
+	testingPrefixes := config.Users().ForbiddenUsernamePrefixes()
+	// As 'kube' is already a forbidden prefix, so "kubesaw" is covered
+	// but testing it explicitly would prevent future changes from breaking this behavior.
+	testingPrefixes = append(testingPrefixes, "kubesaw")
+
 	for _, prefix := range testingPrefixes {
 		userSignup := commonsignup.NewUserSignup(
 			commonsignup.ApprovedManually(),


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/ASC-531

As 'kube' is already a forbidden prefix, there is no need of explicitly add 'kubesaw'.
Adding it in test to prevent future changes to break this behavior.

Signed-off-by: Francesco Ilario <filario@redhat.com>
