### PR TITLE
[SANDBOX-1804] add a ValidatingAdmissionPolicy to prevent big VMs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,6 +95,7 @@ func printVersion() {
 //+kubebuilder:rbac:groups=apps,resources=deployments;deployments/finalizers;replicasets,verbs=get;list;watch;update;patch;create;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io;authorization.openshift.io,resources=rolebindings;roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;update;patch;create;delete
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicies;validatingadmissionpolicybindings,verbs=get;list;watch;create;update;patch;delete
 
 func main() { // nolint:gocyclo
 	var metricsAddr string

--- a/deploy/templates/nstemplatetiers/base1ns/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/base1ns/cluster.yaml
@@ -136,6 +136,50 @@ objects:
     name: ${SPACE_NAME}-dev
   spec:
     timeoutSeconds: ${{IDLER_TIMEOUT_SECONDS}}
+- apiVersion: admissionregistration.k8s.io/v1
+  kind: ValidatingAdmissionPolicy
+  metadata:
+    name: "for-${SPACE_NAME}-vms"
+  spec:
+    failurePolicy: Fail
+    matchConstraints:
+      resourceRules:
+      - apiGroups: ["kubevirt.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["virtualmachines"]
+    validations:
+    - expression: '!has(object.spec.template.spec.domain.memory) || !has(object.spec.template.spec.domain.memory.guest)
+        || quantity(object.spec.template.spec.domain.memory.guest).compareTo(quantity("8Gi"))
+        <= 0'
+      message: VM guest memory must not exceed 8Gi
+    - expression: '!has(object.spec.template.spec.domain.resources) || !has(object.spec.template.spec.domain.resources.limits)
+        || !has(object.spec.template.spec.domain.resources.limits.memory) || quantity(object.spec.template.spec.domain.resources.limits.memory).compareTo(quantity("8Gi"))
+        <= 0'
+      message: VM memory limit must not exceed 8Gi
+    - expression: '!has(object.spec.template.spec.domain.resources) || !has(object.spec.template.spec.domain.resources.requests)
+        || !has(object.spec.template.spec.domain.resources.requests.memory) || quantity(object.spec.template.spec.domain.resources.requests.memory).compareTo(quantity("8Gi"))
+        <= 0'
+      message: VM memory request must not exceed 8Gi
+    - expression: '!has(object.spec.template.spec.domain.resources) || !has(object.spec.template.spec.domain.resources.limits)
+        || !has(object.spec.template.spec.domain.resources.limits.cpu) || quantity(object.spec.template.spec.domain.resources.limits.cpu).compareTo(quantity("2"))
+        <= 0'
+      message: VM CPU limit must not exceed 2
+    - expression: '!has(object.spec.template.spec.domain.resources) || !has(object.spec.template.spec.domain.resources.requests)
+        || !has(object.spec.template.spec.domain.resources.requests.cpu) || quantity(object.spec.template.spec.domain.resources.requests.cpu).compareTo(quantity("2"))
+        <= 0'
+      message: VM CPU request must not exceed 2
+- apiVersion: admissionregistration.k8s.io/v1
+  kind: ValidatingAdmissionPolicyBinding
+  metadata:
+    name: "for-${SPACE_NAME}-vms"
+  spec:
+    policyName: "for-${SPACE_NAME}-vms"
+    validationActions: ["Deny"]
+    matchResources:
+      namespaceSelector:
+        matchLabels:
+            toolchain.dev.openshift.com/space: ${SPACE_NAME}
 parameters:
 - name: SPACE_NAME
   required: true


### PR DESCRIPTION
The validation policy as such seems to work fine. I tested this manually on a demo cluster with virtualization enabled.

The policy doesn't break anything if virtualization is not installed in the cluster (tested locally in crc).

Not sure how to implement automated tests for this though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced VM resource validation: new and updated virtual machine configs are checked and denied if memory exceeds 8 GiB or CPU exceeds 2 cores (applies per instance and is active for matching namespaces).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->