### PR TITLE
Role and RoleBinding for SecretStore and ExternalSecret CRs

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -227,7 +227,6 @@ objects:
     - update
     - patch
     - delete
-
 # RoleBinding that grants limited CRUD permissions to the User
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -242,6 +241,41 @@ objects:
   - kind: User
     name: ${USERNAME}
 # RoleBinding that grants view permissions to the User
+
+# Role(s) and RoleBinding(s) that grant CRUD permissions on SecretStore and ExternalSecret CRs to the user's SA
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-admin-user-actions-externalsecrets
+  rules:
+  - apiGroups:
+    - external-secrets.io/v1beta1
+    resources:
+    - SecretStore
+    - ExternalSecret
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+
+# RoleBinding that grants access to SecretStore and ExternalSecret to the User
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-admin-${USERNAME}-actions-user
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: appstudio-admin-user-actions-externalsecrets
+  subjects:
+  - kind: User
+    name: ${USERNAME}
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -268,7 +268,7 @@ objects:
   kind: RoleBinding
   metadata:
     namespace: ${NAMESPACE}
-    name: appstudio-admin-${USERNAME}-actions-user
+    name: appstudio-admin-${USERNAME}-actions-user-externalsecrets
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -227,6 +227,20 @@ objects:
     - update
     - patch
     - delete
+  # Allow CRUD permissions on SecretStore and ExternalSecret CRs to the user's SA
+  - apiGroups:
+    - external-secrets.io/v1beta1
+    resources:
+    - secretstores
+    - externalsecrets
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
 # RoleBinding that grants limited CRUD permissions to the User
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
@@ -241,41 +255,6 @@ objects:
   - kind: User
     name: ${USERNAME}
 # RoleBinding that grants view permissions to the User
-
-# Role(s) and RoleBinding(s) that grant CRUD permissions on SecretStore and ExternalSecret CRs to the user's SA
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    namespace: ${NAMESPACE}
-    name: appstudio-admin-user-actions-externalsecrets
-  rules:
-  - apiGroups:
-    - external-secrets.io/v1beta1
-    resources:
-    - SecretStore
-    - ExternalSecret
-    verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - patch
-    - delete
-
-# RoleBinding that grants access to SecretStore and ExternalSecret to the User
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    namespace: ${NAMESPACE}
-    name: appstudio-admin-${USERNAME}-actions-user-externalsecrets
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: appstudio-admin-user-actions-externalsecrets
-  subjects:
-  - kind: User
-    name: ${USERNAME}
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:


### PR DESCRIPTION
This change adds a Role and RoleBinding to the tenant use to CRUD on SecretStore and ExternalSecret CRs provided by external-secrets.io

This is meant for testing if this can enable tenants to create SecretStore and ExternalSecret from their own self-hosted or managed secrets backend 

Paired PR in `codeready-toolchain/toolchain-e2e` - https://github.com/codeready-toolchain/toolchain-e2e/pull/982