### PR TITLE
Increase quotas in appstudio and appstudiolarge

### DIFF
--- a/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/deploy/templates/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -64,7 +64,7 @@ objects:
   spec:
     hard:
       limits.ephemeral-storage: 50Gi
-      requests.storage: 200Gi
+      requests.storage: ${REQUEST_STORAGE}
       requests.ephemeral-storage: 50Gi
       count/persistentvolumeclaims: "${COUNT_PVC}"
 - apiVersion: v1
@@ -280,10 +280,12 @@ parameters:
 - name: CPU_BUILD_LIMIT
   value: "120"
 - name: CPU_BUILD_REQUEST
-  value: "12"
+  value: "60"
 - name: MEMORY_BUILD_LIMIT
   value: "128Gi"
 - name: MEMORY_BUILD_REQUEST
   value: "64Gi"
 - name: COUNT_PVC
   value: "90"
+- name: REQUEST_STORAGE
+  value: "200Gi"

--- a/deploy/templates/nstemplatetiers/appstudiolarge/based_on_tier.yaml
+++ b/deploy/templates/nstemplatetiers/appstudiolarge/based_on_tier.yaml
@@ -15,10 +15,12 @@ parameters:
 - name: CPU_BUILD_LIMIT
   value: "480"
 - name: CPU_BUILD_REQUEST
-  value: "48"
+  value: "240"
 - name: MEMORY_BUILD_LIMIT
   value: "512Gi"
 - name: MEMORY_BUILD_REQUEST
-  value: "128Gi"
+  value: "256Gi"
 - name: COUNT_PVC
   value: "180"
+- name: REQUEST_STORAGE
+  value: "400Gi"


### PR DESCRIPTION
appstudio:
* Parametrize request storage, keep same value of 200Gi
* Set build CPU request to half of limit, i.e. 60.

appstudiolarge:
* Set request storage to double of appstudio tier, i.e. 400Gi.
* Set build CPU request to half of limit, i.e. 240.
* Set build memory request to half of limit, i.e. 256Gi.

[KFLUXINFRA-632](https://issues.redhat.com//browse/KFLUXINFRA-632)