### PR TITLE
Remove the advanced ns tiertemplate

### DIFF
--- a/deploy/templates/nstemplatetiers/advanced/based_on_tier.yaml
+++ b/deploy/templates/nstemplatetiers/advanced/based_on_tier.yaml
@@ -1,8 +1,0 @@
-from: base
-parameters:
-- name: MEMORY_LIMIT
-  value: "32Gi"
-- name: MEMORY_REQUEST
-  value: "32Gi"
-- name: IDLER_TIMEOUT_SECONDS
-  value: 0

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 var expectedProdTiers = []string{
-	"advanced",
 	"base",
 	"base1ns",
 	"base1nsnoidling",
@@ -51,7 +50,6 @@ func roles(_ string) []string {
 }
 
 func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
-
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
@@ -109,10 +107,8 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 	}
 
 	t.Run("failures", func(t *testing.T) {
-
 		namespace := "host-operator" + uuid.Must(uuid.NewV4()).String()[:7]
 		t.Run("nstemplatetiers", func(t *testing.T) {
-
 			t.Run("failed to create nstemplatetiers", func(t *testing.T) {
 				// given
 				clt := commontest.NewFakeClient(t)
@@ -136,11 +132,11 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 				clt := commontest.NewFakeClient(t, &toolchainv1alpha1.NSTemplateTier{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespace,
-						Name:      "advanced",
+						Name:      "base",
 					},
 				})
 				clt.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
-					if obj.GetObjectKind().GroupVersionKind().Kind == "NSTemplateTier" && obj.GetName() == "advanced" {
+					if obj.GetObjectKind().GroupVersionKind().Kind == "NSTemplateTier" && obj.GetName() == "base" {
 						// simulate a client/server error
 						return errors.Errorf("an error")
 					}
@@ -151,12 +147,11 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 				err := nstemplatetiers.CreateOrUpdateResources(context.TODO(), s, clt, namespace)
 				// then
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "unable to create NSTemplateTiers: unable to create or update the 'advanced' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to update the resource")
+				assert.Contains(t, err.Error(), "unable to create NSTemplateTiers: unable to create or update the 'base' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to update the resource")
 			})
 		})
 
 		t.Run("tiertemplates", func(t *testing.T) {
-
 			t.Run("failed to create nstemplatetiers", func(t *testing.T) {
 				// given
 				clt := commontest.NewFakeClient(t)
@@ -174,7 +169,6 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 				assert.Regexp(t, fmt.Sprintf("unable to create TierTemplates: unable to create the 'base1ns-dev-\\w+-\\w+' TierTemplate in namespace '%s'", namespace), err.Error()) // we can't tell for sure which namespace will fail first, but the error should match the given regex
 			})
 		})
-
 	})
 	t.Run("failed to load assets", func(t *testing.T) {
 		// when
@@ -183,7 +177,6 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, "unable to load templates: open /templates/nstemplatetiers/metadata.yaml: file does not exist", err.Error()) // error occurred while creating TierTemplate resources
 	})
-
 }
 
 func verifyTierTemplate(t *testing.T, cl *commontest.FakeClient, namespace, tierName, typeName string) string {


### PR DESCRIPTION
This removes the `advanced` namespace template tier because it is no longer used in production.

Related PRs:
* toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1151