### PR TITLE
make idler email content generic instead

### DIFF
--- a/deploy/templates/notificationtemplates/sandbox/idlertriggered/notification.html
+++ b/deploy/templates/notificationtemplates/sandbox/idlertriggered/notification.html
@@ -41,11 +41,11 @@
 >
 
     <p>
-        You are receiving this email because one or more of your workloads in the Developer Sandbox has been running for 12 hours and has been automatically idled.
+        You are receiving this email because one or more of your workloads in the Developer Sandbox has been running for long and has been automatically idled.
     </p>
 
     <p>
-        After 12 hours, our system idles running workloads. No further action is required by you. You can <a href="https://developers.redhat.com/learn/openshift/revive-inactive-openshift-pods-scaled-zero">restart your workload,</a> {{.AppType}} {{.AppName}}
+        Our system idles long running or crashlooping workloads. No further action is required by you. You can <a href="https://developers.redhat.com/learn/openshift/revive-inactive-openshift-pods-scaled-zero">restart your workload,</a> {{.AppType}} {{.AppName}}
         when you're ready to continue exploring on the Developer Sandbox.
     </p>
 

--- a/pkg/templates/notificationtemplates/notification_generator_test.go
+++ b/pkg/templates/notificationtemplates/notification_generator_test.go
@@ -66,7 +66,7 @@ func TestGetNotificationTemplate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, template)
 			assert.Equal(t, "Notice: Your running workload in namespace {{.Namespace}} has been idled", template.Subject)
-			assert.Contains(t, template.Content, "You are receiving this email because one or more of your workloads in the Developer Sandbox has been running for 12 hours and has been automatically idled.")
+			assert.Contains(t, template.Content, "You are receiving this email because one or more of your workloads in the Developer Sandbox has been running for long and has been automatically idled.")
 
 		})
 	})


### PR DESCRIPTION
currently idler emails specify 12 hours of long running workload as the only criteria to be idled. But we idle VMs for a shorter duration and also will start idling crashlooping pods. Thus this PR makes changes to the idler email sent out to include other scenarios as well.