### PR TITLE
Add OpenShift Lightspeed CRB to base1ns

### DIFF
--- a/deploy/templates/nstemplatetiers/base1ns/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/base1ns/cluster.yaml
@@ -116,6 +116,20 @@ objects:
       labels:
         matchLabels:
           toolchain.dev.openshift.com/space: ${SPACE_NAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: osl-access-${SPACE_NAME}
+    annotations:
+      toolchain.dev.openshift.com/feature: openshift-lightspeed
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: lightspeed-operator-query-access
+  subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: ${SPACE_NAME}
 - apiVersion: toolchain.dev.openshift.com/v1alpha1
   kind: Idler
   metadata:


### PR DESCRIPTION
This ClusterRoleBinding is managed by the `openshift-lightspeed` feature. See:
```
annotations:
  toolchain.dev.openshift.com/feature: openshift-lightspeed
```
This should not affect anything until we:
- add the feature to the specific toolchain configuration
- get the OSL operator installed

Related to (not paired with!): https://github.com/codeready-toolchain/toolchain-e2e/pull/1016