### PR TITLE
SANDBOX-1282 | refactor: replace "wrapf" calls with stdlib wrap calls

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -475,7 +475,7 @@ func main() { // nolint:gocyclo
 func addMemberClusters(mgr ctrl.Manager, cl runtimeclient.Client, namespace string, namespacedCache bool) (map[string]cluster.Cluster, error) {
 	memberConfigs, err := commoncluster.ListToolchainClusterConfigs(cl, namespace, memberClientTimeout)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get ToolchainCluster configs for members")
+		return nil, fmt.Errorf("unable to get ToolchainCluster configs for members: %w", err)
 	}
 	memberClusters := map[string]cluster.Cluster{}
 	for _, memberConfig := range memberConfigs {

--- a/controllers/usersignup/approval.go
+++ b/controllers/usersignup/approval.go
@@ -11,7 +11,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 
-	"github.com/pkg/errors"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -77,12 +76,12 @@ func isAutoApprovalEnabled(userSignup *toolchainv1alpha1.UserSignup, config tool
 func getClusterIfApproved(ctx context.Context, cl runtimeclient.Client, userSignup *toolchainv1alpha1.UserSignup, clusterManager *capacity.ClusterManager) (bool, targetCluster, error) {
 	config, err := toolchainconfig.GetToolchainConfig(cl)
 	if err != nil {
-		return false, unknown, errors.Wrapf(err, "unable to get ToolchainConfig")
+		return false, unknown, fmt.Errorf("unable to get ToolchainConfig: %w", err)
 	}
 
 	autoApproved, err := isAutoApprovalEnabled(userSignup, config)
 	if err != nil {
-		return false, unknown, errors.Wrapf(err, "unable to determine automatic approval")
+		return false, unknown, fmt.Errorf("unable to determine automatic approval: %w", err)
 	}
 
 	if !states.ApprovedManually(userSignup) && !autoApproved {
@@ -106,7 +105,7 @@ func getClusterIfApproved(ctx context.Context, cl runtimeclient.Client, userSign
 		ClusterRoles:     clusterRoles,
 	})
 	if err != nil {
-		return false, unknown, errors.Wrapf(err, "unable to get the optimal target cluster")
+		return false, unknown, fmt.Errorf("unable to get the optimal target cluster: %w", err)
 	}
 	if clusterName == "" {
 		return states.ApprovedManually(userSignup), notFound, nil

--- a/pkg/templates/notificationtemplates/notification_generator.go
+++ b/pkg/templates/notificationtemplates/notification_generator.go
@@ -60,7 +60,7 @@ func templatesForAssets(notificationFS embed.FS, root string, setName string) (m
 		}
 		segments := strings.Split(path, "/")
 		if len(segments) != 5 {
-			return nil, fmt.Errorf("unable to load templates: %w", errors.New("path must contain directory and file"))
+			return nil, errors.New("unable to load templates: path must contain directory and file")
 		}
 		directoryName := segments[3]
 		filename := segments[4]

--- a/pkg/templates/notificationtemplates/notification_generator.go
+++ b/pkg/templates/notificationtemplates/notification_generator.go
@@ -60,7 +60,7 @@ func templatesForAssets(notificationFS embed.FS, root string, setName string) (m
 		}
 		segments := strings.Split(path, "/")
 		if len(segments) != 5 {
-			return nil, errors.Wrapf(errors.New("path must contain directory and file"), "unable to load templates")
+			return nil, fmt.Errorf("unable to load templates: %w", errors.New("path must contain directory and file"))
 		}
 		directoryName := segments[3]
 		filename := segments[4]
@@ -75,7 +75,7 @@ func templatesForAssets(notificationFS embed.FS, root string, setName string) (m
 			template.Subject = string(content)
 			notificationTemplates[directoryName] = template
 		default:
-			return nil, errors.Wrapf(errors.New("must contain notification.html and subject.txt"), "unable to load templates")
+			return nil, fmt.Errorf("unable to load templates: %w", errors.New("must contain notification.html and subject.txt"))
 		}
 	}
 

--- a/pkg/templates/usertiers/usertier_generator.go
+++ b/pkg/templates/usertiers/usertier_generator.go
@@ -143,7 +143,7 @@ func loadTemplatesByTiers(userTierFS embed.FS, root string) (map[string]*tierDat
 		}
 		content, err := userTierFS.ReadFile(name)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to load templates")
+			return nil, fmt.Errorf("unable to load templates: %w", err)
 		}
 		tmpl := template{
 			content: content,
@@ -242,7 +242,7 @@ func (t *tierGenerator) newUserTier(sourceTierName, tierName string, userTierTem
 	tmplObj := &templatev1.Template{}
 	_, _, err := decoder.Decode(userTierTemplate.content, nil, tmplObj)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to generate '%s' UserTier manifest", tierName)
+		return nil, fmt.Errorf("unable to generate '%s' UserTier manifest: %w", tierName, err)
 	}
 
 	tmplProcessor := commonTemplate.NewProcessor(t.scheme)

--- a/pkg/templates/usertiers/usertier_generator.go
+++ b/pkg/templates/usertiers/usertier_generator.go
@@ -14,7 +14,6 @@ import (
 	commonTemplate "github.com/codeready-toolchain/toolchain-common/pkg/template"
 
 	templatev1 "github.com/openshift/api/template/v1"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -33,13 +32,13 @@ func CreateOrUpdateResources(ctx context.Context, s *runtime.Scheme, client runt
 	// initialize tier generator, loads templates from assets
 	generator, err := newUserTierGenerator(s, client, namespace, userTiersFS, root)
 	if err != nil {
-		return errors.Wrap(err, "unable to create UserTier generator")
+		return fmt.Errorf("unable to create UserTier generator: %w", err)
 	}
 
 	// create the UserTier resources
 	err = generator.createUserTiers(ctx)
 	if err != nil {
-		return errors.Wrap(err, "unable to create UserTiers")
+		return fmt.Errorf("unable to create UserTiers: %w", err)
 	}
 
 	return nil
@@ -152,7 +151,7 @@ func loadTemplatesByTiers(userTierFS embed.FS, root string) (map[string]*tierDat
 		case "tier.yaml":
 			results[tier].rawTemplates.userTier = &tmpl
 		default:
-			return nil, errors.Errorf("unable to load templates: unknown scope for file '%s'", name)
+			return nil, fmt.Errorf("unable to load templates: unknown scope for file '%s'", name)
 		}
 	}
 


### PR DESCRIPTION
There is no need to keep the legacy "wrapf" calls to wrap errors anymore, so the idea is to remove them in favor of the wrapping calls of the stdlib.

## Related PRs

- https://github.com/codeready-toolchain/host-operator/pull/1257
- https://github.com/codeready-toolchain/member-operator/pull/744
- https://github.com/codeready-toolchain/toolchain-common/pull/526
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1275

## Jira ticket
[[SANDBOX-1282]](https://redhat.atlassian.net/browse/SANDBOX-1282)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved error handling across the app to preserve underlying error context, leading to clearer and more informative error messages during user signup approval, template processing, notification generation, and startup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->