### PR TITLE
SANDBOX-1889: update CRD default phoneLookupMode to disabled

### DIFF
--- a/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
+++ b/config/crd/bases/toolchain.dev.openshift.com_toolchainconfigs.yaml
@@ -365,11 +365,11 @@ spec:
                             type: array
                             x-kubernetes-list-type: set
                           phoneLookupMode:
-                            default: log
+                            default: disabled
                             description: |-
                               PhoneLookupMode controls how the registration service handles Twilio Lookup v2 phone risk checks.
                               Valid values are "disabled" (skip Lookup entirely), "log" (call Lookup and store results but don't block),
-                              and "enabled" (call Lookup and enforce blocking). Defaults to "log".
+                              and "enabled" (call Lookup and enforce blocking). Defaults to "disabled".
                             enum:
                             - disabled
                             - log


### PR DESCRIPTION
Generated CRD update reflecting the default phoneLookupMode change from "log" to "disabled" in the API types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default phone verification behavior so phone risk checks are now skipped unless explicitly enabled.
  * Clarified the configuration description to match the new default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->