### PR TITLE
add watch permissions to secrets & CMs, and view to whole Toolchain api

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -31,26 +31,11 @@ objects:
       - apiGroups:
           - toolchain.dev.openshift.com
         resources:
-          - masteruserrecords
-          - socialevents
-          - spacebindings
-          - spaces
-          - toolchainconfigs
-          - toolchainstatuses
-          - proxyplugins
-          - nstemplatetiers
+          - "*"
         verbs:
           - get
           - list
           - watch
-      - apiGroups:
-          - toolchain.dev.openshift.com
-        resources:
-          - bannedusers
-          - toolchainclusters
-        verbs:
-          - get
-          - list
       - apiGroups:
           - ""
         resources:
@@ -59,6 +44,7 @@ objects:
         verbs:
           - get
           - list
+          - watch
   - kind: RoleBinding
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:


### PR DESCRIPTION
we need to grant watch permissions to secrets so we can use controller-runtime cache to watch cache them.
I also simplified the permissions related to the Toolchain API - just simply added "view" permissions to the whole Toolchain API group

[KUBESAW-188](https://issues.redhat.com/browse/KUBESAW-188)