### PR TITLE
measure UserSignup provision time

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -380,6 +380,12 @@ func (r *Reconciler) checkIfMurAlreadyExists(
 			}
 		}
 
+		logger.Info("Checking whether MUR is Ready", "MUR", mur.Name)
+		if !condition.IsTrueWithReason(mur.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.MasterUserRecordProvisionedReason) &&
+			!condition.IsTrue(userSignup.Status.Conditions, toolchainv1alpha1.UserSignupComplete) {
+			return true, r.updateIncompleteStatus(ctx, userSignup, fmt.Sprintf("MUR %s was not ready", mur.Name))
+		}
+
 		logger.Info("Setting UserSignup status to 'Complete'")
 
 		if err := r.updateStatus(ctx, userSignup, r.updateCompleteStatus(mur.Name)); err != nil {

--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -3,8 +3,8 @@ package usersignup
 import (
 	"context"
 	"fmt"
-
 	"strconv"
+	"time"
 
 	recaptcha "cloud.google.com/go/recaptchaenterprise/v2/apiv1"
 	recaptchapb "cloud.google.com/go/recaptchaenterprise/v2/apiv1/recaptchaenterprisepb"
@@ -382,10 +382,44 @@ func (r *Reconciler) checkIfMurAlreadyExists(
 
 		logger.Info("Setting UserSignup status to 'Complete'")
 
-		return true, r.updateStatus(ctx, userSignup, r.updateCompleteStatus(mur.Name))
+		if err := r.updateStatus(ctx, userSignup, r.updateCompleteStatus(mur.Name)); err != nil {
+			return true, err
+		}
+		if err := recordProvisionTime(ctx, r.Client, userSignup); err != nil {
+			return true, fmt.Errorf("unable to record provision time: %w", err)
+		}
+		return true, nil
 	}
 
 	return false, nil
+}
+
+func recordProvisionTime(ctx context.Context, cl runtimeclient.Client, userSignup *toolchainv1alpha1.UserSignup) error {
+	requestReceivedTime, ok := userSignup.Annotations[toolchainv1alpha1.UserSignupRequestReceivedTimeAnnotationKey]
+	// if annotation not present, then nothing to record
+	if !ok {
+		return nil
+	}
+	// delete annotation to make sure that we don't record the same UserSignup twice
+	delete(userSignup.Annotations, toolchainv1alpha1.UserSignupRequestReceivedTimeAnnotationKey)
+	if err := cl.Update(ctx, userSignup); err != nil {
+		return err
+	}
+	logger := log.FromContext(ctx)
+	parsedTime, err := time.Parse(time.RFC3339, requestReceivedTime)
+	if err != nil {
+		logger.Error(err, "unable to parse the request-received-time annotation", "value", requestReceivedTime)
+		return nil
+	}
+	_, phoneVerificationTriggered := userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]
+	// don't measure provision time for cases when UserSignup was either approved manually or it required phone verification step
+	if states.ApprovedManually(userSignup) || phoneVerificationTriggered {
+		return nil
+	}
+	provisionTimeSeconds := time.Since(parsedTime).Seconds()
+	logger.Info("provision time", "time-in-seconds", provisionTimeSeconds)
+	metrics.UserSignupProvisionTimeHistogram.Observe(provisionTimeSeconds)
+	return nil
 }
 
 func (r *Reconciler) ensureNewMurIfApproved(

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -4903,9 +4903,10 @@ func TestRecordProvisionTime(t *testing.T) {
 			require.NoError(t, err)
 			AssertThatUserSignup(t, test.HostOperatorNs, userSignup.Name, client).DoesNotHaveAnnotation(toolchainv1alpha1.UserSignupRequestReceivedTimeAnnotationKey)
 		}
-		for _, value := range []int{1, 2, 3, 5, 8, 13, 21, 34, 55, 89} {
+		for _, value := range metrics.UserSignupProvisionTimeHistogramBuckets {
 			metricstest.AssertHistogramBucketEquals(t, value, value, metrics.UserSignupProvisionTimeHistogram) // could fail when debugging
 		}
+		metricstest.AssertHistogramSampleCountEquals(t, 100, metrics.UserSignupProvisionTimeHistogram)
 	})
 
 	t.Run("should not be in histogram", func(t *testing.T) {

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -4322,7 +4322,7 @@ func TestMigrateMur(t *testing.T) {
 		murtest.AssertThatMasterUserRecords(t, r.Client).HaveCount(1)
 		murtest.AssertThatMasterUserRecord(t, expectedMur.Name, r.Client).
 			Exists().
-			HasTier(*deactivate30Tier). // tier name should be set
+			HasTier(*deactivate30Tier).                                                         // tier name should be set
 			HasLabelWithValue(toolchainv1alpha1.MasterUserRecordOwnerLabelKey, userSignup.Name) // other labels unchanged
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0
-	github.com/codeready-toolchain/api v0.0.0-20250131222557-beba5463f429
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20250225125153-139ef30bbd6d
+	github.com/codeready-toolchain/api v0.0.0-20250227073728-5999971adb48
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20250227105612-03e9ebab49c7
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v1.4.1
@@ -30,10 +30,6 @@ require (
 	k8s.io/klog/v2 v2.110.1
 	sigs.k8s.io/controller-runtime v0.17.3
 )
-
-replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20250225121920-2aa06e36874e
-
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20250226144039-67625f8d4ee7
 
 require (
 	cloud.google.com/go/auth v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.17.3
 )
 
+replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20250225114159-7e2aa7cf0ada
+
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20250225115436-1e9ef245b210
+
 require (
 	cloud.google.com/go/auth v0.3.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 
 replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20250225121920-2aa06e36874e
 
-replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20250225154813-c7a74a683dc7
+replace github.com/codeready-toolchain/toolchain-common => github.com/matousjobanek/toolchain-common v0.0.0-20250226144039-67625f8d4ee7
 
 require (
 	cloud.google.com/go/auth v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/mailgun/mailgun-go/v4 v4.8.1 h1:1+MdKakJuXnW2JJDbyPdO1ngAANOyHyVPxQvF
 github.com/mailgun/mailgun-go/v4 v4.8.1/go.mod h1:FJlF9rI5cQT+mrwujtJjPMbIVy3Ebor9bKTVsJ0QU40=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/matousjobanek/api v0.0.0-20250225114159-7e2aa7cf0ada/go.mod h1:gPwicZPTmRm1PF75ysEYXaYKdXoFgwgCggTJd1oYmOs=
+github.com/matousjobanek/toolchain-common v0.0.0-20250225115436-1e9ef245b210/go.mod h1:I38hiluJQcUT/GKo6iLhNLSrueqvtw+W9huBLjwX3SE=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matousjobanek/api v0.0.0-20250225121920-2aa06e36874e h1:IuZp1p8aL4z+Esa47X+niKxGWbEjhqSt03CUoBN6RrA=
 github.com/matousjobanek/api v0.0.0-20250225121920-2aa06e36874e/go.mod h1:gPwicZPTmRm1PF75ysEYXaYKdXoFgwgCggTJd1oYmOs=
-github.com/matousjobanek/toolchain-common v0.0.0-20250225154813-c7a74a683dc7 h1:ZpodQA4rZEslZMc97aT5C4nCieWU7z5y6EsZ3/5PKmw=
-github.com/matousjobanek/toolchain-common v0.0.0-20250225154813-c7a74a683dc7/go.mod h1:I38hiluJQcUT/GKo6iLhNLSrueqvtw+W9huBLjwX3SE=
+github.com/matousjobanek/toolchain-common v0.0.0-20250226144039-67625f8d4ee7 h1:uWHQxyvJj3mCsdd98+Xmv7iyX9zfVRDClj/dQ6hy7oA=
+github.com/matousjobanek/toolchain-common v0.0.0-20250226144039-67625f8d4ee7/go.mod h1:I38hiluJQcUT/GKo6iLhNLSrueqvtw+W9huBLjwX3SE=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=

--- a/go.sum
+++ b/go.sum
@@ -36,10 +36,6 @@ github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtM
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/codeready-toolchain/api v0.0.0-20250131222557-beba5463f429 h1:I7xzHRmstvzucH9NqF54xvsM/yYuWOp/G5+BUr5j4tY=
-github.com/codeready-toolchain/api v0.0.0-20250131222557-beba5463f429/go.mod h1:gPwicZPTmRm1PF75ysEYXaYKdXoFgwgCggTJd1oYmOs=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250131223755-a9c24d874b32 h1:mX8aMYw9yPCSZuRNeZwShOPQDl0aTKV9FcEfb1Sdhiw=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250131223755-a9c24d874b32/go.mod h1:/PeschEEyTZIAsXQxIf83Fl8kOpSOHDfR5yyanz+bSA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -177,7 +173,9 @@ github.com/mailgun/mailgun-go/v4 v4.8.1 h1:1+MdKakJuXnW2JJDbyPdO1ngAANOyHyVPxQvF
 github.com/mailgun/mailgun-go/v4 v4.8.1/go.mod h1:FJlF9rI5cQT+mrwujtJjPMbIVy3Ebor9bKTVsJ0QU40=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/matousjobanek/api v0.0.0-20250225114159-7e2aa7cf0ada h1:pcIVW9vAUd7agBG5Vow1ajB/91HOUxudOienzeFRuYM=
 github.com/matousjobanek/api v0.0.0-20250225114159-7e2aa7cf0ada/go.mod h1:gPwicZPTmRm1PF75ysEYXaYKdXoFgwgCggTJd1oYmOs=
+github.com/matousjobanek/toolchain-common v0.0.0-20250225115436-1e9ef245b210 h1:bR46Pz4wKb62ypcbLuDWTf+ASEUCpvrl8NVByXOOTz8=
 github.com/matousjobanek/toolchain-common v0.0.0-20250225115436-1e9ef245b210/go.mod h1:I38hiluJQcUT/GKo6iLhNLSrueqvtw+W9huBLjwX3SE=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtM
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/codeready-toolchain/api v0.0.0-20250227073728-5999971adb48 h1:jqGcYw4KdQzqe5WEp+06HXBRyosAktgO5Y6ADs+NF5A=
+github.com/codeready-toolchain/api v0.0.0-20250227073728-5999971adb48/go.mod h1:gPwicZPTmRm1PF75ysEYXaYKdXoFgwgCggTJd1oYmOs=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250227105612-03e9ebab49c7 h1:Y4EMaYLn62ptrChtaPcqzGFe0h0TNDVmwL1WOVbu2IY=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250227105612-03e9ebab49c7/go.mod h1:mNRKnxjBHxggT03t6TwGJT5AZvmHMn6oQ32DrkGwV+w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -173,10 +177,6 @@ github.com/mailgun/mailgun-go/v4 v4.8.1 h1:1+MdKakJuXnW2JJDbyPdO1ngAANOyHyVPxQvF
 github.com/mailgun/mailgun-go/v4 v4.8.1/go.mod h1:FJlF9rI5cQT+mrwujtJjPMbIVy3Ebor9bKTVsJ0QU40=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/matousjobanek/api v0.0.0-20250225121920-2aa06e36874e h1:IuZp1p8aL4z+Esa47X+niKxGWbEjhqSt03CUoBN6RrA=
-github.com/matousjobanek/api v0.0.0-20250225121920-2aa06e36874e/go.mod h1:gPwicZPTmRm1PF75ysEYXaYKdXoFgwgCggTJd1oYmOs=
-github.com/matousjobanek/toolchain-common v0.0.0-20250226144039-67625f8d4ee7 h1:uWHQxyvJj3mCsdd98+Xmv7iyX9zfVRDClj/dQ6hy7oA=
-github.com/matousjobanek/toolchain-common v0.0.0-20250226144039-67625f8d4ee7/go.mod h1:I38hiluJQcUT/GKo6iLhNLSrueqvtw+W9huBLjwX3SE=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/migueleliasweb/go-github-mock v0.0.18 h1:0lWt9MYmZQGnQE2rFtjlft/YtD6hzxuN6JJRFpujzEI=

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -51,12 +51,19 @@ var (
 	HostOperatorVersionGaugeVec *prometheus.GaugeVec
 )
 
+// histograms
+var (
+	// UserSignupProvisionTimeHistogram measures the provision time of the UserSignup needed either for its creation or reactivation
+	UserSignupProvisionTimeHistogram prometheus.Histogram
+)
+
 // collections
 var (
 	allCounters    = []prometheus.Counter{}
 	allCounterVecs = []*prometheus.CounterVec{}
 	allGauges      = []prometheus.Gauge{}
 	allGaugeVecs   = []*prometheus.GaugeVec{}
+	allHistograms  = []prometheus.Histogram{}
 )
 
 func init() {
@@ -82,6 +89,8 @@ func initMetrics() {
 	UserSignupsPerActivationAndDomainGaugeVec = newGaugeVec("users_per_activations_and_domain", "Number of UserSignups per activations and domain", []string{"activations", "domain"}...)
 	MasterUserRecordGaugeVec = newGaugeVec("master_user_records", "Number of MasterUserRecords per email address domain ('internal' vs 'external')", "domain")
 	HostOperatorVersionGaugeVec = newGaugeVec("host_operator_version", "Current version of the host operator", "commit")
+	// Histograms
+	UserSignupProvisionTimeHistogram = newHistogram("user_signup_provision_time", "UserSignup provision time in seconds")
 	log.Info("custom metrics initialized")
 }
 
@@ -127,6 +136,16 @@ func newGaugeVec(name, help string, labels ...string) *prometheus.GaugeVec {
 	return v
 }
 
+func newHistogram(name, help string) prometheus.Histogram {
+	v := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    metricsPrefix + name,
+		Help:    help,
+		Buckets: []float64{1, 2, 3, 5, 8, 13, 21, 34, 55, 89},
+	})
+	allHistograms = append(allHistograms, v)
+	return v
+}
+
 // RegisterCustomMetrics registers the custom metrics
 func RegisterCustomMetrics() {
 	// register metrics
@@ -140,6 +159,9 @@ func RegisterCustomMetrics() {
 		k8smetrics.Registry.MustRegister(g)
 	}
 	for _, v := range allGaugeVecs {
+		k8smetrics.Registry.MustRegister(v)
+	}
+	for _, v := range allHistograms {
 		k8smetrics.Registry.MustRegister(v)
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -55,6 +55,8 @@ var (
 var (
 	// UserSignupProvisionTimeHistogram measures the provision time of the UserSignup needed either for its creation or reactivation
 	UserSignupProvisionTimeHistogram prometheus.Histogram
+	// UserSignupProvisionTimeHistogramBuckets is the list of buckets defined for UserSignupProvisionTimeHistogram
+	UserSignupProvisionTimeHistogramBuckets = []float64{1, 2, 3, 5, 8, 13, 21, 34, 55, 89}
 )
 
 // collections
@@ -140,7 +142,7 @@ func newHistogram(name, help string) prometheus.Histogram {
 	v := prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    metricsPrefix + name,
 		Help:    help,
-		Buckets: []float64{1, 2, 3, 5, 8, 13, 21, 34, 55, 89},
+		Buckets: UserSignupProvisionTimeHistogramBuckets,
 	})
 	allHistograms = append(allHistograms, v)
 	return v

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -43,6 +43,21 @@ func TestInitGaugeVec(t *testing.T) {
 	metricstest.AssertMetricsGaugeEquals(t, 2, m.WithLabelValues("member-2"))
 }
 
+func TestInitHistogram(t *testing.T) {
+	// given
+	m := newHistogram("test_histogram", "test histogram description")
+
+	// when
+	for i := 1; i <= 100; i++ {
+		m.Observe(float64(i))
+	}
+
+	// then
+	for _, value := range []int{1, 2, 3, 5, 8, 13, 21, 34, 55, 89} {
+		metricstest.AssertHistogramBucketEquals(t, value, value, m)
+	}
+}
+
 func TestRegisterCustomMetrics(t *testing.T) {
 	// when
 	RegisterCustomMetrics()
@@ -60,6 +75,10 @@ func TestRegisterCustomMetrics(t *testing.T) {
 	for _, m := range allGaugeVecs {
 		assert.True(t, k8smetrics.Registry.Unregister(m))
 	}
+
+	for _, m := range allHistograms {
+		assert.True(t, k8smetrics.Registry.Unregister(m))
+	}
 }
 
 func TestResetMetrics(t *testing.T) {
@@ -67,10 +86,12 @@ func TestResetMetrics(t *testing.T) {
 	// when
 	UserSignupUniqueTotal.Inc()
 	SpaceGaugeVec.WithLabelValues("member-1").Set(20)
+	UserSignupProvisionTimeHistogram.Observe(1)
 
 	Reset()
 
 	// then
 	metricstest.AssertMetricsCounterEquals(t, 0, UserSignupUniqueTotal)
 	metricstest.AssertMetricsGaugeEquals(t, 0, SpaceGaugeVec.WithLabelValues("member-1"))
+	metricstest.AssertAllHistogramBucketsAreEmpty(t, UserSignupProvisionTimeHistogram)
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -53,9 +53,10 @@ func TestInitHistogram(t *testing.T) {
 	}
 
 	// then
-	for _, value := range []int{1, 2, 3, 5, 8, 13, 21, 34, 55, 89} {
+	for _, value := range UserSignupProvisionTimeHistogramBuckets {
 		metricstest.AssertHistogramBucketEquals(t, value, value, m)
 	}
+	metricstest.AssertHistogramSampleCountEquals(t, 100, m)
 }
 
 func TestRegisterCustomMetrics(t *testing.T) {

--- a/test/usersignup_assertions.go
+++ b/test/usersignup_assertions.go
@@ -79,7 +79,7 @@ func (a *UserSignupAssertion) HasAnnotation(key, value string) *UserSignupAssert
 	return a
 }
 
-func (a *UserSignupAssertion) HasNoAnnotation(key string) *UserSignupAssertion {
+func (a *UserSignupAssertion) DoesNotHaveAnnotation(key string) *UserSignupAssertion {
 	err := a.loadUserSignup()
 	require.NoError(a.t, err)
 	_, found := a.usersignup.Annotations[key]


### PR DESCRIPTION
Measures the provision time of the UserSignups. 
The start-time is taken from the annotation set in reg-service, as the end-time is taken the moment when UserSignup is marked as Complete.
The provision time is measured only when:
* the user didn't have to complete the whole verification
* the UserSignup wasn't approved manually
* when the annotation is present

The annotation is removed to ensure that we don't record the provision time twice for the same user

TODO:
- [x] e2e tests

depends on:
https://github.com/codeready-toolchain/api/pull/464
https://github.com/codeready-toolchain/toolchain-common/pull/461
https://github.com/codeready-toolchain/registration-service/pull/515 (this needs to be merged first to properly test it in e2e tests)

paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/1126

[SANDBOX-957](https://issues.redhat.com/browse/SANDBOX-957)

