### PR TITLE
KUBESAW-187: Have similar label names in member and host

### DIFF
--- a/deploy/registration-service/registration-service.yaml
+++ b/deploy/registration-service/registration-service.yaml
@@ -7,14 +7,14 @@ objects:
     kind: ServiceAccount
     metadata:
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
       name: registration-service
       namespace: ${NAMESPACE}
   - kind: Role
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
       name: registration-service
       namespace: ${NAMESPACE}
     rules:
@@ -62,7 +62,7 @@ objects:
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
       name: registration-service
       namespace: ${NAMESPACE}
     subjects:
@@ -76,7 +76,7 @@ objects:
     apiVersion: apps/v1
     metadata:
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
       name: registration-service
       namespace: ${NAMESPACE}
     spec:
@@ -147,7 +147,7 @@ objects:
     apiVersion: v1
     metadata:
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
         run: registration-service
       name: registration-service
       namespace: ${NAMESPACE}
@@ -170,7 +170,7 @@ objects:
       name: registration-service
       namespace: ${NAMESPACE}
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
         run: registration-service
     spec:
       ports:
@@ -190,7 +190,7 @@ objects:
       name: registration-service-metrics
       namespace: ${NAMESPACE}
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
         run: registration-service
     spec:
       ports:
@@ -208,7 +208,7 @@ objects:
     apiVersion: v1
     metadata:
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
         run: registration-service
       annotations:
         haproxy.router.openshift.io/timeout: 24h
@@ -232,7 +232,7 @@ objects:
       name: api
       namespace: ${NAMESPACE}
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
         run: registration-service
     spec:
       ports:
@@ -252,7 +252,7 @@ objects:
       name: proxy-metrics-service
       namespace: ${NAMESPACE}
       labels:
-        provider: codeready-toolchain
+        toolchain.dev.openshift.com/provider: codeready-toolchain
         run: proxy-metrics
     spec:
       ports:


### PR DESCRIPTION
The label in member operator and host operator are diffferent as registration service uses a shorter name. 
this is related to https://github.com/kubesaw/ksctl/pull/79#discussion_r1781172443 and making the label same across host and member deployments

this is related to https://github.com/kubesaw/ksctl/pull/79 