### PR TITLE
Add tier for -claw namespace

### DIFF
--- a/deploy/templates/nstemplatetiers/base/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/base/ns_dev.yaml
@@ -76,6 +76,15 @@ objects:
       defaultRequest:
         cpu: 10m
         memory: 64Mi
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: compute-spacerequests
+    namespace: ${SPACE_NAME}-dev
+  spec:
+    hard:
+      count/spacerequests.toolchain.dev.openshift.com: "1"
+
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:

--- a/deploy/templates/nstemplatetiers/base/ns_stage.yaml
+++ b/deploy/templates/nstemplatetiers/base/ns_stage.yaml
@@ -76,6 +76,15 @@ objects:
       defaultRequest:
         cpu: 10m
         memory: 64Mi
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: compute-spacerequests
+    namespace: ${SPACE_NAME}-stage
+  spec:
+    hard:
+      count/spacerequests.toolchain.dev.openshift.com: "1"
+
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:

--- a/deploy/templates/nstemplatetiers/base1ns/ns_dev.yaml
+++ b/deploy/templates/nstemplatetiers/base1ns/ns_dev.yaml
@@ -120,6 +120,15 @@ objects:
         cpu: 10m
         memory: 64Mi
 
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: compute-spacerequests
+    namespace: ${SPACE_NAME}-dev
+  spec:
+    hard:
+      count/spacerequests.toolchain.dev.openshift.com: "1"
+
 - apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:

