### PR TITLE
SANDBOX-1769 | feature: definition of the "disabled integrations" in the CRD

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
@@ -403,6 +403,15 @@ spec:
                           WorkatoWebHookURL is used by the UI to push events to Marketo for analytics purposes.
                           The webhook URL is unique per environment.
                         type: string
+                      disabledIntegrations:
+                        description: |-
+                          DisabledIntegrations specifies the list of integrations that should be
+                          hidden/disabled in the UI. When nil or empty, all integrations are
+                          considered enabled. Only listed integrations are hidden.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
                     type: object
                   spaceConfig:
                     description: Keeps parameters necessary for configuring Space

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/host-operator
 
 require (
 	cloud.google.com/go/recaptchaenterprise/v2 v2.13.0
-	github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174
+	github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJ
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
-github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174 h1:hed3ZyardxswS6yMB0ME9l3vEkO+pFouyk4dvIiAQOo=
-github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6 h1:d4DTT/6zhDFTN9rlCggsz/PLZGUCRccbSATcDmdTjzI=
+github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74 h1:yxKX0m6Kk1AIWwaGpf25flTfTrYrEJ9TyLW5NEQSq0Y=
 github.com/codeready-toolchain/toolchain-common v0.0.0-20260305144813-52d9242e8c74/go.mod h1:NEnnq2R5GYoWdN0b0iaSdX7L1ndrzxl3ML0m7XLsSqk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
Defines the "disabled integrations" field for the ToolchainConfig CRD.

## Related PRs

- https://github.com/codeready-toolchain/api/pull/502
  - https://github.com/codeready-toolchain/api/pull/503 (this one)
- https://github.com/codeready-toolchain/toolchain-common/pull/524
- https://github.com/codeready-toolchain/host-operator/pull/1255
- https://github.com/codeready-toolchain/host-operator/pull/1256
- https://github.com/codeready-toolchain/registration-service/pull/590
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1274

## Jira ticket
[[SANDBOX-1769]](https://issues.atlassian.net/browse/SANDBOX-1769)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional host setting to configure disabled integrations. If omitted or empty, all integrations remain enabled by default; if specific integrations are listed, only those will be hidden/disabled in the UI.
  * No other user-visible changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->