### PR TITLE
Revert annotation predicate for tiertemplate

### DIFF
--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -50,7 +50,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, memberClusters map[strin
 		For(&toolchainv1alpha1.Space{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.NSTemplateTier{}},
 			handler.EnqueueRequestsFromMapFunc(MapNSTemplateTierToSpaces(r.Namespace, r.Client)),
-			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &toolchainv1alpha1.SpaceBinding{}},
 			handler.EnqueueRequestsFromMapFunc(MapSpaceBindingToParentAndSubSpaces(r.Client)))
 	// watch NSTemplateSets in all the member clusters


### PR DESCRIPTION
The annotation predicate for NSTemplateTier was added by mistake. See https://github.com/codeready-toolchain/host-operator/pull/1061#discussion_r1686637235 for details.