### PR TITLE
Deploy the registration service using the new SSA client

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,7 +70,8 @@ var (
 )
 
 const (
-	memberClientTimeout = 3 * time.Second
+	memberClientTimeout      = 3 * time.Second
+	hostOperatorFieldManager = "kubesaw-host-operator"
 )
 
 func init() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -294,6 +294,7 @@ func main() { // nolint:gocyclo
 		Client:         mgr.GetClient(),
 		GetMembersFunc: commoncluster.GetMemberClusters,
 		Scheme:         mgr.GetScheme(),
+		FieldManager:   hostOperatorFieldManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ToolchainConfig")
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/host-operator
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0
 	github.com/codeready-toolchain/api v0.0.0-20250313170542-4e3c4147cb80
-	github.com/codeready-toolchain/toolchain-common v0.0.0-20250313203311-0bce6563576f
+	github.com/codeready-toolchain/toolchain-common v0.0.0-20250430091615-95cf792ac171
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/go-logr/logr v1.4.1
@@ -30,6 +30,8 @@ require (
 	k8s.io/klog/v2 v2.120.1
 	sigs.k8s.io/controller-runtime v0.18.4
 )
+
+require k8s.io/kubectl v0.30.1
 
 require (
 	cloud.google.com/go/auth v0.3.0 // indirect
@@ -117,7 +119,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/cli-runtime v0.30.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/kubectl v0.30.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/codeready-toolchain/api v0.0.0-20250313170542-4e3c4147cb80 h1:wh41dZ7VkyClQWiMJbMypku6xTxtxNZTgQJUAcodgUo=
 github.com/codeready-toolchain/api v0.0.0-20250313170542-4e3c4147cb80/go.mod h1:shTTQ+bYWinbdF/oK+ly4DO5jdXtIASZ+uPZElsmsKg=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250313203311-0bce6563576f h1:qBUZ/xBNgDMf5Y0tObJ85/9GcDSgtUf8WFfCrNSxaZ4=
-github.com/codeready-toolchain/toolchain-common v0.0.0-20250313203311-0bce6563576f/go.mod h1:0dopWh1MWi9eg2d5RAd4uSUmXfDMqz4Yk2oNPHF15+Y=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250430091615-95cf792ac171 h1:qK+3ECtkMiWT8IyPhwetajh04E/XRSzC2NN5PQnSDSM=
+github.com/codeready-toolchain/toolchain-common v0.0.0-20250430091615-95cf792ac171/go.mod h1:Rd64iFrlcocihpLq4qIsCMkjN/1invHHaU1AMq19OWA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This was not as simple as initially thought because SSA client does not report the fact whether the objects were updated or not back to the caller.

This was relied upon when determining the "deploying" and "deployed" phases of the registration service as reported in the `ToolchainConfig.status`.

This has been discussed and we agreed to drop the distinction and merely consider the registration service not deployed or deployed.