### PR TITLE
don't process NSTemplateTier that is being deleted

### DIFF
--- a/controllers/nstemplatetier/nstemplatetier_controller.go
+++ b/controllers/nstemplatetier/nstemplatetier_controller.go
@@ -7,6 +7,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
+	"github.com/redhat-cop/operator-utils/pkg/util"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -53,6 +54,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		// Error reading the object - requeue the request.
 		logger.Error(err, "unable to get the current NSTemplateTier")
 		return reconcile.Result{}, fmt.Errorf("unable to get the current NSTemplateTier: %w", err)
+	}
+	// if the NSTemplateTier is being deleted, then do nothing
+	if util.IsBeingDeleted(tier) {
+		return reconcile.Result{}, nil
 	}
 
 	_, err := toolchainconfig.GetToolchainConfig(r.Client)
@@ -211,7 +216,7 @@ func NewTTR(tierTmpl *toolchainv1alpha1.TierTemplate, nsTmplTier *toolchainv1alp
 	ttr := &toolchainv1alpha1.TierTemplateRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    tierTmpl.GetNamespace(),
-			GenerateName: newTTRName + "-",
+			GenerateName: newTTRName,
 			Labels:       labels,
 		},
 		Spec: toolchainv1alpha1.TierTemplateRevisionSpec{


### PR DESCRIPTION
don't process NSTemplateTier that is being deleted, otherwise, the controller can create TTR CRs in the reconcile that was triggered by the "delete" call.

https://redhat-internal.slack.com/archives/C06MJ2DVBU4/p1737375318490079