### PR TITLE
rely on the phone hash label skipping tracked provision time

### DIFF
--- a/controllers/usersignup/usersignup_controller.go
+++ b/controllers/usersignup/usersignup_controller.go
@@ -417,7 +417,7 @@ func recordProvisionTime(ctx context.Context, cl runtimeclient.Client, userSignu
 		logger.Error(err, "unable to parse the request-received-time annotation", "value", requestReceivedTime)
 		return nil
 	}
-	_, phoneVerificationTriggered := userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]
+	_, phoneVerificationTriggered := userSignup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]
 	// don't measure provision time for cases when UserSignup was either approved manually or it required phone verification step
 	if states.ApprovedManually(userSignup) || phoneVerificationTriggered {
 		return nil

--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -4934,7 +4934,7 @@ func TestRecordProvisionTime(t *testing.T) {
 			t.Cleanup(metrics.Reset)
 			verify(commonsignup.NewUserSignup(
 				commonsignup.WithRequestReceivedTimeAnnotation(time.Now()),
-				commonsignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "123")))
+				commonsignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "123")))
 		})
 
 		t.Run("request-received-time annotation is missing", func(t *testing.T) {


### PR DESCRIPTION
the label is more reliable (annotations are removed after successfully verifying the phone, which I didn't realize before)

paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/1127

[SANDBOX-957](https://issues.redhat.com/browse/SANDBOX-957)
