### PR TITLE
Try to reduce the log verbosity of the SPC controller.

### DIFF
--- a/controllers/spaceprovisionerconfig/mapper.go
+++ b/controllers/spaceprovisionerconfig/mapper.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func MapToolchainClusterToSpaceProvisionerConfigs(cl runtimeclient.Client) func(context.Context, runtimeclient.Object) []reconcile.Request {
+func mapToolchainClusterToSpaceProvisionerConfigs(cl runtimeclient.Client) func(context.Context, runtimeclient.Object) []reconcile.Request {
 	return func(ctx context.Context, obj runtimeclient.Object) []reconcile.Request {
 		if _, ok := obj.(*toolchainv1alpha1.ToolchainCluster); !ok {
 			return nil

--- a/controllers/spaceprovisionerconfig/mapper_test.go
+++ b/controllers/spaceprovisionerconfig/mapper_test.go
@@ -97,7 +97,7 @@ func TestMapToolchainClusterToSpaceProvisionerConfigs(t *testing.T) {
 		cl := test.NewFakeClient(t, spc0, spc1, spc2)
 
 		// when
-		reqs := MapToolchainClusterToSpaceProvisionerConfigs(cl)(context.TODO(), &toolchainv1alpha1.ToolchainCluster{
+		reqs := mapToolchainClusterToSpaceProvisionerConfigs(cl)(context.TODO(), &toolchainv1alpha1.ToolchainCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster1",
 				Namespace: test.HostOperatorNs,
@@ -123,7 +123,7 @@ func TestMapToolchainClusterToSpaceProvisionerConfigs(t *testing.T) {
 		}
 
 		// when
-		reqs := MapToolchainClusterToSpaceProvisionerConfigs(cl)(context.TODO(), &toolchainv1alpha1.ToolchainCluster{
+		reqs := mapToolchainClusterToSpaceProvisionerConfigs(cl)(context.TODO(), &toolchainv1alpha1.ToolchainCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "cluster1",
 				Namespace: test.HostOperatorNs,

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -28,7 +28,7 @@ type Reconciler struct {
 
 var _ reconcile.Reconciler = (*Reconciler)(nil)
 
-func GetToolchainClusterConditions(obj runtimeclient.Object) []toolchainv1alpha1.Condition {
+func getToolchainClusterConditions(obj runtimeclient.Object) []toolchainv1alpha1.Condition {
 	tc, ok := obj.(*toolchainv1alpha1.ToolchainCluster)
 	if !ok {
 		return nil
@@ -42,18 +42,18 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&toolchainv1alpha1.ToolchainCluster{},
 			handler.EnqueueRequestsFromMapFunc(mapToolchainClusterToSpaceProvisionerConfigs(r.Client)),
-			builder.WithPredicates(predicate.Or(
+			builder.WithPredicates(
 				// NOTE: this is ignoring the changes in the Spec as well as the Status.OperatorNamespace or Status.APIEndpoint
 				//
 				// The spec of the TC contains just the reference to the secret with the connection information. We're not actually
-				// interested in that change here because the SPC is not interested HOW we connect to the cluster rather IF
+				// interested in that change here because the SPC is not interested in HOW we connect to the cluster but rather IF
 				// we're connected to the cluster.
 				//
 				// For the same reason we're not actually interested in the values of the Status.OperatorNamespace or Status.APIEndpoint.
 				//
 				// So in another words, we're only interested in the change of the ready condition of the TC.
-				&toolchainpredicate.ToolchainConditionChanged{GetConditions: GetToolchainClusterConditions, Type: toolchainv1alpha1.ConditionReady},
-			)),
+				&toolchainpredicate.ToolchainConditionChanged{GetConditions: getToolchainClusterConditions, Type: toolchainv1alpha1.ConditionReady},
+			),
 		).
 		// we use the same information as the ToolchainStatus specific for the SPCs. Because memory consumption is
 		// read directly out of the member clusters using remote connections, let's look for it only once

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -6,6 +6,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/controllers/toolchainconfig"
+	toolchainpredicate "github.com/codeready-toolchain/host-operator/pkg/predicate"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -27,12 +28,32 @@ type Reconciler struct {
 
 var _ reconcile.Reconciler = (*Reconciler)(nil)
 
+func GetToolchainClusterConditions(obj runtimeclient.Object) []toolchainv1alpha1.Condition {
+	tc, ok := obj.(*toolchainv1alpha1.ToolchainCluster)
+	if !ok {
+		return nil
+	}
+	return tc.Status.Conditions
+}
+
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&toolchainv1alpha1.SpaceProvisionerConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(
 			&toolchainv1alpha1.ToolchainCluster{},
-			handler.EnqueueRequestsFromMapFunc(MapToolchainClusterToSpaceProvisionerConfigs(r.Client)),
+			handler.EnqueueRequestsFromMapFunc(mapToolchainClusterToSpaceProvisionerConfigs(r.Client)),
+			builder.WithPredicates(predicate.Or(
+				// NOTE: this is ignoring the changes in the Spec as well as the Status.OperatorNamespace or Status.APIEndpoint
+				//
+				// The spec of the TC contains just the reference to the secret with the connection information. We're not actually
+				// interested in that change here because the SPC is not interested HOW we connect to the cluster rather IF
+				// we're connected to the cluster.
+				//
+				// For the same reason we're not actually interested in the values of the Status.OperatorNamespace or Status.APIEndpoint.
+				//
+				// So in another words, we're only interested in the change of the ready condition of the TC.
+				&toolchainpredicate.ToolchainConditionChanged{GetConditions: GetToolchainClusterConditions, Type: toolchainv1alpha1.ConditionReady},
+			)),
 		).
 		// we use the same information as the ToolchainStatus specific for the SPCs. Because memory consumption is
 		// read directly out of the member clusters using remote connections, let's look for it only once

--- a/pkg/predicate/toolchainconditionchanged.go
+++ b/pkg/predicate/toolchainconditionchanged.go
@@ -58,9 +58,5 @@ func (t *ToolchainConditionChanged) Update(evt event.UpdateEvent) bool {
 
 	// we're intentionally ignoring changes to *Time fields of the conditions. If nothing else changed, those do not represent a factual
 	// change in the condition.
-	if oldCond.Status != newCond.Status || oldCond.Reason != newCond.Reason || oldCond.Message != newCond.Message {
-		return true
-	}
-
-	return false
+	return oldCond.Status != newCond.Status || oldCond.Reason != newCond.Reason || oldCond.Message != newCond.Message
 }

--- a/pkg/predicate/toolchainconditionchanged.go
+++ b/pkg/predicate/toolchainconditionchanged.go
@@ -1,0 +1,66 @@
+package predicate
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ predicate.Predicate = (*ToolchainConditionChanged)(nil)
+
+type (
+	GetToolchainConditions func(client.Object) []toolchainv1alpha1.Condition
+
+	// ToolchainConditionChanged is a predicate to check that some conditions changed in a toolchain object.
+	ToolchainConditionChanged struct {
+		// GetConditions is function used to obtain the conditions from an object. There is no generic way of
+		// doing that using the standard k8s api.
+		GetConditions GetToolchainConditions
+
+		// Type is the type of the condition to look at
+		Type toolchainv1alpha1.ConditionType
+	}
+)
+
+// Create implements predicate.Predicate.
+func (t *ToolchainConditionChanged) Create(event.CreateEvent) bool {
+	return true
+}
+
+// Delete implements predicate.Predicate.
+func (t *ToolchainConditionChanged) Delete(event.DeleteEvent) bool {
+	return true
+}
+
+// Generic implements predicate.Predicate.
+func (t *ToolchainConditionChanged) Generic(event.GenericEvent) bool {
+	return true
+}
+
+func (t *ToolchainConditionChanged) Update(evt event.UpdateEvent) bool {
+	oldConds := t.GetConditions(evt.ObjectOld)
+	newConds := t.GetConditions(evt.ObjectNew)
+
+	oldCond, oldOk := condition.FindConditionByType(oldConds, t.Type)
+	newCond, newOk := condition.FindConditionByType(newConds, t.Type)
+
+	if oldOk != newOk {
+		// the condition appeared or disappeared
+		return true
+	}
+
+	if !oldOk {
+		// neither the old nor the new version contains a condition of the required type
+		return false
+	}
+
+	// we're intentionally ignoring changes to *Time fields of the conditions. If nothing else changed, those do not represent a factual
+	// change in the condition.
+	if oldCond.Status != newCond.Status || oldCond.Reason != newCond.Reason || oldCond.Message != newCond.Message {
+		return true
+	}
+
+	return false
+}

--- a/pkg/predicate/toolchainconditionchanged_test.go
+++ b/pkg/predicate/toolchainconditionchanged_test.go
@@ -60,11 +60,37 @@ func TestToolchainConditionChangedPredicate(t *testing.T) {
 			ObjectNew: tcNew,
 		}
 
-		// when
-		result := predicate.Update(ev)
+		t.Run("update", func(t *testing.T) {
+			// when
+			result := predicate.Update(ev)
 
-		// then
-		assert.Equal(t, expectedResult, result)
+			// then
+			assert.Equal(t, expectedResult, result)
+		})
+
+		t.Run("create", func(t *testing.T) {
+			// when
+			result := predicate.Create(event.CreateEvent{Object: tcNew})
+
+			// then
+			assert.True(t, result)
+		})
+
+		t.Run("delete", func(t *testing.T) {
+			// when
+			result := predicate.Delete(event.DeleteEvent{Object: tcNew})
+
+			// then
+			assert.True(t, result)
+		})
+
+		t.Run("generic", func(t *testing.T) {
+			// when
+			result := predicate.Generic(event.GenericEvent{Object: tcNew})
+
+			// then
+			assert.True(t, result)
+		})
 	}
 
 	t.Run("ignores no change", func(t *testing.T) {
@@ -114,7 +140,12 @@ func TestToolchainConditionChangedPredicate(t *testing.T) {
 			old.Status.Conditions = nil
 		})
 	})
-
+	t.Run("ignores missing conditions", func(t *testing.T) {
+		test(t, false, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.Conditions = nil
+			old.Status.Conditions = nil
+		})
+	})
 	t.Run("detects change when condition disappears", func(t *testing.T) {
 		test(t, true, func(old, new *toolchainv1alpha1.ToolchainCluster) {
 			new.Status.Conditions = nil

--- a/pkg/predicate/toolchainconditionchanged_test.go
+++ b/pkg/predicate/toolchainconditionchanged_test.go
@@ -1,7 +1,141 @@
 package predicate
 
-import "testing"
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 func TestToolchainConditionChangedPredicate(t *testing.T) {
-	// TODO: implement
+	// given
+	blueprint := &toolchainv1alpha1.ToolchainCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tc",
+			Namespace: test.HostOperatorNs,
+		},
+		Spec: toolchainv1alpha1.ToolchainClusterSpec{
+			SecretRef: toolchainv1alpha1.LocalSecretReference{
+				Name: "secret",
+			},
+		},
+		Status: toolchainv1alpha1.ToolchainClusterStatus{
+			APIEndpoint:       "https://endpoint",
+			OperatorNamespace: "member-op-ns",
+			Conditions: []toolchainv1alpha1.Condition{
+				{
+					Type:    toolchainv1alpha1.ConditionReady,
+					Status:  corev1.ConditionTrue,
+					Reason:  "because",
+					Message: "I CAN",
+				},
+			},
+		},
+	}
+
+	predicate := ToolchainConditionChanged{
+		GetConditions: func(o client.Object) []toolchainv1alpha1.Condition {
+			return o.(*toolchainv1alpha1.ToolchainCluster).Status.Conditions
+		},
+		Type: toolchainv1alpha1.ConditionReady,
+	}
+
+	test := func(t *testing.T, expectedResult bool, updateObjects func(old, new *toolchainv1alpha1.ToolchainCluster)) {
+		t.Helper()
+
+		// given
+		tcOld := blueprint.DeepCopy()
+		tcNew := blueprint.DeepCopy()
+
+		updateObjects(tcOld, tcNew)
+
+		ev := event.UpdateEvent{
+			ObjectOld: tcOld,
+			ObjectNew: tcNew,
+		}
+
+		// when
+		result := predicate.Update(ev)
+
+		// then
+		assert.Equal(t, expectedResult, result)
+	}
+
+	t.Run("ignores no change", func(t *testing.T) {
+		test(t, false, func(old, new *toolchainv1alpha1.ToolchainCluster) {})
+	})
+
+	t.Run("ignores changes in the object meta", func(t *testing.T) {
+		test(t, false, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Annotations = map[string]string{"k": "v"}
+		})
+	})
+
+	t.Run("ignores changes in the spec", func(t *testing.T) {
+		test(t, false, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Spec.SecretRef.Name = "other"
+		})
+	})
+
+	t.Run("ignores changes in the status outside of conditions", func(t *testing.T) {
+		test(t, false, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.OperatorNamespace = "other"
+		})
+	})
+
+	t.Run("ignores change in other condition types", func(t *testing.T) {
+		test(t, false, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.Conditions = append(new.Status.Conditions, toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ConditionType("other")})
+		})
+	})
+
+	t.Run("ignores changes in the last transition time", func(t *testing.T) {
+		test(t, false, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.Conditions[0].LastTransitionTime = metav1.Now()
+		})
+	})
+
+	t.Run("ignores changes in the updated time", func(t *testing.T) {
+		test(t, false, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			time := metav1.Now()
+			new.Status.Conditions[0].LastUpdatedTime = &time
+		})
+	})
+
+	t.Run("detects when condition appears", func(t *testing.T) {
+		test(t, true, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.Conditions = old.Status.Conditions
+			old.Status.Conditions = nil
+		})
+	})
+
+	t.Run("detects change when condition disappears", func(t *testing.T) {
+		test(t, true, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.Conditions = nil
+		})
+	})
+
+	t.Run("detects change in the status", func(t *testing.T) {
+		test(t, true, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.Conditions[0].Status = corev1.ConditionFalse
+		})
+	})
+
+	t.Run("detects change in the reason", func(t *testing.T) {
+		test(t, true, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.Conditions[0].Reason = "other"
+		})
+	})
+
+	t.Run("detects change in the message", func(t *testing.T) {
+		test(t, true, func(old, new *toolchainv1alpha1.ToolchainCluster) {
+			new.Status.Conditions[0].Message = "other"
+		})
+	})
 }

--- a/pkg/predicate/toolchainconditionchanged_test.go
+++ b/pkg/predicate/toolchainconditionchanged_test.go
@@ -1,0 +1,7 @@
+package predicate
+
+import "testing"
+
+func TestToolchainConditionChangedPredicate(t *testing.T) {
+	// TODO: implement
+}


### PR DESCRIPTION
This is done by introducing a filter for the watch that should ignore any changes to the TCs that are only caused by the changes in the timestamps of the conditions.

FYI, I didn't create any e2e test for this because frankly, I am not sure how that would look like. There should be no change in the behavior and I don't really see a way of testing "the reconciliation shouldn't happen if I do this".

JIRA: https://issues.redhat.com/browse/KUBESAW-256