### PR TITLE
feat: idling after 24h for Claw namespaces

### DIFF
--- a/deploy/templates/nstemplatetiers/claw/cluster.yaml
+++ b/deploy/templates/nstemplatetiers/claw/cluster.yaml
@@ -31,5 +31,5 @@ parameters:
 - name: SPACE_NAME
   required: true
 - name: IDLER_TIMEOUT_SECONDS
-  # no idling for claw resources
-  value: "0"
+  # 24h idling for claw resources
+  value: "86400"


### PR DESCRIPTION
kinda revert of #1280, but allow running for 24h instead of default 12h

e2e tests: https://github.com/codeready-toolchain/toolchain-e2e/pull/1315

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claw deployments now automatically idle after 24 hours by default, helping reduce resource usage.
  * Updated the configuration guidance to reflect the new default timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->