### PR TITLE
adjust buckets in provision time histogram

### DIFF
--- a/controllers/usersignup/usersignup_controller_test.go
+++ b/controllers/usersignup/usersignup_controller_test.go
@@ -4891,7 +4891,7 @@ func TestRecordProvisionTime(t *testing.T) {
 	t.Run("should be in histogram", func(t *testing.T) {
 		// given
 		t.Cleanup(metrics.Reset)
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 4000; i++ {
 			userSignup := commonsignup.NewUserSignup(
 				commonsignup.WithRequestReceivedTimeAnnotation(time.Now().Add(-time.Duration(i) * time.Second)))
 			client := test.NewFakeClient(t, userSignup)
@@ -4906,7 +4906,7 @@ func TestRecordProvisionTime(t *testing.T) {
 		for _, value := range metrics.UserSignupProvisionTimeHistogramBuckets {
 			metricstest.AssertHistogramBucketEquals(t, value, value, metrics.UserSignupProvisionTimeHistogram) // could fail when debugging
 		}
-		metricstest.AssertHistogramSampleCountEquals(t, 100, metrics.UserSignupProvisionTimeHistogram)
+		metricstest.AssertHistogramSampleCountEquals(t, 4000, metrics.UserSignupProvisionTimeHistogram)
 	})
 
 	t.Run("should not be in histogram", func(t *testing.T) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -56,7 +56,7 @@ var (
 	// UserSignupProvisionTimeHistogram measures the provision time of the UserSignup needed either for its creation or reactivation
 	UserSignupProvisionTimeHistogram prometheus.Histogram
 	// UserSignupProvisionTimeHistogramBuckets is the list of buckets defined for UserSignupProvisionTimeHistogram
-	UserSignupProvisionTimeHistogramBuckets = []float64{1, 2, 3, 5, 8, 13, 21, 34, 55, 89}
+	UserSignupProvisionTimeHistogramBuckets = []float64{1, 2, 3, 5, 10, 30, 60, 120, 180, 360, 3600}
 )
 
 // collections

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -48,7 +48,7 @@ func TestInitHistogram(t *testing.T) {
 	m := newHistogram("test_histogram", "test histogram description")
 
 	// when
-	for i := 1; i <= 100; i++ {
+	for i := 1; i <= 4000; i++ {
 		m.Observe(float64(i))
 	}
 
@@ -56,7 +56,7 @@ func TestInitHistogram(t *testing.T) {
 	for _, value := range UserSignupProvisionTimeHistogramBuckets {
 		metricstest.AssertHistogramBucketEquals(t, value, value, m)
 	}
-	metricstest.AssertHistogramSampleCountEquals(t, 100, m)
+	metricstest.AssertHistogramSampleCountEquals(t, 4000, m)
 }
 
 func TestRegisterCustomMetrics(t *testing.T) {


### PR DESCRIPTION
based on the discussion from: https://redhat-internal.slack.com/archives/CHK0J6HT6/p1741187208229359

adjusted the buckets so they are more human readable and they also span across the longer provision times:
1s, 2s, 3s, 5s, 10s, 30s, 1m, 2m, 3m, 6m, 1h