### PR TITLE
Forbid creating loadbalancer services

### DIFF
--- a/deploy/templates/nstemplatetiers/base/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/base/cluster.yaml
@@ -91,6 +91,7 @@ objects:
     quota:
       hard:
         count/services: "30"
+        services.loadbalancers: '0'
     selector:
       annotations: null
       labels:

--- a/deploy/templates/nstemplatetiers/base1ns/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/base1ns/cluster.yaml
@@ -71,6 +71,7 @@ objects:
     quota:
       hard:
         count/services: "30"
+        services.loadbalancers: '0'
     selector:
       annotations: null
       labels:


### PR DESCRIPTION
So users can't create services with type `LoadBalancer` which triggers creating a LB

Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/1004