### PR TITLE
Update remaining GH runners to Ubuntu 26-04

### DIFF
--- a/.github/workflows/ci-check-gomod-alt.yml
+++ b/.github/workflows/ci-check-gomod-alt.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   gomodreplacements:
     name: go.mod replacements
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - run: 'echo "No check required" '

--- a/.github/workflows/ci-check-gomod.yml
+++ b/.github/workflows/ci-check-gomod.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   gomodreplacements:
     name: go.mod replacements
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v7

--- a/.github/workflows/ci-golang-sbom.yml
+++ b/.github/workflows/ci-golang-sbom.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   golangci:
     name: GolangCI Lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -36,7 +36,7 @@ jobs:
   
   sbom:
     name: Generate SBOM
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v7

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   govulncheck:
     name: govulncheck
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
     - name: Checkout code

--- a/.github/workflows/publish-components-for-e2e-tests.yml
+++ b/.github/workflows/publish-components-for-e2e-tests.yml
@@ -12,7 +12,7 @@ jobs:
   binary:
     name: Build & push operator bundles & dashboard image for e2e tests
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     if: >-
       ${{ github.event_name == 'pull_request_target' ||
           (github.event_name == 'issue_comment' &&

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Checkout PR code

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -8,7 +8,7 @@ jobs:
   upload-coverage:
     if: >
       github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - name: Download coverage artifact


### PR DESCRIPTION
Just for the consistency sake. 
Follow up on https://github.com/codeready-toolchain/host-operator/pull/1285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation, testing, security scanning, SBOM generation, and coverage workflows to use the newer Ubuntu 26.04 runner environment.
  * Existing workflow steps and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->