### PR TITLE
set ForceSynchronization to true by default

### DIFF
--- a/controllers/toolchainconfig/configuration.go
+++ b/controllers/toolchainconfig/configuration.go
@@ -199,7 +199,7 @@ type MetricsConfig struct {
 }
 
 func (d MetricsConfig) ForceSynchronization() bool {
-	return commonconfig.GetBool(d.metrics.ForceSynchronization, false)
+	return commonconfig.GetBool(d.metrics.ForceSynchronization, true)
 }
 
 type GitHubSecret struct {


### PR DESCRIPTION
# Description
Lately, we are often hitting this [flaky test](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/codeready-toolchain_toolchain-e2e/1204/pull-ci-codeready-toolchain-toolchain-e2e-master-e2e/1973006227021500416#1:build-log.txt%3A22643-22648):
```
space.go:108: 
        	Error Trace:	/go/src/github.com/codeready-toolchain/toolchain-e2e/testsupport/space/space.go:108
        	            				/go/src/github.com/codeready-toolchain/toolchain-e2e/test/e2e/space_autocompletion_test.go:73
        	Error:      	Received unexpected error:
        	            	context deadline exceeded
        	Test:       	TestAutomaticClusterAssignment/set_low_max_number_of_spaces_and_expect_that_space_won't_be_provisioned_but_added_on_waiting_list/increment_the_max_number_of_spaces_and_expect_that_first_space_will_be_provisioned.
```

The space count mismatch seems to happen between "setup migration" and "verify migration" steps. It can be happening for two reasons:

- **Premature Operator Shutdown**
we simply kill the operators (at the end of the migration setup) too early, so it either doesn't properly decreased the counter or it doesn't store the decreased value to the ToolchainStatus

- **No Counter Reconciliation on Startup**
we don't recount the Spaces at the start of the host operator in e2e tests


# Slack thread
https://redhat-internal.slack.com/archives/CHK0J6HT6/p1759830691610259


# Paired PR
https://github.com/codeready-toolchain/toolchain-e2e/pull/1212
