### PR TITLE
SANDBOX-1225: Fix Phone verification matrix

### DIFF
--- a/controllers/usersignupcleanup/usersignup_cleanup_controller.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller.go
@@ -236,8 +236,8 @@ func validateEmailHash(userEmail, userEmailHash string) bool {
 // metrics incremented - UserSignupDeletedWithInitiatingVerificationTotal and UserSignupDeletedWithoutInitiatingVerificationTotal
 func (r *Reconciler) deleteSignupUnverifiedRetentionPeriod(ctx context.Context, userSignup *toolchainv1alpha1.UserSignup) error {
 	// before deleting the resource, we want to "remember" if the user triggered a phone verification or not,
-	// based on the presence of the `toolchain.dev.openshift.com/phone-hash` annotation
-	_, phoneVerificationTriggered := userSignup.Annotations[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]
+	// based on the presence of the `toolchain.dev.openshift.com/phone-hash` Label
+	_, phoneVerificationTriggered := userSignup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]
 
 	err := r.DeleteUserSignup(ctx, userSignup)
 	if err != nil {

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller.go
@@ -236,8 +236,8 @@ func validateEmailHash(userEmail, userEmailHash string) bool {
 // metrics incremented - UserSignupDeletedWithInitiatingVerificationTotal and UserSignupDeletedWithoutInitiatingVerificationTotal
 func (r *Reconciler) deleteSignupUnverifiedRetentionPeriod(ctx context.Context, userSignup *toolchainv1alpha1.UserSignup) error {
 	// before deleting the resource, we want to "remember" if the user triggered a phone verification or not,
-	// based on the presence of the `toolchain.dev.openshift.com/verification-code` annotation
-	_, phoneVerificationTriggered := userSignup.Annotations[toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey]
+	// based on the presence of the `toolchain.dev.openshift.com/phone-hash` annotation
+	_, phoneVerificationTriggered := userSignup.Annotations[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]
 
 	err := r.DeleteUserSignup(ctx, userSignup)
 	if err != nil {

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -168,7 +168,7 @@ func TestUserCleanup(t *testing.T) {
 		userSignup := commonsignup.NewUserSignup(
 			commonsignup.CreatedBefore(days(8)),
 			commonsignup.VerificationRequiredAgo(days(8)),
-			commonsignup.WithAnnotation(toolchainv1alpha1.UserSignupVerificationCodeAnnotationKey, "12345"),
+			commonsignup.WithAnnotation(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "12345"),
 		)
 		r, req, _ := prepareReconcile(t, userSignup.Name, userSignup)
 		// when

--- a/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
+++ b/controllers/usersignupcleanup/usersignup_cleanup_controller_test.go
@@ -168,7 +168,7 @@ func TestUserCleanup(t *testing.T) {
 		userSignup := commonsignup.NewUserSignup(
 			commonsignup.CreatedBefore(days(8)),
 			commonsignup.VerificationRequiredAgo(days(8)),
-			commonsignup.WithAnnotation(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "12345"),
+			commonsignup.WithLabel(toolchainv1alpha1.UserSignupUserPhoneHashLabelKey, "12345"),
 		)
 		r, req, _ := prepareReconcile(t, userSignup.Name, userSignup)
 		// when


### PR DESCRIPTION
Currently the `Abandonned Signups (last 24hours) `matrix is counting some users as without phone verification initiated even when they were actually sent to the phone verification flow, but had error while doing the phone verification.

Hence updated to check the `usersigupuserhashlabel` and update  the matrix accordingly 