### PR TITLE
Updating the api dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0
-	github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80
+	github.com/codeready-toolchain/api v0.0.0-20250116110936-14cd9cc79fc6
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20250113092648-1078d683961b
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtM
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80 h1:OpZkP3OGAdrDHOb1TtHVnLSVuevEiQhOH//plnpVL/c=
-github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80/go.mod h1:DUq1ffy9Mbersdgji48i/cm9Y+6NMwAdAQJNlfOrPRo=
+github.com/codeready-toolchain/api v0.0.0-20250116110936-14cd9cc79fc6 h1:vr7dQouJ7J5MzAIemBVRVDHHFGM67+fMQSQxFSXIw+4=
+github.com/codeready-toolchain/api v0.0.0-20250116110936-14cd9cc79fc6/go.mod h1:2KYfJlFwZtiKfa5QDhQfXTFh6RyALilURWBXyfKmKso=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20250113092648-1078d683961b h1:zlLUDN9ddogCX8hzuPrIdS/YpAF8siucA5b56zGUz00=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20250113092648-1078d683961b/go.mod h1:wLXGFyEan+RJHZEEMmvTxNa2BrlizIA+4+Lsi1cyuAk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
This is to update the api dependency after removing the `tier.status.update` field

Similar PRs:
- Toolchain-Common - https://github.com/codeready-toolchain/toolchain-common/pull/448
- Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/613 
- Registration-Service - https://github.com/codeready-toolchain/registration-service/pull/495 
- Toolchain-E2E - https://github.com/codeready-toolchain/toolchain-e2e/pull/1095
- KSCTL - https://github.com/kubesaw/ksctl/pull/101