### PR TITLE
print info about space counts

### DIFF
--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -132,6 +132,7 @@ func (r *Reconciler) refreshStatus(ctx context.Context, spc *toolchainv1alpha1.S
 		updateReadyCondition(spc, corev1.ConditionUnknown, toolchainv1alpha1.SpaceProvisionerConfigFailedToDetermineCapacityReason, err.Error())
 		return err
 	}
+	log.FromContext(ctx).Info("updating consumed capacity", "space count", spc.Status.ConsumedCapacity.SpaceCount, "memory usage", spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole)
 
 	capacityCondition := r.determineCapacityReadyState(spc)
 

--- a/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
+++ b/controllers/spaceprovisionerconfig/spaceprovisionerconfig_controller.go
@@ -132,7 +132,9 @@ func (r *Reconciler) refreshStatus(ctx context.Context, spc *toolchainv1alpha1.S
 		updateReadyCondition(spc, corev1.ConditionUnknown, toolchainv1alpha1.SpaceProvisionerConfigFailedToDetermineCapacityReason, err.Error())
 		return err
 	}
-	log.FromContext(ctx).Info("updating consumed capacity", "space count", spc.Status.ConsumedCapacity.SpaceCount, "memory usage", spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole)
+	if spc.Status.ConsumedCapacity != nil {
+		log.FromContext(ctx).Info("updating consumed capacity", "space count", spc.Status.ConsumedCapacity.SpaceCount, "memory usage", spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole)
+	}
 
 	capacityCondition := r.determineCapacityReadyState(spc)
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -234,6 +234,7 @@ func IncrementSpaceCount(clusterName string) {
 	SpaceGaugeVec.WithLabelValues(clusterName).Inc()
 	actual, _ := cachedSpaceCounts.LoadOrStore(clusterName, &atomic.Int32{})
 	actual.(*atomic.Int32).Add(1)
+	logger.Info("incremented space-per-cluster count", "clusterName", clusterName, "value", actual.(*atomic.Int32).Load())
 }
 
 // DecrementSpaceCount decreases the number of Spaces for the given member cluster
@@ -241,6 +242,7 @@ func DecrementSpaceCount(clusterName string) {
 	SpaceGaugeVec.WithLabelValues(clusterName).Dec()
 	actual, _ := cachedSpaceCounts.LoadOrStore(clusterName, &atomic.Int32{})
 	actual.(*atomic.Int32).Add(-1)
+	logger.Info("decremented space-per-cluster count", "clusterName", clusterName, "value", actual.(*atomic.Int32).Load())
 }
 
 // IncrementUsersPerActivationCounters updates the activation counters and metrics


### PR DESCRIPTION
to be able to address failures like this one https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily/2048326225075638272
https://redhat-internal.slack.com/archives/C09430LK7QE/p1777199983272299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added informational logging to space provisioning flows that reports updated space counts and memory usage percentages per node role after capacity is collected.
  * Added informational logging to metrics operations that reports updated cached per-cluster counters after space count increments and decrements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->