### PR TITLE
Remove the baseextendedidling ns template tier

### DIFF
--- a/deploy/templates/nstemplatetiers/baseextendedidling/based_on_tier.yaml
+++ b/deploy/templates/nstemplatetiers/baseextendedidling/based_on_tier.yaml
@@ -1,5 +1,0 @@
-from: base
-parameters:
-- name: IDLER_TIMEOUT_SECONDS
-  # 144 hours
-  value: "518400"

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
@@ -31,7 +31,6 @@ var expectedProdTiers = []string{
 	"base1nsnoidling",
 	"base1ns6didler",
 	"baselarge",
-	"baseextendedidling",
 	"intelmedium",
 	"intellarge",
 	"intelxlarge",


### PR DESCRIPTION
The tier is not used anywhere, so we can get rid of it.