### PR TITLE
remove the bundled NSTemplateTiers that are no longer used

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -425,7 +425,7 @@ func main() { // nolint:gocyclo
 
 		// create or update all NSTemplateTiers on the cluster at startup
 		setupLog.Info("Creating/updating the NSTemplateTier resources")
-		if err := nstemplatetiers.CreateOrUpdateResources(ctx, mgr.GetScheme(), mgr.GetClient(), namespace); err != nil {
+		if err := nstemplatetiers.SyncResources(ctx, mgr.GetScheme(), mgr.GetClient(), namespace); err != nil {
 			setupLog.Error(err, "")
 			os.Exit(1)
 		}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+// HostOperatorFieldManager is the field manager we want to use in the managed fields
+// of objects deployed by the host operator.
+const HostOperatorFieldManager = "kubesaw-host-operator"
+
+// BundledWithHostOperatorAnnotationValue is meant to be the value of the toolchainv1alpha1.BundledLabelKey that marks
+// the objects as bundled with the host operator and therefore managed by it.
+const BundledWithHostOperatorAnnotationValue = "host-operator"

--- a/pkg/constants/field_manager.go
+++ b/pkg/constants/field_manager.go
@@ -1,5 +1,0 @@
-package constants
-
-// HostOperatorFieldManager is the field manager we want to use in the managed fields
-// of objects deployed by the host operator.
-const HostOperatorFieldManager = "kubesaw-host-operator"

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator.go
@@ -3,15 +3,18 @@ package nstemplatetiers
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/deploy"
+	"github.com/codeready-toolchain/host-operator/pkg/constants"
 	"github.com/codeready-toolchain/host-operator/pkg/templates"
 	commonclient "github.com/codeready-toolchain/toolchain-common/pkg/client"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template/nstemplatetiers"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,17 +23,27 @@ import (
 
 const NsTemplateTierRootDir = "templates/nstemplatetiers"
 
-// CreateOrUpdateResources generates the NSTemplateTier resources from the cluster resource template and namespace templates,
-// then uses the manager's client to create or update the resources on the cluster.
-func CreateOrUpdateResources(ctx context.Context, s *runtime.Scheme, client runtimeclient.Client, namespace string) error {
+var bundledAnnotation = map[string]string{
+	toolchainv1alpha1.BundledAnnotationKey: constants.BundledWithHostOperatorAnnotationValue,
+}
 
+// SyncResources generates the NSTemplateTier resources from the cluster resource template and namespace templates,
+// then uses the manager's client to create or update the resources on the cluster. It also deletes all the tiers
+// that used to be bundled but are not anymore.
+func SyncResources(ctx context.Context, s *runtime.Scheme, client runtimeclient.Client, namespace string) error {
 	metadata, files, err := LoadFiles(deploy.NSTemplateTiersFS, NsTemplateTierRootDir)
 	if err != nil {
 		return err
 	}
 
+	var bundledTierKeys []runtimeclient.ObjectKey
+
 	// initialize tier generator, loads templates from assets
-	return nstemplatetiers.GenerateTiers(s, func(toEnsure runtimeclient.Object, canUpdate bool, _ string) (bool, error) {
+	err = nstemplatetiers.GenerateTiers(s, func(toEnsure runtimeclient.Object, canUpdate bool, _ string) (bool, error) {
+		commonclient.MergeAnnotations(toEnsure, bundledAnnotation)
+
+		bundledTierKeys = append(bundledTierKeys, runtimeclient.ObjectKeyFromObject(toEnsure))
+
 		if !canUpdate {
 			if err := client.Create(ctx, toEnsure); err != nil && !apierrors.IsAlreadyExists(err) {
 				return false, err
@@ -40,6 +53,35 @@ func CreateOrUpdateResources(ctx context.Context, s *runtime.Scheme, client runt
 		applyCl := commonclient.NewApplyClient(client)
 		return applyCl.ApplyObject(ctx, toEnsure, commonclient.ForceUpdate(true))
 	}, namespace, metadata, files)
+	if err != nil {
+		return err
+	}
+
+	return removeNoLongerBundledTiers(ctx, client, namespace, bundledTierKeys)
+}
+
+func removeNoLongerBundledTiers(ctx context.Context, client runtimeclient.Client, namespace string, bundledTierKeys []runtimeclient.ObjectKey) error {
+	allTiers := &toolchainv1alpha1.NSTemplateTierList{}
+	if err := client.List(ctx, allTiers, runtimeclient.InNamespace(namespace)); err != nil {
+		return err
+	}
+
+	var allErrors []error
+	for _, tier := range allTiers.Items {
+		if tier.Annotations[toolchainv1alpha1.BundledAnnotationKey] == constants.BundledWithHostOperatorAnnotationValue &&
+			!slices.Contains(bundledTierKeys, runtimeclient.ObjectKeyFromObject(&tier)) {
+			if err := client.Delete(ctx, &tier); err != nil {
+				allErrors = append(allErrors, err)
+			}
+		}
+	}
+
+	err := errors.Join(allErrors...)
+	if err != nil {
+		err = fmt.Errorf("failed to delete some of the no-longer-bundled NSTemplateTiers: %w", err)
+	}
+
+	return err
 }
 
 // LoadFiles takes the file from deploy/nstemplatetiers/<tiername>/<yaml file name> . the folder structure should be 4 steps .
@@ -48,13 +90,13 @@ func LoadFiles(nsTemplateTiers embed.FS, root string) (metadata map[string]strin
 	// load templates from assets
 	metadataContent, err := nsTemplateTiers.ReadFile(filepath.Join(root, "metadata.yaml"))
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "unable to load templates")
+		return nil, nil, fmt.Errorf("unable to load templates: %w", err)
 	}
 
 	metadata = make(map[string]string)
 	err = yaml.Unmarshal(metadataContent, &metadata)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "unable to load templates")
+		return nil, nil, fmt.Errorf("unable to load templates: %w", err)
 	}
 
 	paths, err := templates.GetAllFileNames(&nsTemplateTiers, root)
@@ -79,7 +121,7 @@ func LoadFiles(nsTemplateTiers embed.FS, root string) (metadata map[string]strin
 		fileName := filepath.Join(parts[2], parts[3])
 		content, err := nsTemplateTiers.ReadFile(name)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "unable to load templates")
+			return nil, nil, fmt.Errorf("unable to load templates: %w", err)
 		}
 		files[fileName] = content
 	}

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
@@ -9,10 +9,12 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/host-operator/deploy"
 	"github.com/codeready-toolchain/host-operator/pkg/apis"
+	"github.com/codeready-toolchain/host-operator/pkg/constants"
 	"github.com/codeready-toolchain/host-operator/pkg/templates/nstemplatetiers"
 	commontest "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/gofrs/uuid"
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,8 +52,7 @@ func roles(_ string) []string {
 	return []string{"admin"}
 }
 
-func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
-
+func TestSyncResourcesWitProdAssets(t *testing.T) {
 	s := scheme.Scheme
 	err := apis.AddToScheme(s)
 	require.NoError(t, err)
@@ -60,7 +61,7 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 	cl := commontest.NewFakeClient(t)
 
 	// when
-	err = nstemplatetiers.CreateOrUpdateResources(context.TODO(), s, cl, namespace)
+	err = nstemplatetiers.SyncResources(context.TODO(), s, cl, namespace)
 
 	// then
 	require.NoError(t, err)
@@ -109,10 +110,8 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 	}
 
 	t.Run("failures", func(t *testing.T) {
-
 		namespace := "host-operator" + uuid.Must(uuid.NewV4()).String()[:7]
 		t.Run("nstemplatetiers", func(t *testing.T) {
-
 			t.Run("failed to create nstemplatetiers", func(t *testing.T) {
 				// given
 				clt := commontest.NewFakeClient(t)
@@ -124,7 +123,7 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 					return clt.Client.Create(ctx, obj, opts...)
 				}
 				// when
-				err := nstemplatetiers.CreateOrUpdateResources(context.TODO(), s, clt, namespace)
+				err := nstemplatetiers.SyncResources(context.TODO(), s, clt, namespace)
 				// then
 				require.Error(t, err)
 				assert.Regexp(t, "unable to create NSTemplateTiers: unable to create or update the 'base' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: an error", err.Error())
@@ -148,7 +147,7 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 				}
 
 				// when
-				err := nstemplatetiers.CreateOrUpdateResources(context.TODO(), s, clt, namespace)
+				err := nstemplatetiers.SyncResources(context.TODO(), s, clt, namespace)
 				// then
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to create NSTemplateTiers: unable to create or update the 'advanced' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to update the resource")
@@ -156,7 +155,6 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 		})
 
 		t.Run("tiertemplates", func(t *testing.T) {
-
 			t.Run("failed to create nstemplatetiers", func(t *testing.T) {
 				// given
 				clt := commontest.NewFakeClient(t)
@@ -168,13 +166,12 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 					return clt.Client.Create(ctx, obj, opts...)
 				}
 				// when
-				err := nstemplatetiers.CreateOrUpdateResources(context.TODO(), s, clt, namespace)
+				err := nstemplatetiers.SyncResources(context.TODO(), s, clt, namespace)
 				// then
 				require.Error(t, err)
 				assert.Regexp(t, fmt.Sprintf("unable to create TierTemplates: unable to create the 'base1ns-dev-\\w+-\\w+' TierTemplate in namespace '%s'", namespace), err.Error()) // we can't tell for sure which namespace will fail first, but the error should match the given regex
 			})
 		})
-
 	})
 	t.Run("failed to load assets", func(t *testing.T) {
 		// when
@@ -183,7 +180,45 @@ func TestCreateOrUpdateResourcesWitProdAssets(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, "unable to load templates: open /templates/nstemplatetiers/metadata.yaml: file does not exist", err.Error()) // error occurred while creating TierTemplate resources
 	})
+	t.Run("tier that is no longer bundled is deleted", func(t *testing.T) {
+		// given
+		testTier := &toolchainv1alpha1.NSTemplateTier{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "not-bundled",
+				Namespace: namespace,
+				// add the annotation marking the tier as bundled - in production, this might happen after an operator
+				// upgrade, where we removed a tier from the binary.
+				Annotations: map[string]string{toolchainv1alpha1.BundledAnnotationKey: constants.BundledWithHostOperatorAnnotationValue},
+			},
+		}
+		objs := []runtimeclient.Object{testTier}
 
+		clt := commontest.NewFakeClient(t, objs...)
+
+		// when
+		err := nstemplatetiers.SyncResources(context.TODO(), clt.Scheme(), clt, namespace)
+		inCluster := &toolchainv1alpha1.NSTemplateTier{}
+		gerr := clt.Get(context.TODO(), runtimeclient.ObjectKeyFromObject(testTier), inCluster)
+
+		// then
+		require.NoError(t, err)
+		require.True(t, apierrors.IsNotFound(gerr))
+	})
+	t.Run("bundled tiers are created with an annotation", func(t *testing.T) {
+		// given
+		clt := commontest.NewFakeClient(t)
+
+		// when
+		err := nstemplatetiers.SyncResources(context.TODO(), clt.Scheme(), clt, namespace)
+		inCluster := &toolchainv1alpha1.NSTemplateTier{}
+		// we know that the "base" tier is bundled
+		gerr := clt.Get(context.TODO(), runtimeclient.ObjectKey{Name: "base", Namespace: namespace}, inCluster)
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, gerr)
+		assert.Equal(t, constants.BundledWithHostOperatorAnnotationValue, inCluster.Annotations[toolchainv1alpha1.BundledAnnotationKey])
+	})
 }
 
 func verifyTierTemplate(t *testing.T, cl *commontest.FakeClient, namespace, tierName, typeName string) string {

--- a/test/nstemplatetier/nstemplatetier.go
+++ b/test/nstemplatetier/nstemplatetier.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/host-operator/pkg/constants"
 	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/nstemplateset"
@@ -246,9 +247,20 @@ func WithParameter(name, value string) TierOption {
 	}
 }
 