--- a/deploy/templates/nstemplatetiers/base1ns/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/base1ns/spacerole_admin.yaml
@@ -50,6 +50,37 @@ objects:
   - kind: User
     name: ${USERNAME}
 
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: spacerequest-manage
+    namespace: ${NAMESPACE}
+  rules:
+  - apiGroups:
+    - toolchain.dev.openshift.com
+    resources:
+    - spacerequests
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: ${USERNAME}-spacerequest-manage
+    namespace: ${NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: spacerequest-manage
+  subjects:
+  - kind: User
+    name: ${USERNAME}
+
 parameters:
 - name: NAMESPACE
   required: true

--- a/deploy/templates/nstemplatetiers/base1ns/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/base1ns/spacerole_admin.yaml
@@ -50,37 +50,6 @@ objects:
   - kind: User
     name: ${USERNAME}
 
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name: spacerequest-manage
-    namespace: ${NAMESPACE}
-  rules:
-  - apiGroups:
-    - toolchain.dev.openshift.com
-    resources:
-    - spacerequests
-    verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - patch
-    - delete
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: RoleBinding
-  metadata:
-    name: ${USERNAME}-spacerequest-manage
-    namespace: ${NAMESPACE}
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: spacerequest-manage
-  subjects:
-  - kind: User
-    name: ${USERNAME}
-
 parameters:
 - name: NAMESPACE
   required: true

--- a/deploy/templates/nstemplatetiers/claw/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/claw/cluster.yaml
@@ -1,0 +1,35 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: claw-cluster-resources
+objects:
+- apiVersion: quota.openshift.io/v1
+  kind: ClusterResourceQuota
+  metadata:
+    name: for-${SPACE_NAME}-claw
+  spec:
+    quota:
+      hard:
+        count/deployments.apps: "5"
+        count/pods: "10"
+        count/routes.route.openshift.io: "3"
+        count/services: "5"
+        count/secrets: "50"
+        count/configmaps: "10"
+    selector:
+      annotations: null
+      labels:
+        matchLabels:
+          toolchain.dev.openshift.com/space: ${SPACE_NAME}
+- apiVersion: toolchain.dev.openshift.com/v1alpha1
+  kind: Idler
+  metadata:
+    name: ${SPACE_NAME}-claw
+  spec:
+    timeoutSeconds: ${{IDLER_TIMEOUT_SECONDS}}
+parameters:
+- name: SPACE_NAME
+  required: true
+- name: IDLER_TIMEOUT_SECONDS
+  # 12 hours
+  value: "43200"

--- a/deploy/templates/nstemplatetiers/claw/ns_claw.yaml
+++ b/deploy/templates/nstemplatetiers/claw/ns_claw.yaml
@@ -1,0 +1,171 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: claw-claw
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      openshift.io/description: ${SPACE_NAME}-claw
+      openshift.io/display-name: ${SPACE_NAME}-claw
+      openshift.io/requester: ${SPACE_NAME}
+    labels:
+      name: ${SPACE_NAME}-claw
+    name: ${SPACE_NAME}-claw
+
+# Role and RoleBindings for CRT administration (not associated with users)
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: exec-pods
+    namespace: ${SPACE_NAME}-claw
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods/exec
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: crtadmin-view
+    namespace: ${SPACE_NAME}-claw
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: crtadmin-users-view
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: crtadmin-pods
+    namespace: ${SPACE_NAME}-claw
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: exec-pods
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: crtadmin-users-view
+
+# ResourceQuota — sized for operator workloads (gateway, proxy, device-pairing)
+# plus headroom for future components and rolling updates.
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: compute-deploy
+    namespace: ${SPACE_NAME}-claw
+  spec:
+    hard:
+      limits.cpu: "8"
+      limits.memory: 10Gi
+      requests.cpu: "1"
+      requests.memory: 3Gi
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: storage
+    namespace: ${SPACE_NAME}-claw
+  spec:
+    hard:
+      limits.ephemeral-storage: 5Gi
+      requests.storage: 15Gi
+      requests.ephemeral-storage: 5Gi
+      count/persistentvolumeclaims: "1"
+# LimitRange — default resource requests/limits for containers
+- apiVersion: v1
+  kind: LimitRange
+  metadata:
+    name: resource-limits
+    namespace: ${SPACE_NAME}-claw
+  spec:
+    limits:
+    - type: "Container"
+      default:
+        cpu: 500m
+        memory: 512Mi
+      defaultRequest:
+        cpu: 10m
+        memory: 64Mi
+
+# NetworkPolicies — sandbox-standard ingress policies
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-same-namespace
+    namespace: ${SPACE_NAME}-claw
+  spec:
+    podSelector: {}
+    ingress:
+    - from:
+      - podSelector: {}
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-ingress
+    namespace: ${SPACE_NAME}-claw
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: ingress
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-openshift-monitoring
+    namespace: ${SPACE_NAME}-claw
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: monitoring
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-olm-namespaces
+    namespace: ${SPACE_NAME}-claw
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            openshift.io/scc: anyuid
+    podSelector: {}
+    policyTypes:
+    - Ingress
+- apiVersion: networking.k8s.io/v1
+  kind: NetworkPolicy
+  metadata:
+    name: allow-from-console-namespaces
+    namespace: ${SPACE_NAME}-claw
+  spec:
+    ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            network.openshift.io/policy-group: console
+    podSelector: {}
+    policyTypes:
+    - Ingress
+parameters:
+- name: SPACE_NAME
+  required: true

--- a/deploy/templates/nstemplatetiers/claw/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/claw/spacerole_admin.yaml
@@ -1,0 +1,82 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: claw-spacerole-admin
+objects:
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: claw-user
+    namespace: ${NAMESPACE}
+  rules:
+  - apiGroups:
+    - "claw.sandbox.redhat.com"
+    resources:
+    - claws
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods/log
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - "route.openshift.io"
+    resources:
+    - routes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+    - update
+    - patch
+    - delete
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: ${USERNAME}-claw-user
+    namespace: ${NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: claw-user
+  subjects:
+  - kind: User
+    name: ${USERNAME}
+
+parameters:
+- name: NAMESPACE
+  required: true
+- name: USERNAME
+  required: true

--- a/deploy/templates/nstemplatetiers/claw/spacerole_admin.yaml
+++ b/deploy/templates/nstemplatetiers/claw/spacerole_admin.yaml
@@ -4,6 +4,21 @@ metadata:
   name: claw-spacerole-admin
 objects:
 
+# RoleBinding to built-in view ClusterRole (read access to most resources, excludes secrets)
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: ${USERNAME}-view
+    namespace: ${NAMESPACE}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+  subjects:
+  - kind: User
+    name: ${USERNAME}
+
+# Custom Role for claw-specific permissions not covered by view
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
@@ -25,39 +40,18 @@ objects:
   - apiGroups:
     - ""
     resources:
-    - pods
+    - pods/exec
     verbs:
     - get
-    - list
-    - watch
-  - apiGroups:
-    - ""
-    resources:
-    - pods/log
-    verbs:
-    - get
-    - list
-  - apiGroups:
-    - ""
-    resources:
-    - events
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - "route.openshift.io"
-    resources:
-    - routes
-    verbs:
-    - get
-    - list
-    - watch
+    - create
   - apiGroups:
     - ""
     resources:
     - secrets
     verbs:
+    - get
+    - list
+    - watch
     - create
     - update
     - patch

--- a/deploy/templates/nstemplatetiers/claw/tier.yaml
+++ b/deploy/templates/nstemplatetiers/claw/tier.yaml
@@ -1,0 +1,23 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: claw-tier
+objects:
+- kind: NSTemplateTier
+  apiVersion: toolchain.dev.openshift.com/v1alpha1
+  metadata:
+    name: claw
+    namespace: ${NAMESPACE}
+  spec:
+    clusterResources:
+      templateRef: ${CLUSTER_TEMPL_REF}
+    namespaces:
+    - templateRef: ${CLAW_TEMPL_REF}
+    spaceRoles:
+      admin:
+        templateRef: ${ADMIN_TEMPL_REF}
+parameters:
+- name: NAMESPACE
+- name: CLUSTER_TEMPL_REF
+- name: CLAW_TEMPL_REF
+- name: ADMIN_TEMPL_REF

--- a/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/templates/nstemplatetiers/nstemplatetier_generator_test.go
@@ -31,12 +31,15 @@ var expectedProdTiers = []string{
 	"base1ns",
 	"base1nsnoidling",
 	"base1ns6didler",
+	"claw",
 }
 
 func nsTypes(tier string) []string {
 	switch tier {
 	case "base":
 		return []string{"dev", "stage"}
+	case "claw":
+		return []string{"claw"}
 	default:
 		return []string{"dev"}
 	}


### PR DESCRIPTION
Related to https://github.com/codeready-toolchain/sandbox-sre/pull/3177
Paired with https://github.com/codeready-toolchain/toolchain-e2e/pull/1282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new workspace tier with dedicated cluster resource management, namespace isolation through network policies, RBAC controls, and configurable idle timeout capabilities.

* **Configuration**
  * Added resource quota constraints across multiple workspace tier templates to limit resource consumption.

* **Tests**
  * Extended test suite to validate the new tier configuration and template references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->