### PR TITLE
SANDBOX-955: update controller-gen.kubebuilder.io/version to v0.16.5

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_bannedusers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_bannedusers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: bannedusers.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_masteruserrecords.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: masteruserrecords.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_notifications.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_notifications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: notifications.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_nstemplatetiers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: nstemplatetiers.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_proxyplugins.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_proxyplugins.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: proxyplugins.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_socialevents.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_socialevents.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: socialevents.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_spacebindingrequests.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_spacebindingrequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: spacebindingrequests.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_spacebindings.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_spacebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: spacebindings.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_spaceprovisionerconfigs.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_spaceprovisionerconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: spaceprovisionerconfigs.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com
@@ -55,7 +55,6 @@ spec:
                       MaxMemoryUtilizationPercent is the maximum memory utilization of the cluster to permit provisioning
                       new spaces to it.
 
-
                       0 or undefined value means no limit.
                     maximum: 100
                     minimum: 0
@@ -63,7 +62,6 @@ spec:
                   maxNumberOfSpaces:
                     description: |-
                       MaxNumberOfSpaces is the maximum number of spaces that can be provisioned to the referenced cluster.
-
 
                       0 or undefined value means no limit.
                     minimum: 0

--- a/config/crd/bases/toolchain.dev.openshift.com_spacerequests.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_spacerequests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: spacerequests.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com
@@ -56,7 +56,6 @@ spec:
                 description: |-
                   DisableInheritance indicates whether or not SpaceBindings from the parent-spaces are
                   automatically inherited to all sub-spaces in the tree.
-
 
                   Set to True to disable SpaceBinding inheritance from the parent-spaces.
                   Default is False.

--- a/config/crd/bases/toolchain.dev.openshift.com_spaces.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_spaces.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: spaces.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com
@@ -57,7 +57,6 @@ spec:
                   DisableInheritance indicates whether or not SpaceBindings from the parent-spaces are
                   automatically inherited to all sub-spaces in the tree.
 
-
                   Set to True to disable SpaceBinding inheritance from the parent-spaces.
                   Default is False.
                 type: boolean
@@ -65,7 +64,6 @@ spec:
                 description: |-
                   ParentSpace holds the name of the context (Space) from which this space was created (requested),
                   enabling hierarchy relationships between different Spaces.
-
 
                   Keeping this association brings two main benefits:
                   1. SpaceBindings are inherited from the parent Space

--- a/config/crd/bases/toolchain.dev.openshift.com_tiertemplaterevisions.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_tiertemplaterevisions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: tiertemplaterevisions.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_tiertemplates.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_tiertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: tiertemplates.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com
@@ -129,21 +129,13 @@ spec:
                             stored into Value field. If empty, no generator is being used, leaving
                             the result Value untouched. Optional.
 
-
                             The only supported generator is "expression", which accepts a "from"
                             value in the form of a simple regular expression containing the
                             range expression "[a-zA-Z0-9]", and the length expression "a{length}".
 
-
                             Examples:
 
-
                             from             | value
-                            -----------------------------
-                            "test[0-9]{1}x"  | "test7x"
-                            "[0-1]{8}"       | "01001100"
-                            "0x[A-F0-9]{4}"  | "0xB3AF"
-                            "[a-zA-Z0-9]{8}" | "hW4yQU5i"
                           type: string
                         name:
                           description: |-
@@ -171,11 +163,9 @@ spec:
                 description: |-
                   TemplateObjects contains list of Unstructured Objects that can be parsed at runtime and will be applied as part of the tier provisioning.
 
-
                   NOTE: when specifying variables as part of the objects list , those concatenated as part of other strings do not need to be wrapped inside quotes,
                   while those that are not part of other strings do need to be wrapped in single quotes. This is required otherwise the yaml parser will error while trying to parse those resources containing variables.
                   eg: https://docs.google.com/document/d/1x5SoBT80df9fmVsaDgAE6DE7hE6lzmNIK087JUmgaJs/edit#heading=h.2iuytpfnmul5
-
 
                   The template parameters values will be defined in the NSTemplateTier CRD.
                 items:

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: toolchainclusters.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: toolchainconfigs.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com
@@ -375,7 +375,6 @@ spec:
                                 a phone number when receiving an SMS message), for example "RED HAT", with an array of country
                                 code values for which the Sender ID value will be set via the Twilio API when sending a verification code to a user in
                                 any of the country codes specified.
-
 
                                 Since some countries are starting to block long form phone numbers (i.e. SMS messages from international phone numbers)
                                 the Sender ID may be an acceptable alternative to requiring the verification message to be sent from a local phone number.

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: toolchainstatuses.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_usersignups.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_usersignups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: usersignups.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com

--- a/config/crd/bases/toolchain.dev.openshift.com_usertiers.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_usertiers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: usertiers.toolchain.dev.openshift.com
 spec:
   group: toolchain.dev.openshift.com


### PR DESCRIPTION
## Description
Generated by https://github.com/codeready-toolchain/api/pull/474

## Issue ticket number and link
[SANDBOX-955](https://issues.redhat.com/browse/SANDBOX-955)