+// WithFinalizer adds the finalizer to the tier
 func WithFinalizer() TierOption {
 	return func(nt *toolchainv1alpha1.NSTemplateTier) {
 		controllerutil.AddFinalizer(nt, toolchainv1alpha1.FinalizerName)
+	}
+}
+
+// MarkedBundled marks the tier as bundled by adding the appropriate annotation
+func MarkedBundled() TierOption {
+	return func(tier *toolchainv1alpha1.NSTemplateTier) {
+		if tier.Annotations == nil {
+			tier.Annotations = map[string]string{}
+		}
+		tier.Annotations[toolchainv1alpha1.BundledAnnotationKey] = constants.BundledWithHostOperatorAnnotationValue
 	}
 }
 

--- a/test/nstemplatetier/nstemplatetier.go
+++ b/test/nstemplatetier/nstemplatetier.go
@@ -177,9 +177,13 @@ func AppStudioEnvTier(t *testing.T, spec toolchainv1alpha1.NSTemplateTierSpec, o
 }
 
 func Tier(t *testing.T, name string, spec toolchainv1alpha1.NSTemplateTierSpec, options ...TierOption) *toolchainv1alpha1.NSTemplateTier {
+	return TierInNamespace(t, name, "toolchain-host-operator", spec, options...)
+}
+
+func TierInNamespace(t *testing.T, name, namespace string, spec toolchainv1alpha1.NSTemplateTierSpec, options ...TierOption) *toolchainv1alpha1.NSTemplateTier {
 	tier := &toolchainv1alpha1.NSTemplateTier{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "toolchain-host-operator",
+			Namespace: namespace,
 			Name:      name,
 		},
 		Spec: spec,


### PR DESCRIPTION
This compiles the list of the `NSTemplateTier`s that are bundled in the binary and makes sure that any `NSTemplateTier` that is annotated as bundled and is NOT in that list, is automatically deleted if no longer used by any space.

This will provide a nice cleanup mechanism of the bundled `NSTemplateTier` that we no longer use.

It does not affect any user-defined `NSTemplateTier`s.

Related PRs:
- api: https://github.com/codeready-toolchain/api/pull/480
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1154