### PR TITLE
Fix: Check age of spacebinding before deletion

### DIFF
--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller.go
@@ -24,7 +24,7 @@ import (
 
 const norequeue = 0 * time.Second
 const requeueDelay = 10 * time.Second
-const deletionDelay = 30 * time.Second
+const deletionDelay = 2 * time.Second
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
@@ -120,7 +120,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 			t.Run("kubesaw-authenticated SpaceBinding requeues when redhat space is missing and SpaceBinding is too young", func(t *testing.T) {
 				// given
 				sbYoung := sbPublicViewerRedhatView.DeepCopy()
-				sbYoung.CreationTimestamp = metav1.NewTime(time.Now().Add(-5 * time.Second))
+				sbYoung.CreationTimestamp = metav1.NewTime(time.Now().Add(-1 * time.Second))
 				fakeClient := test.NewFakeClient(t, sbYoung, toolchainconfig)
 				reconciler := prepareReconciler(t, fakeClient)
 
@@ -129,8 +129,8 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				require.Greater(t, res.RequeueAfter, 24*time.Second)
-				require.LessOrEqual(t, res.RequeueAfter, 25*time.Second) // approximately 25 seconds left
+				require.Greater(t, res.RequeueAfter, 0*time.Second)
+				require.LessOrEqual(t, res.RequeueAfter, 1*time.Second) // approximately 1 second left
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, toolchainv1alpha1.KubesawAuthenticatedUsername, "redhat", fakeClient).Exists()
 			})
 
@@ -153,7 +153,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 			t.Run("lara-redhat SpaceBinding requeues when redhat space is missing and SpaceBinding is too young", func(t *testing.T) {
 				// given
 				sbYoung := sbLaraRedhatAdmin.DeepCopy()
-				sbYoung.CreationTimestamp = metav1.NewTime(time.Now().Add(-10 * time.Second))
+				sbYoung.CreationTimestamp = metav1.NewTime(time.Now().Add(-1 * time.Second))
 				fakeClient := test.NewFakeClient(t, sbYoung, sbJoeRedhatView, sbLaraIbmEdit, laraMur, joeMur, ibmSpace, toolchainconfig)
 				reconciler := prepareReconciler(t, fakeClient)
 
@@ -162,8 +162,8 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				require.Greater(t, res.RequeueAfter, 19*time.Second)
-				require.LessOrEqual(t, res.RequeueAfter, 20*time.Second)                                           // approximately 20 seconds left
+				require.Greater(t, res.RequeueAfter, 0*time.Second)
+				require.LessOrEqual(t, res.RequeueAfter, 1*time.Second)                                            // approximately 1 second left
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara", "redhat", fakeClient).Exists() // not deleted yet
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe", "redhat", fakeClient).Exists()
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara", "ibm", fakeClient).Exists()
@@ -190,7 +190,7 @@ func TestDeleteSpaceBinding(t *testing.T) {
 			t.Run("joe-redhat SpaceBinding requeues when joe MUR is missing and SpaceBinding is too young", func(t *testing.T) {
 				// given
 				sbYoung := sbJoeRedhatView.DeepCopy()
-				sbYoung.CreationTimestamp = metav1.NewTime(time.Now().Add(-10 * time.Second))
+				sbYoung.CreationTimestamp = metav1.NewTime(time.Now().Add(-1 * time.Second))
 				fakeClient := test.NewFakeClient(t, sbYoung, sbLaraRedhatAdmin, sbLaraIbmEdit, laraMur, ibmSpace, redhatSpace, toolchainconfig)
 				reconciler := prepareReconciler(t, fakeClient)
 
@@ -199,8 +199,8 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				require.Greater(t, res.RequeueAfter, 19*time.Second)
-				require.LessOrEqual(t, res.RequeueAfter, 20*time.Second) // approximately 20 seconds left
+				require.Greater(t, res.RequeueAfter, 0*time.Second)
+				require.LessOrEqual(t, res.RequeueAfter, 1*time.Second) // approximately 1 second left
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara", "redhat", fakeClient).Exists()
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe", "redhat", fakeClient).Exists() // not deleted yet
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara", "ibm", fakeClient).Exists()

--- a/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
+++ b/controllers/spacebindingcleanup/spacebinding_cleanup_controller_test.go
@@ -129,7 +129,8 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				require.True(t, res.RequeueAfter > 24*time.Second && res.RequeueAfter <= 25*time.Second) // approximately 25 seconds left
+				require.Greater(t, res.RequeueAfter, 24*time.Second)
+				require.LessOrEqual(t, res.RequeueAfter, 25*time.Second) // approximately 25 seconds left
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, toolchainv1alpha1.KubesawAuthenticatedUsername, "redhat", fakeClient).Exists()
 			})
 
@@ -161,7 +162,8 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				require.True(t, res.RequeueAfter > 19*time.Second && res.RequeueAfter <= 20*time.Second)           // approximately 20 seconds left
+				require.Greater(t, res.RequeueAfter, 19*time.Second)
+				require.LessOrEqual(t, res.RequeueAfter, 20*time.Second)                                           // approximately 20 seconds left
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara", "redhat", fakeClient).Exists() // not deleted yet
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe", "redhat", fakeClient).Exists()
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara", "ibm", fakeClient).Exists()
@@ -197,7 +199,8 @@ func TestDeleteSpaceBinding(t *testing.T) {
 
 				// then
 				require.NoError(t, err)
-				require.True(t, res.RequeueAfter > 19*time.Second && res.RequeueAfter <= 20*time.Second) // approximately 20 seconds left
+				require.Greater(t, res.RequeueAfter, 19*time.Second)
+				require.LessOrEqual(t, res.RequeueAfter, 20*time.Second) // approximately 20 seconds left
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara", "redhat", fakeClient).Exists()
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "joe", "redhat", fakeClient).Exists() // not deleted yet
 				spacebinding.AssertThatSpaceBinding(t, test.HostOperatorNs, "lara", "ibm", fakeClient).Exists()


### PR DESCRIPTION
this is to fix the flakiness of tests, examples and discussion of failures slack thread https://redhat-internal.slack.com/archives/CHK0J6HT6/p1758276534724369
here  the `space_binding_cleanup_controller`  checks the age of the spacebinding along with if related space is present or not before deleting so that its not deleted in case the client cache is  updated with spacebinding first and its yet to be updated with related space

Assisted by: Cursor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces a short delay (2s) before removing SpaceBindings when the target Space/MUR is missing; requeues if binding is too new.
  * Logs now show binding age and remaining delay for clearer visibility.

* **Bug Fixes**
  * Prevents premature SpaceBinding deletion during transient missing-resource conditions.

* **Tests**
  * Expanded age-based coverage validating requeue timing and eventual deletion across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->