### PR TITLE
avoid index out-of-bounds in toolchainstatus controller

### DIFF
--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -736,7 +736,7 @@ func compareAndAssignMemberStatuses(ctx context.Context, toolchainStatus *toolch
 			member.MemberStatus = customMemberStatus(*memberStatusNotFoundCondition)
 			allOk = false
 		} else {
-			continue
+			continue // member toolchaincluster has been removed and SpaceCount is 0 so the cluster has been intentionally removed
 		}
 
 		newMembers = append(newMembers, member)


### PR DESCRIPTION
Modifying the members array while we're indexing through it with a range is an unsafe operation.  Instead, create a new array and assign it after processing all elements.