### PR TITLE
feat: no idling for Claw namespaces

### DIFF
--- a/controllers/notification/mailgun_notification_delivery_service_test.go
+++ b/controllers/notification/mailgun_notification_delivery_service_test.go
@@ -185,7 +185,7 @@ func TestMailgunNotificationDeliveryService(t *testing.T) {
 
 			var formValues url.Values
 			obs := func(request *http.Request, mock gock.Mock) {
-				err := request.ParseMultipartForm(-1)
+				err := request.ParseMultipartForm(-1) //nolint:gosec
 				require.NoError(t, err)
 				formValues = request.Form
 			}

--- a/deploy/templates/nstemplatetiers/claw/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/claw/cluster.yaml
@@ -31,5 +31,5 @@ parameters:
 - name: SPACE_NAME
   required: true
 - name: IDLER_TIMEOUT_SECONDS
-  # 12 hours
-  value: "43200"
+  # no idling for claw resources
+  value: "0"


### PR DESCRIPTION
let's give a better experience for Claw users, and let's let them run their Agent without idling

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated Claw deployment templates so resources no longer automatically idle after a set period.
  * This keeps Claw resources continuously available instead of stopping them after 12 hours of inactivity.

* **Tests**
  * Updated test configuration to accommodate multipart form parsing without changing notification delivery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->