### PR TITLE
Allow users to manage ImageRepository objects with the same access level as Components

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -16,6 +16,7 @@ objects:
     resources:
     - applications
     - components
+    - imagerepositories
     - componentdetectionqueries
     verbs:
     - get

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_contributor.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_contributor.yaml
@@ -17,6 +17,7 @@ objects:
     resources:
     - applications
     - components
+    - imagerepositories
     - componentdetectionqueries
     verbs:
     - get

--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_maintainer.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_maintainer.yaml
@@ -17,6 +17,7 @@ objects:
     resources:
     - applications
     - components
+    - imagerepositories
     - componentdetectionqueries
     verbs:
     - get


### PR DESCRIPTION
Since we are switching to the new way of managing image repositories in Konflux via a separate `ImageRepositopry` resource instead of `Component` annotations, we need to grant users permissions to work with the new resource. `ImageRepositopry` should be created together with the `Component` (by UI) in case user wants to use default image repository option.
The permissions are set in sync with the `Component` permissions of each role.

[STONEBLD-2473](https://issues.redhat.com/browse/STONEBLD-2473)