### PR TITLE
Remove version from apiGroups

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -229,7 +229,7 @@ objects:
     - delete
   # Allow CRUD permissions on SecretStore and ExternalSecret CRs to the user's SA
   - apiGroups:
-    - external-secrets.io/v1beta1
+    - external-secrets.io
     resources:
     - secretstores
     - externalsecrets


### PR DESCRIPTION
Intended role was not applied properly due to including version in apiGroups.
Removing the same as part of this PR

Paired PR - https://github.com/codeready-toolchain/toolchain-e2e/pull/988