### PR TITLE
React on NSTemplateTier deletions

### DIFF
--- a/controllers/nstemplatetier/nstemplatetier_controller.go
+++ b/controllers/nstemplatetier/nstemplatetier_controller.go
@@ -21,7 +21,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -35,7 +34,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 		For(&toolchainv1alpha1.NSTemplateTier{}, builder.WithPredicates(predicate.Or(
 			predicate.GenerationChangedPredicate{},
 			// we need to know about the deletions so that we can remove the finalizer
-			predicate.Funcs{DeleteFunc: func(event.TypedDeleteEvent[runtimeclient.Object]) bool { return true }}))).
+			IsBeingDeletedPredicate{}))).
 		Watches(&toolchainv1alpha1.TierTemplate{},
 			handler.EnqueueRequestsFromMapFunc(MapTierTemplateToNSTemplateTier(r.Client))).
 		Complete(r)

--- a/controllers/nstemplatetier/nstemplatetier_controller.go
+++ b/controllers/nstemplatetier/nstemplatetier_controller.go
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -31,7 +32,10 @@ import (
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&toolchainv1alpha1.NSTemplateTier{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&toolchainv1alpha1.NSTemplateTier{}, builder.WithPredicates(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			// we need to know about the deletions so that we can remove the finalizer
+			predicate.Funcs{DeleteFunc: func(event.TypedDeleteEvent[runtimeclient.Object]) bool { return true }}))).
 		Watches(&toolchainv1alpha1.TierTemplate{},
 			handler.EnqueueRequestsFromMapFunc(MapTierTemplateToNSTemplateTier(r.Client))).
 		Complete(r)

--- a/controllers/nstemplatetier/predicate.go
+++ b/controllers/nstemplatetier/predicate.go
@@ -1,0 +1,37 @@
+package nstemplatetier
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type IsBeingDeletedPredicate struct{}
+
+// Create implements predicate.TypedPredicate.
+func (i IsBeingDeletedPredicate) Create(event.TypedCreateEvent[client.Object]) bool {
+	return false
+}
+
+// Delete implements predicate.TypedPredicate.
+func (i IsBeingDeletedPredicate) Delete(event.TypedDeleteEvent[client.Object]) bool {
+	return false
+}
+
+// Generic implements predicate.TypedPredicate.
+func (i IsBeingDeletedPredicate) Generic(e event.TypedGenericEvent[client.Object]) bool {
+	if e.Object == nil {
+		return false
+	}
+	return !e.Object.GetDeletionTimestamp().IsZero()
+}
+
+// Update implements predicate.TypedPredicate.
+func (i IsBeingDeletedPredicate) Update(e event.TypedUpdateEvent[client.Object]) bool {
+	if e.ObjectNew == nil {
+		return false
+	}
+	return !e.ObjectNew.GetDeletionTimestamp().IsZero()
+}
+
+var _ predicate.Predicate = IsBeingDeletedPredicate{}

--- a/controllers/nstemplatetier/predicate_test.go
+++ b/controllers/nstemplatetier/predicate_test.go
@@ -1,0 +1,37 @@
+package nstemplatetier
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestIsBeingDeletedPredicate(t *testing.T) {
+	pred := IsBeingDeletedPredicate{}
+	t.Run("doesn't react on create", func(t *testing.T) {
+		assert.False(t, pred.Create(event.CreateEvent{}))
+	})
+	t.Run("doesn't react on delete", func(t *testing.T) {
+		assert.False(t, pred.Delete(event.DeleteEvent{}))
+	})
+	t.Run("doesn't react on unrelated update", func(t *testing.T) {
+		assert.False(t, pred.Update(event.UpdateEvent{}))
+	})
+	t.Run("doesn't react on unrelated generic event", func(t *testing.T) {
+		assert.False(t, pred.Generic(event.GenericEvent{}))
+	})
+	t.Run("reacts on update of deletion timestamp", func(t *testing.T) {
+		assert.True(t, pred.Update(event.UpdateEvent{
+			ObjectNew: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+		}))
+	})
+	t.Run("reacts on update of deletion timestamp through generic event", func(t *testing.T) {
+		assert.True(t, pred.Generic(event.GenericEvent{
+			Object: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now()}}},
+		}))
+	})
+}


### PR DESCRIPTION
We've added the finalizer on the NSTemplateTier but the reconciler would never receive the delete events, because it only reacted on the generation changed.

This is a followup of https://github.com/codeready-toolchain/host-operator/pull/1180.

Related PRs:
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1154