### PR TITLE
SANDBOX-1931: space count should not be negative

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -229,20 +229,31 @@ func DecrementMasterUserRecordCount(domain Domain) {
 	MasterUserRecordGaugeVec.WithLabelValues(string(domain)).Dec()
 }
 
-// IncrementSpaceCount increments the number of Space's for the given member cluster
+// IncrementSpaceCount increments the number of Spaces for the given member cluster
 func IncrementSpaceCount(clusterName string) {
 	SpaceGaugeVec.WithLabelValues(clusterName).Inc()
 	actual, _ := cachedSpaceCounts.LoadOrStore(clusterName, &atomic.Int32{})
-	actual.(*atomic.Int32).Add(1)
-	logger.Info("incremented space-per-cluster count", "clusterName", clusterName, "value", actual.(*atomic.Int32).Load())
+	counter := actual.(*atomic.Int32)
+	newVal := counter.Add(1)
+	logger.Info("incremented space-per-cluster count", "clusterName", clusterName, "value", newVal)
 }
 
 // DecrementSpaceCount decreases the number of Spaces for the given member cluster
 func DecrementSpaceCount(clusterName string) {
-	SpaceGaugeVec.WithLabelValues(clusterName).Dec()
 	actual, _ := cachedSpaceCounts.LoadOrStore(clusterName, &atomic.Int32{})
-	actual.(*atomic.Int32).Add(-1)
-	logger.Info("decremented space-per-cluster count", "clusterName", clusterName, "value", actual.(*atomic.Int32).Load())
+	counter := actual.(*atomic.Int32)
+	for {
+		current := counter.Load()
+		if current <= 0 {
+			logger.Info("space-per-cluster count not decremented - already zero", "clusterName", clusterName, "value", current)
+			return
+		}
+		if counter.CompareAndSwap(current, current-1) {
+			SpaceGaugeVec.WithLabelValues(clusterName).Dec()
+			logger.Info("decremented space-per-cluster count", "clusterName", clusterName, "value", current-1)
+			return
+		}
+	}
 }
 
 // IncrementUsersPerActivationCounters updates the activation counters and metrics

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -169,12 +169,13 @@ func TestSpaceCountInParallelWithoutGoingNegative(t *testing.T) {
 	allDone := sync.WaitGroup{}
 	for range 100 {
 		for _, clusterName := range []string{"member-1", "member-2"} {
-			allDone.Add(2)
+			allDone.Add(3)
 			go func() {
 				gate.Wait()
 				metrics.IncrementSpaceCount(clusterName)
 				go func() {
 					metrics.DecrementSpaceCount(clusterName)
+					allDone.Done()
 				}()
 				allDone.Done()
 			}()

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -160,6 +160,42 @@ func TestDecrementSpaceCount(t *testing.T) {
 		HaveSpacesForCluster("member-2", 1)
 }
 
+func TestSpaceCountInParallelWithoutGoingNegative(t *testing.T) {
+	// given
+	metrics.Reset()
+	defer metrics.Reset()
+	gate := sync.WaitGroup{}
+	gate.Add(1)
+	allDone := sync.WaitGroup{}
+	for range 100 {
+		for _, clusterName := range []string{"member-1", "member-2"} {
+			allDone.Add(2)
+			go func() {
+				gate.Wait()
+				metrics.IncrementSpaceCount(clusterName)
+				go func() {
+					metrics.DecrementSpaceCount(clusterName)
+				}()
+				allDone.Done()
+			}()
+			go func() {
+				gate.Wait()
+				metrics.DecrementSpaceCount(clusterName)
+				allDone.Done()
+			}()
+		}
+	}
+
+	// when
+	gate.Done()
+	allDone.Wait()
+
+	// then
+	metricstest.AssertThatCountersAndMetrics(t).
+		HaveSpacesForCluster("member-1", 0).
+		HaveSpacesForCluster("member-2", 0)
+}
+
 // end spaces tests ------
 
 func TestInitializeCountersFromExistingResources(t *testing.T) {


### PR DESCRIPTION
from time to time it happens in e2e tests that a Space controller is triggered twice (immediately after each other) for the same space that is supposed to be deleted, but the cache is not updated with the information that the space was already marked for deletion. This causes that `DecrementSpaceCount` is called twice for the same space which decrements the count to a negative value - this causes additional flakiness in space autocompletion tests 
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-codeready-toolchain-toolchain-e2e-master-ci-daily/2069707126829223936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Space counts can no longer fall below zero.
  * Metrics remain accurate when multiple count updates occur simultaneously.
  * Invalid decrement attempts are safely ignored.

* **Tests**
  * Added coverage for concurrent updates across multiple clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->