### PR TITLE
Add annotation changed predicate for Space and NSTemplateSet watch

### DIFF
--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -47,10 +47,10 @@ type Reconciler struct {
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, memberClusters map[string]cluster.Cluster) error {
 	b := ctrl.NewControllerManagedBy(mgr).
 		// watch Spaces in the host cluster
-		For(&toolchainv1alpha1.Space{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&toolchainv1alpha1.Space{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.NSTemplateTier{}},
 			handler.EnqueueRequestsFromMapFunc(MapNSTemplateTierToSpaces(r.Namespace, r.Client)),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.SpaceBinding{}},
 			handler.EnqueueRequestsFromMapFunc(MapSpaceBindingToParentAndSubSpaces(r.Client)))
 	// watch NSTemplateSets in all the member clusters

--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -47,10 +47,10 @@ type Reconciler struct {
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, memberClusters map[string]cluster.Cluster) error {
 	b := ctrl.NewControllerManagedBy(mgr).
 		// watch Spaces in the host cluster
-		For(&toolchainv1alpha1.Space{}, builder.WithPredicates(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
+		For(&toolchainv1alpha1.Space{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.NSTemplateTier{}},
 			handler.EnqueueRequestsFromMapFunc(MapNSTemplateTierToSpaces(r.Namespace, r.Client)),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
+			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.SpaceBinding{}},
 			handler.EnqueueRequestsFromMapFunc(MapSpaceBindingToParentAndSubSpaces(r.Client)))
 	// watch NSTemplateSets in all the member clusters


### PR DESCRIPTION
To properly auto-update NSTemplateSets when we enable or disable a feature for Spaces we need to watch for Space and NSTemplateSet annotations. This PR adds `AnnotationChangedPredicate` to the Space and NSTemplateSet watchers in the Space controller.

This PR should unblock https://github.com/codeready-toolchain/toolchain-e2e/pull/1008 which is currently failing because of this. I can't pair https://github.com/codeready-toolchain/toolchain-e2e/pull/1008 to this PR though because it's already paired with https://github.com/codeready-toolchain/member-operator/pull/580