### PR TITLE
SANDBOX-1392: Api pair-Drop dependency on Che instance

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
@@ -563,44 +563,6 @@ spec:
                               to deploy the autoscaler buffer
                             type: boolean
                         type: object
-                      che:
-                        description: Keeps parameters concerned with Che/CRW
-                        properties:
-                          keycloakRouteName:
-                            description: Defines the Che/CRW Keycloak route name
-                            type: string
-                          namespace:
-                            description: Defines the Che/CRW operator namespace
-                            type: string
-                          required:
-                            description: Defines a flag that indicates whether the
-                              Che/CRW operator is required to be installed on the
-                              cluster. May be used in monitoring.
-                            type: boolean
-                          routeName:
-                            description: Defines the Che/CRW route name
-                            type: string
-                          secret:
-                            description: Defines all secrets related to Che configuration
-                            properties:
-                              cheAdminPasswordKey:
-                                description: The key for the Che admin password in
-                                  the secret values map
-                                type: string
-                              cheAdminUsernameKey:
-                                description: The key for the Che admin username in
-                                  the secret values map
-                                type: string
-                              ref:
-                                description: Reference is the name of the secret resource
-                                  to look up
-                                type: string
-                            type: object
-                          userDeletionEnabled:
-                            description: Defines a flag to turn the Che user deletion
-                              logic on/off
-                            type: boolean
-                        type: object
                       console:
                         description: Keeps parameters concerned with the console
                         properties:
@@ -701,44 +663,6 @@ spec:
                             deploy:
                               description: Defines the flag that determines whether
                                 to deploy the autoscaler buffer
-                              type: boolean
-                          type: object
-                        che:
-                          description: Keeps parameters concerned with Che/CRW
-                          properties:
-                            keycloakRouteName:
-                              description: Defines the Che/CRW Keycloak route name
-                              type: string
-                            namespace:
-                              description: Defines the Che/CRW operator namespace
-                              type: string
-                            required:
-                              description: Defines a flag that indicates whether the
-                                Che/CRW operator is required to be installed on the
-                                cluster. May be used in monitoring.
-                              type: boolean
-                            routeName:
-                              description: Defines the Che/CRW route name
-                              type: string
-                            secret:
-                              description: Defines all secrets related to Che configuration
-                              properties:
-                                cheAdminPasswordKey:
-                                  description: The key for the Che admin password
-                                    in the secret values map
-                                  type: string
-                                cheAdminUsernameKey:
-                                  description: The key for the Che admin username
-                                    in the secret values map
-                                  type: string
-                                ref:
-                                  description: Reference is the name of the secret
-                                    resource to look up
-                                  type: string
-                              type: object
-                            userDeletionEnabled:
-                              description: Defines a flag to turn the Che user deletion
-                                logic on/off
                               type: boolean
                           type: object
                         console:

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
@@ -249,49 +249,6 @@ spec:
                     memberStatus:
                       description: The array of member status objects
                       properties:
-                        che:
-                          description: Che is the status of Che/CRW, such as installed
-                            and whether the member configuration is correct
-                          properties:
-                            conditions:
-                              description: |-
-                                Conditions is an array of current Che status conditions
-                                Supported condition types: ConditionReady
-                              items:
-                                properties:
-                                  lastTransitionTime:
-                                    description: Last time the condition transit from
-                                      one status to another.
-                                    format: date-time
-                                    type: string
-                                  lastUpdatedTime:
-                                    description: Last time the condition was updated
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Human readable message indicating
-                                      details about last transition.
-                                    type: string
-                                  reason:
-                                    description: (brief) reason for the condition's
-                                      last transition.
-                                    type: string
-                                  status:
-                                    description: Status of the condition, one of True,
-                                      False, Unknown.
-                                    type: string
-                                  type:
-                                    description: Type of condition
-                                    type: string
-                                required:
-                                - status
-                                - type
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                              - type
-                              x-kubernetes-list-type: map
-                          type: object
                         conditions:
                           description: |-
                             Conditions is an array of current toolchain status conditions

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
@@ -542,10 +542,6 @@ spec:
                           description: Routes/URLs of the cluster, such as Console
                             and Che Dashboard URLs
                           properties:
-                            cheDashboardURL:
-                              description: CheDashboardURL is the Che Dashboard URL
-                                of the cluster if Che is installed
-                              type: string
                             conditions:
                               description: |-
                                 Conditions is an array of current member operator status conditions

--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainstatuses.yaml
@@ -497,7 +497,6 @@ spec:
                           type: object
                         routes:
                           description: Routes/URLs of the cluster, such as Console
-                            and Che Dashboard URLs
                           properties:
                             conditions:
                               description: |-


### PR DESCRIPTION
This PR is to remove the `che` related unused code from crds

Related PRs:
- Api : https://github.com/codeready-toolchain/api/pull/488
- Member-operator : https://github.com/codeready-toolchain/member-operator/pull/704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed Che/CRW integration from host and per-member configurations.
  - Eliminated Che-related fields from status reporting, including the Che dashboard URL and member Che status details.
  - Tools or configs that referenced Che/CRW settings or status fields will no longer detect or use them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->