### PR TITLE
Fix unverified UserSignup deletion metrics bug

### DIFF
--- a/controllers/usersignupcleanup/usersignup_cleanup_controller.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller.go
@@ -231,6 +231,8 @@ func validateEmailHash(userEmail, userEmailHash string) bool {
 	return hash.EncodeString(userEmail) == userEmailHash
 }
 
+// deleteSignupUnverifiedRetentionPeriod deletes specified Usersignup and increments metrics if applicable.
+// metrics incremented - UserSignupDeletedWithInitiatingVerificationTotal and UserSignupDeletedWithoutInitiatingVerificationTotal
 func (r *Reconciler) deleteSignupUnverifiedRetentionPeriod(ctx context.Context, userSignup *toolchainv1alpha1.UserSignup) error {
 	// before deleting the resource, we want to "remember" if the user triggered a phone verification or not,
 	// based on the presence of the `toolchain.dev.openshift.com/verification-code` annotation

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller.go
@@ -3,10 +3,11 @@ package usersignupcleanup
 import (
 	"context"
 	"fmt"
-	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
-	"github.com/redhat-cop/operator-utils/pkg/util"
 	"strconv"
 	"time"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
@@ -97,7 +98,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 			if createdTime.Time.Before(unverifiedThreshold) {
 				reqLogger.Info("Deleting UserSignup due to exceeding unverified retention period")
-				return reconcile.Result{}, r.DeleteUserSignup(ctx, instance)
+				return reconcile.Result{}, r.deleteSignupUnverifiedRetentionPeriod(ctx, instance)
 			}
 
 			// Requeue this for reconciliation after the time has passed between the last active time
@@ -230,12 +231,29 @@ func validateEmailHash(userEmail, userEmailHash string) bool {
 	return hash.EncodeString(userEmail) == userEmailHash
 }
 
-// DeleteUserSignup deletes the specified UserSignup
-func (r *Reconciler) DeleteUserSignup(ctx context.Context, userSignup *toolchainv1alpha1.UserSignup) error {
+func (r *Reconciler) deleteSignupUnverifiedRetentionPeriod(ctx context.Context, userSignup *toolchainv1alpha1.UserSignup) error {
 	// before deleting the resource, we want to "remember" if the user triggered a phone verification or not,
 	// based on the presence of the `toolchain.dev.openshift.com/verification-code` annotation
 	_, phoneVerificationTriggered := userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]
 
+	err := r.DeleteUserSignup(ctx, userSignup)
+	if err != nil {
+		return err
+	}
+
+	// increment the appropriate counter, based on whether the phone verification was triggered or not
+	if phoneVerificationTriggered {
+		metrics.UserSignupDeletedWithInitiatingVerificationTotal.Inc()
+	} else {
+		metrics.UserSignupDeletedWithoutInitiatingVerificationTotal.Inc()
+	}
+	logger := log.FromContext(ctx)
+	logger.Info("incremented counter", "name", userSignup.Name, "phone verification triggered", phoneVerificationTriggered)
+	return err
+}
+
+// DeleteUserSignup deletes the specified UserSignup
+func (r *Reconciler) DeleteUserSignup(ctx context.Context, userSignup *toolchainv1alpha1.UserSignup) error {
 	propagationPolicy := metav1.DeletePropagationForeground
 	err := r.Client.Delete(ctx, userSignup, &runtimeclient.DeleteOptions{
 		PropagationPolicy: &propagationPolicy,
@@ -246,12 +264,5 @@ func (r *Reconciler) DeleteUserSignup(ctx context.Context, userSignup *toolchain
 
 	logger := log.FromContext(ctx)
 	logger.Info("Deleted UserSignup", "name", userSignup.Name)
-	// increment the appropriate counter, based whether the phone verification was triggered or not
-	if phoneVerificationTriggered {
-		metrics.UserSignupDeletedWithInitiatingVerificationTotal.Inc()
-	} else {
-		metrics.UserSignupDeletedWithoutInitiatingVerificationTotal.Inc()
-	}
-	logger.Info("incremented counter", "name", userSignup.Name, "phone verification triggered", phoneVerificationTriggered)
 	return nil
 }

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -104,7 +104,7 @@ func TestUserCleanup(t *testing.T) {
 		require.ErrorAs(t, err, &statusErr)
 		require.Equal(t, fmt.Sprintf("usersignups.toolchain.dev.openshift.com \"%s\" not found", key.Name), statusErr.Error())
 		// and verify the metrics
-		assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithInitiatingVerificationTotal))    // incremented
+		assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithInitiatingVerificationTotal))    // unchanged
 		assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithoutInitiatingVerificationTotal)) // unchanged
 	})
 

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -103,6 +103,9 @@ func TestUserCleanup(t *testing.T) {
 		statusErr := &apierrors.StatusError{}
 		require.ErrorAs(t, err, &statusErr)
 		require.Equal(t, fmt.Sprintf("usersignups.toolchain.dev.openshift.com \"%s\" not found", key.Name), statusErr.Error())
+		// and verify the metrics
+		assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithInitiatingVerificationTotal))    // incremented
+		assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithoutInitiatingVerificationTotal)) // unchanged
 	})
 
 	t.Run("test that an old, unverified UserSignup is deleted", func(t *testing.T) {
@@ -127,6 +130,9 @@ func TestUserCleanup(t *testing.T) {
 		statusErr := &apierrors.StatusError{}
 		require.ErrorAs(t, err, &statusErr)
 		require.Equal(t, fmt.Sprintf("usersignups.toolchain.dev.openshift.com \"%s\" not found", key.Name), statusErr.Error())
+		// and verify the metrics
+		assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithInitiatingVerificationTotal))    // incremented
+		assert.Equal(t, float64(1), promtestutil.ToFloat64(metrics.UserSignupDeletedWithoutInitiatingVerificationTotal)) // unchanged
 
 		t.Run("deletion is not initiated twice", func(t *testing.T) {
 			alreadyDeletedSignupIgnored(t, userSignup)

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -131,8 +131,8 @@ func TestUserCleanup(t *testing.T) {
 		require.ErrorAs(t, err, &statusErr)
 		require.Equal(t, fmt.Sprintf("usersignups.toolchain.dev.openshift.com \"%s\" not found", key.Name), statusErr.Error())
 		// and verify the metrics
-		assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithInitiatingVerificationTotal))    // incremented
-		assert.Equal(t, float64(1), promtestutil.ToFloat64(metrics.UserSignupDeletedWithoutInitiatingVerificationTotal)) // unchanged
+		assert.Equal(t, float64(0), promtestutil.ToFloat64(metrics.UserSignupDeletedWithInitiatingVerificationTotal))    // unchanged
+		assert.Equal(t, float64(1), promtestutil.ToFloat64(metrics.UserSignupDeletedWithoutInitiatingVerificationTotal)) //  incremented
 
 		t.Run("deletion is not initiated twice", func(t *testing.T) {
 			alreadyDeletedSignupIgnored(t, userSignup)


### PR DESCRIPTION
The UserSignupDeletedWithInitiatingVerificationTotal and UserSignupDeletedWithoutInitiatingVerificationTotal metrics are meant for tracking signups that were deleted because the user signed up but was not approved because they did not complete the verification process within the retention period. It was found that the metrics were also being incremented when the UserSignup was deleted due to exceeding deactivated retention period too which was not intentional and makes the metric inaccurate.

This PR fixes the bug by ensuring the metrics are only incremented for the unverified deletion case.

https://issues.redhat.com/browse/SANDBOX-679