### PR TITLE
make sure that registration-service role matches the cache

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -18,6 +18,10 @@ objects:
       name: registration-service
       namespace: ${NAMESPACE}
     rules:
+# !!! IMPORTANT !!!
+# If there is a new resource added to this role, then revisit the registration-service client cache
+# and make sure that the cache is pre-populated with all resources of this new kind.
+# See: https://github.com/codeready-toolchain/registration-service/blob/36ce810d4c4cd68dc100646e8060ec94ae846f52/cmd/main.go#L192-L204
       - apiGroups:
           - toolchain.dev.openshift.com
         resources:
@@ -31,7 +35,16 @@ objects:
       - apiGroups:
           - toolchain.dev.openshift.com
         resources:
-          - "*"
+          - masteruserrecords
+          - socialevents
+          - spacebindings
+          - spaces
+          - toolchainconfigs
+          - toolchainstatuses
+          - proxyplugins
+          - nstemplatetiers
+          - bannedusers
+          - toolchainclusters
         verbs:
           - get
           - list
@@ -40,11 +53,11 @@ objects:
           - ""
         resources:
           - secrets
-          - configmaps
         verbs:
           - get
           - list
           - watch
+# !!! IMPORTANT - see the comment above !!!
   - kind: RoleBinding
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:


### PR DESCRIPTION
https://github.com/codeready-toolchain/registration-service/pull/461#discussion_r1768083781

I'm listing the toolchain resources explicitly to match list of resources that the client cache of the registration-service is pre-populated with. Related PR https://github.com/codeready-toolchain/registration-service/pull/463