### PR TITLE
Escape html when setting message content for notifications

### DIFF
--- a/controllers/notification/mailgun_notification_delivery_service.go
+++ b/controllers/notification/mailgun_notification_delivery_service.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"context"
 	"fmt"
+	"html"
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -114,7 +115,7 @@ func (s *MailgunNotificationDeliveryService) Send(notification *toolchainv1alpha
 		message.SetReplyTo(s.ReplyToEmail)
 	}
 
-	message.SetHtml(body)
+	message.SetHtml(html.EscapeString(body))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()


### PR DESCRIPTION
This simple change should fix the issue with truncated notification content.