### PR TITLE
fix: rename Service to registration-service metrics

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -188,7 +188,7 @@ objects:
   - kind: Service
     apiVersion: v1
     metadata:
-      name: regsvc-metrics
+      name: registration-service-metrics
       namespace: ${NAMESPACE}
       labels:
         provider: codeready-toolchain


### PR DESCRIPTION
keeping the name consistent with the existing
`registration-service` Service

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
