### PR TITLE
KUBESAW-250: Fixing the linter error Linter for v1.63.1

### DIFF
--- a/controllers/space/space_controller.go
+++ b/controllers/space/space_controller.go
@@ -254,7 +254,7 @@ func (r *Reconciler) ensureNSTemplateSet(ctx context.Context, space *toolchainv1
 
 		return norequeue, r.setStatusProvisioned(ctx, space)
 	default:
-		return norequeue, r.setStatusProvisioningFailed(ctx, space, fmt.Errorf(nsTmplSetReady.Message))
+		return norequeue, r.setStatusProvisioningFailed(ctx, space, fmt.Errorf("%s", nsTmplSetReady.Message))
 	}
 }
 

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -184,7 +184,7 @@ func (r *Reconciler) determineCapacityReadyState(spc *toolchainv1alpha1.SpacePro
 // It always knows this fact so returning a bool is ok, in contrast to determinMemoryUtilizationReadyState.
 func determineSpaceCountReadyState(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
 	max := spc.Spec.CapacityThresholds.MaxNumberOfSpaces
-	return max == 0 || max > uint(spc.Status.ConsumedCapacity.SpaceCount)
+	return max == 0 || max > uint(spc.Status.ConsumedCapacity.SpaceCount) // nolint:gosec
 }
 
 // determineMemoryUtilizationReadyState checks that the cluster has enough free memory. It may not be able to tell the fact
@@ -203,7 +203,7 @@ func determineMemoryUtilizationReadyState(spc *toolchainv1alpha1.SpaceProvisione
 
 	// the memory utilitzation is ok if it is below the threshold in all node types
 	for _, val := range spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole {
-		if uint(val) >= spc.Spec.CapacityThresholds.MaxMemoryUtilizationPercent {
+		if uint(val) >= spc.Spec.CapacityThresholds.MaxMemoryUtilizationPercent { // nolint:gosec
 			return corev1.ConditionFalse
 		}
 	}

--- a/controllers/toolchainconfig/toolchainconfig_controller.go
+++ b/controllers/toolchainconfig/toolchainconfig_controller.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	if syncErrs := sync.SyncMemberConfigs(ctx, toolchainConfig); len(syncErrs) > 0 {
 		for cluster, errMsg := range syncErrs {
-			err := fmt.Errorf(errMsg)
+			err := fmt.Errorf("%s", errMsg)
 			reqLogger.Error(err, "error syncing configuration to member cluster", "cluster", cluster)
 		}
 		return DefaultReconcile, r.updateSyncStatus(ctx, toolchainConfig, syncErrs, ToSyncFailure())

--- a/controllers/toolchainstatus/toolchainstatus_controller.go
+++ b/controllers/toolchainstatus/toolchainstatus_controller.go
@@ -937,7 +937,7 @@ func (s *regServiceSubstatusHandler) addRegistrationServiceHealthAndRevisionChec
 	// add the health status to the toolchainstatus
 	toolchainStatus.Status.RegistrationService.Health = healthStatus
 	if !healthValues.Alive {
-		err = fmt.Errorf(errMsgRegistrationServiceHealthStatusUnhealthy)
+		err = fmt.Errorf("%s", errMsgRegistrationServiceHealthStatusUnhealthy)
 		logger.Error(err, "registration service is unhealthy")
 		errCondition := status.NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusRegServiceNotReadyReason, err.Error())
 		toolchainStatus.Status.RegistrationService.Health.Conditions = []toolchainv1alpha1.Condition{*errCondition}

--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"strconv"
+
 	recaptcha "cloud.google.com/go/recaptchaenterprise/v2/apiv1"
 	recaptchapb "cloud.google.com/go/recaptchaenterprise/v2/apiv1/recaptchaenterprisepb"
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -36,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"strconv"
 )
 
 type StatusUpdaterFunc func(ctx context.Context, userAcc *toolchainv1alpha1.UserSignup, message string) error
@@ -610,7 +611,7 @@ func (r *Reconciler) generateCompliantUsername(
 		} else if mur.Labels[toolchainv1alpha1.MasterUserRecordOwnerLabelKey] == instance.Name {
 			// If the found MUR has the same UserID as the UserSignup, then *it* is the correct MUR -
 			// Return an error here and allow the reconcile() function to pick it up on the next loop
-			return "", fmt.Errorf(fmt.Sprintf("INFO: could not generate compliant username as MasterUserRecord with the same name [%s] and user id [%s] already exists. The next reconcile loop will pick it up.", mur.Name, instance.Name))
+			return "", fmt.Errorf("INFO: could not generate compliant username as MasterUserRecord with the same name '%s' and user id '%s' already exists. The next reconcile loop will pick it up", mur.Name, instance.Name)
 		}
 
 		if len(transformed) > maxlengthWithSuffix {
@@ -620,7 +621,7 @@ func (r *Reconciler) generateCompliantUsername(
 		}
 	}
 
-	return "", fmt.Errorf(fmt.Sprintf("unable to transform username [%s] even after 100 attempts", instance.Spec.IdentityClaims.PreferredUsername))
+	return "", fmt.Errorf("unable to transform username [%s] even after 100 attempts", instance.Spec.IdentityClaims.PreferredUsername)
 }
 
 // provisionMasterUserRecord does the work of provisioning the MasterUserRecord

--- a/main.go
+++ b/main.go
@@ -464,10 +464,10 @@ func addMemberClusters(mgr ctrl.Manager, cl runtimeclient.Client, namespace stri
 			}
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to create member cluster definition for "+memberConfig.Name)
+			return nil, fmt.Errorf("unable to create member cluster definition for '%s': %w", memberConfig.Name, err)
 		}
 		if err := mgr.Add(memberCluster); err != nil {
-			return nil, errors.Wrapf(err, "unable to add member cluster to the manager for "+memberConfig.Name)
+			return nil, fmt.Errorf("unable to add member cluster to the manager for '%s' : %w", memberConfig.Name, err)
 		}
 		// These fields need to be set when using the REST client
 		memberConfig.RestConfig.ContentConfig = rest.ContentConfig{
@@ -476,7 +476,7 @@ func addMemberClusters(mgr ctrl.Manager, cl runtimeclient.Client, namespace stri
 		}
 		restClient, err := rest.RESTClientFor(memberConfig.RestConfig)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to create member cluster rest client "+memberConfig.Name)
+			return nil, fmt.Errorf("unable to create member cluster rest client '%s' : %w", memberConfig.Name, err)
 		}
 		memberClusters[memberConfig.Name] = cluster.Cluster{
 			Config:     memberConfig,

--- a/pkg/capacity/manager.go
+++ b/pkg/capacity/manager.go
@@ -21,7 +21,7 @@ type (
 
 func hasNotReachedMaxNumberOfSpacesThreshold(counts counter.Counts) spaceProvisionerConfigPredicate {
 	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
-		numberOfSpaces := uint(counts.SpacesPerClusterCounts[spc.Spec.ToolchainCluster])
+		numberOfSpaces := uint(counts.SpacesPerClusterCounts[spc.Spec.ToolchainCluster]) // nolint:gosec
 		threshold := spc.Spec.CapacityThresholds.MaxNumberOfSpaces
 		return threshold == 0 || numberOfSpaces < threshold
 	}
@@ -45,7 +45,7 @@ func hasEnoughMemoryCapacity(status *toolchainv1alpha1.ToolchainStatus) spacePro
 func hasMemberEnoughMemoryCapacity(memberStatus toolchainv1alpha1.Member, threshold uint) bool {
 	if len(memberStatus.MemberStatus.ResourceUsage.MemoryUsagePerNodeRole) > 0 {
 		for _, usagePerNode := range memberStatus.MemberStatus.ResourceUsage.MemoryUsagePerNodeRole {
-			if uint(usagePerNode) >= threshold {
+			if uint(usagePerNode) >= threshold { // nolint:gosec
 				return false
 			}
 		}

--- a/pkg/space/space.go
+++ b/pkg/space/space.go
@@ -46,7 +46,7 @@ func NewSpaceWithFeatureToggles(userSignup *toolchainv1alpha1.UserSignup, target
 func addFeatureToggles(space *toolchainv1alpha1.Space, toggles []toolchainconfig.FeatureToggle) {
 	var winners []string
 	for _, t := range toggles {
-		weight := int(t.Weight())
+		weight := int(t.Weight()) // nolint:gosec
 		// We generate a random number between 0 and 100. If the number is equal to or lower than the weight
 		// then the feature wins.
 		// We don't use recommended crypto/rand here because we don't need crypto grade random generator


### PR DESCRIPTION
Would be upgrading to golangci-lint version 1.63.1 . This PR is to fix the [Linter error](https://github.com/codeready-toolchain/host-operator/actions/runs/12649616851/job/35246418292?pr=1116#step:5:28) which were caught as a result of upgrading the linter

Related PR -
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1116 