### PR TITLE
KUBESAW-170: have a unique label for our OLM based operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: kubesaw-controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,18 +11,18 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: kubesaw-controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: kubesaw-controller-manager
     annotations:
       kubectl.kubernetes.io/default-container: manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: kubesaw-controller-manager
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Have a unique label instead of default controller-manger, so that it becomes easier to perform operations to only our operators