### PR TITLE
fix(cd): use ubuntu-26.04 runner to fix Podman/crun CD failure

### DIFF
--- a/.github/workflows/operator-cd.yml
+++ b/.github/workflows/operator-cd.yml
@@ -12,7 +12,7 @@ jobs:
   binary:
     name: Build & push a new operator release
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
GitHub's ubuntu-24.04 runners now ship static Podman 5.8.4 under /usr/local while leaving apt crun 1.14.1 at /usr/bin/crun. Podman prefers /usr/bin/crun, which rejects OCI runtime-spec 1.2.x and fails image builds with "unknown version specified".

Switch the operator-cd workflow to ubuntu-26.04, where Podman 5.x and crun come from the same apt package set and are compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration environment used for binary releases.
  * Release steps and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->