### PR TITLE
fix link to exporting app

### DIFF
--- a/deploy/templates/notificationtemplates/sandbox/userdeactivating/notification.html
+++ b/deploy/templates/notificationtemplates/sandbox/userdeactivating/notification.html
@@ -23,7 +23,7 @@
                 We recommend you export your work as all data in your sandbox will be deleted. After deactivation, you can sign up again at any time for new access at <a href="{{.RegistrationURL}}" target="_blank" rel="noopener noreferrer" style="color: #0066cc; text-decoration: none;">{{.RegistrationURL}}</a>.
             </p>
             <p style="margin: 0 0 20px 0; text-align: left;">
-                <a href="https://developers.redhat.com/learn/openshift/export-your-application-sandbox-red-hat-openshift-service-aws" target="_blank" rel="noopener noreferrer" style="display: inline-block; padding: 10px 20px; background-color: #0066cc; color: #ffffff; text-decoration: none; border-radius: 20px; font-weight: 600; font-size: 14px; font-family: 'RedHatDisplay', 'Red Hat Display', 'Open Sans', Arial, sans-serif;">Export your work</a>
+                <a href="https://developers.redhat.com/learn/openshift/move-your-developer-sandbox-objects-another-cluster" target="_blank" rel="noopener noreferrer" style="display: inline-block; padding: 10px 20px; background-color: #0066cc; color: #ffffff; text-decoration: none; border-radius: 20px; font-weight: 600; font-size: 14px; font-family: 'RedHatDisplay', 'Red Hat Display', 'Open Sans', Arial, sans-serif;">Export your work</a>
             </p>
 
             <p style="margin: 0 0 20px 0; text-align: left; font-family: 'RedHatDisplay', 'Red Hat Display', 'Open Sans', Arial, sans-serif; font-size: 16px; line-height: 1.5; color: #151515;">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Export your work” link in the sandbox user deactivation notification email to direct recipients to the correct destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->