### PR TITLE
updates language from provisioning to ready in emails

### DIFF
--- a/deploy/templates/notificationtemplates/sandbox/userprovisioned/notification.html
+++ b/deploy/templates/notificationtemplates/sandbox/userprovisioned/notification.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>
-        Notice: Your Developer Sandbox account is provisioned.
+        Notice: Your Developer Sandbox account is ready.
     </title>
     <style>
         a:hover {
@@ -42,7 +42,7 @@
 
     <p>
         You are receiving this email because the Developer Sandbox account associated with {{.UserEmail}} 
-        is now provisioned and ready to use. Your account will be active for {{.DeactivationTimeoutDays}} days at no cost to you.
+        is now ready to use. Your account will be active for {{.DeactivationTimeoutDays}} days at no cost to you.
     </p>
 
     <p>

--- a/deploy/templates/notificationtemplates/sandbox/userprovisioned/subject.txt
+++ b/deploy/templates/notificationtemplates/sandbox/userprovisioned/subject.txt
@@ -1,1 +1,1 @@
-Notice: Your Developer Sandbox account is provisioned
+Notice: Your Developer Sandbox account is ready

--- a/pkg/templates/notificationtemplates/notification_generator_test.go
+++ b/pkg/templates/notificationtemplates/notification_generator_test.go
@@ -29,8 +29,8 @@ func TestGetNotificationTemplate(t *testing.T) {
 			// then
 			require.NoError(t, err)
 			require.NotNil(t, template)
-			assert.Equal(t, "Notice: Your Developer Sandbox account is provisioned", template.Subject)
-			assert.Contains(t, template.Content, "is now provisioned and ready to use. Your account will be active for")
+			assert.Equal(t, "Notice: Your Developer Sandbox account is ready", template.Subject)
+			assert.Contains(t, template.Content, "is now ready to use. Your account will be active for")
 		})
 		t.Run("ensure cache is used", func(t *testing.T) {
 			// when
@@ -42,8 +42,8 @@ func TestGetNotificationTemplate(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, template)
 			require.NotEmpty(t, template["userprovisioned"])
-			assert.Equal(t, "Notice: Your Developer Sandbox account is provisioned", template["userprovisioned"].Subject)
-			assert.Contains(t, template["userprovisioned"].Content, "is now provisioned and ready to use. Your account will be active for")
+			assert.Equal(t, "Notice: Your Developer Sandbox account is ready", template["userprovisioned"].Subject)
+			assert.Contains(t, template["userprovisioned"].Content, "is now ready to use. Your account will be active for")
 			assert.Equal(t, UserProvisionedTemplateName, template["userprovisioned"].Name)
 		})
 		t.Run("get userdeactivating notification template", func(t *testing.T) {


### PR DESCRIPTION
Per [this conversation ](https://redhat-internal.slack.com/archives/C07UWTB1BPB/p1742932177195959), I want to move away from using the word provisioning in our initial email to users because it could create confusion with the AAP 'provision' button/flow.