### PR TITLE
console: temporary remove the DEVSANDBOX_SEGMENT_API_KEY annotation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -311,9 +311,9 @@ func main() { // nolint:gocyclo
 		StatusUpdater: &usersignup.StatusUpdater{
 			Client: mgr.GetClient(),
 		},
-		Namespace:      namespace,
-		Scheme:         mgr.GetScheme(),
-		SegmentClient:  segmentClient,
+		Namespace: namespace,
+		Scheme:    mgr.GetScheme(),
+		// SegmentClient:  segmentClient,
 		ClusterManager: capacity.NewClusterManager(namespace, mgr.GetClient()),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "UserSignup")


### PR DESCRIPTION
Segment quota overpassed

see https://github.com/codeready-toolchain/host-operator/blob/master/controllers/usersignup/usersignup_controller.go#L713 where the call to Segment is skipped when the client is not initialized

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
